### PR TITLE
Fix rootURI processing

### DIFF
--- a/source/ada/lsp-ada_handlers.adb
+++ b/source/ada/lsp-ada_handlers.adb
@@ -65,10 +65,16 @@ package body LSP.Ada_Handlers is
       Response.result.capabilities.textDocumentSync :=
         (Is_Set => True, Is_Number => True, Value => LSP.Messages.Full);
 
-      if not LSP.Types.Is_Empty (Value.rootUri) then
+      --  Turn URI into path by stripping schema from it
+      if LSP.Types.Starts_With (Value.rootUri, "file://") then
          Root := Delete (Value.rootUri, 1, 7);
-      elsif not LSP.Types.Is_Empty (Value.rootPath) then
-         Root := "file://" & Value.rootPath;
+      elsif LSP.Types.Starts_With (Value.rootUri, "file:") then
+         Root := Delete (Value.rootUri, 1, 5);
+      elsif not LSP.Types.Is_Empty (Value.rootUri) then
+         raise Constraint_Error with "Unsupported URI schema";
+      else
+         --  URI isn't provided, rollback to depricated rootPath
+         Root := Value.rootPath;
       end if;
 
       Self.Context.Initialize (Root);

--- a/testsuite/ada_lsp/0002-shutdown.json
+++ b/testsuite/ada_lsp/0002-shutdown.json
@@ -7,7 +7,7 @@
         "send": {
             "request": {"jsonrpc":"2.0","id":0,"method":"initialize","params":{
                 "processId":1,
-                "rootUri":"file://.",
+                "rootUri":"file:.",
                 "capabilities":{}}
             },
             "wait":[{ "id": 0 }]

--- a/testsuite/ada_lsp/0003-get_symbols.json
+++ b/testsuite/ada_lsp/0003-get_symbols.json
@@ -7,7 +7,7 @@
         "send": {
             "request": {"jsonrpc":"2.0","id":0,"method":"initialize","params":{
                 "processId":1,
-                "rootUri":"file://.",
+                "rootUri":"file:.",
                 "capabilities":{}}
             },
             "wait":[{ "id": 0,


### PR DESCRIPTION
URI can be in two form: `file://absolute_path` and `file:relative_path`.
Process both form correctly. Fix rootURI in tests.