### PR TITLE
Implemented textDocument/didClose method

### DIFF
--- a/source/ada/lsp-ada_contexts.adb
+++ b/source/ada/lsp-ada_contexts.adb
@@ -119,8 +119,8 @@ package body LSP.Ada_Contexts is
    -------------------
 
    not overriding procedure Load_Document
-     (Self  : in out Context;
-      Item  : LSP.Messages.TextDocumentItem)
+     (Self : in out Context;
+      Item : LSP.Messages.TextDocumentItem)
    is
       Object : constant LSP.Ada_Documents.Document_Access :=
         new LSP.Ada_Documents.Document;
@@ -128,6 +128,18 @@ package body LSP.Ada_Contexts is
       Object.Initialize (Self.LAL_Context, Item);
       Self.Documents.Insert (Item.uri, Object);
    end Load_Document;
+
+   ---------------------
+   -- Unload_Document --
+   ---------------------
+
+   not overriding procedure Unload_Document
+     (Self : in out Context;
+      Item : LSP.Messages.TextDocumentIdentifier)
+   is
+   begin
+      Self.Documents.Delete (Item.uri);
+   end Unload_Document;
 
    ----------------------
    -- Get_Source_Files --

--- a/source/ada/lsp-ada_contexts.ads
+++ b/source/ada/lsp-ada_contexts.ads
@@ -36,8 +36,12 @@ package LSP.Ada_Contexts is
       Root : LSP.Types.LSP_String);
 
    not overriding procedure Load_Document
-     (Self  : in out Context;
-      Item  : LSP.Messages.TextDocumentItem);
+     (Self : in out Context;
+      Item : LSP.Messages.TextDocumentItem);
+
+   not overriding procedure Unload_Document
+     (Self : in out Context;
+      Item : LSP.Messages.TextDocumentIdentifier);
 
    not overriding function Get_Document
      (Self : Context;

--- a/source/ada/lsp-ada_handlers.ads
+++ b/source/ada/lsp-ada_handlers.ads
@@ -39,30 +39,34 @@ private
       null;
    end record;
 
-   overriding procedure Exit_Notification
-     (Self : access Message_Handler);
-
    overriding procedure Initialize_Request
      (Self     : access Message_Handler;
       Value    : LSP.Messages.InitializeParams;
       Response : in out LSP.Messages.Initialize_Response);
 
-   overriding procedure Text_Document_Did_Change
-     (Self  : access Message_Handler;
-      Value : LSP.Messages.DidChangeTextDocumentParams);
-
-   overriding procedure Text_Document_Did_Open
-     (Self  : access Message_Handler;
-      Value : LSP.Messages.DidOpenTextDocumentParams);
-
    overriding procedure Text_Document_References_Request
-    (Self     : access Message_Handler;
-     Value    : LSP.Messages.ReferenceParams;
-     Response : in out LSP.Messages.Location_Response);
+     (Self     : access Message_Handler;
+      Value    : LSP.Messages.ReferenceParams;
+      Response : in out LSP.Messages.Location_Response);
 
    overriding procedure Text_Document_Symbol_Request
     (Self     : access Message_Handler;
      Value    : LSP.Messages.DocumentSymbolParams;
      Response : in out LSP.Messages.Symbol_Response);
+
+   overriding procedure Text_Document_Did_Open
+     (Self  : access Message_Handler;
+      Value : LSP.Messages.DidOpenTextDocumentParams);
+
+   overriding procedure Text_Document_Did_Change
+     (Self  : access Message_Handler;
+      Value : LSP.Messages.DidChangeTextDocumentParams);
+
+   overriding procedure Text_Document_Did_Close
+     (Self  : access Message_Handler;
+      Value : LSP.Messages.DidCloseTextDocumentParams);
+
+   overriding procedure Exit_Notification
+     (Self : access Message_Handler);
 
 end LSP.Ada_Handlers;


### PR DESCRIPTION
Most changes here are actually just reorderings of definitions so that they appear in the same order in different files, but what this PR actually adds is support for the LSP method `textDocument/didClose` (relative code [here](#diff-272cd9e1bed2bd7cba05ca858ec27546R184) and [here](#diff-98cdd10394f7c1fbad35a68bf3074d2fR136)).