### PR TITLE
Fix URI parsing with Windows file names.

### DIFF
--- a/source/ada/lsp-ada_contexts.ads
+++ b/source/ada/lsp-ada_contexts.ads
@@ -43,7 +43,7 @@ package LSP.Ada_Contexts is
    --  Libadalang related data, and recreate it from scratch.
 
    not overriding procedure Load_Document
-     (Self : in out Context;
+     (Self : aliased in out Context;
       Item : LSP.Messages.TextDocumentItem);
 
    not overriding procedure Unload_Document
@@ -57,6 +57,16 @@ package LSP.Ada_Contexts is
 
    not overriding function Get_Source_Files
      (Self : Context) return GNATCOLL.VFS.File_Array_Access;
+
+   not overriding function URI_To_File
+     (Self : Context;
+      URI  : LSP.Types.LSP_String) return LSP.Types.LSP_String;
+   --  Turn URI into path by stripping schema from it
+
+   not overriding function File_To_URI
+     (Self : Context;
+      File  : LSP.Types.LSP_String) return LSP.Types.LSP_String;
+   --  Convert file name to URI
 
 private
 

--- a/source/ada/lsp-ada_documents.adb
+++ b/source/ada/lsp-ada_documents.adb
@@ -22,6 +22,7 @@ with Langkit_Support.Slocs;
 with Libadalang.Common;
 with Libadalang.Iterators;
 
+with LSP.Ada_Contexts;
 with LSP.Types;
 
 package body LSP.Ada_Documents is
@@ -66,7 +67,7 @@ package body LSP.Ada_Documents is
       Vector : LSP.Messages.TextDocumentContentChangeEvent_Vector)
    is
       File : constant LSP.Types.LSP_String :=
-        LSP.Types.Delete (Self.URI, 1, 7);  --  Delete file://
+        Self.Context.URI_To_File (Self.URI);  --  Delete file://
    begin
       for Change of reverse Vector loop
          --  If whole document then reparse it
@@ -299,7 +300,7 @@ package body LSP.Ada_Documents is
       Item : LSP.Messages.TextDocumentItem)
    is
       File : constant LSP.Types.LSP_String :=
-        LSP.Types.Delete (Item.uri, 1, 7);  --  Delete file://
+        Self.Context.URI_To_File (Item.uri);  --  Delete file://
    begin
       Self.Unit := LAL.Get_From_Buffer
         (Filename => LSP.Types.To_UTF_8_String (File),

--- a/source/ada/lsp-ada_documents.ads
+++ b/source/ada/lsp-ada_documents.ads
@@ -17,10 +17,12 @@
 
 with LSP.Messages;
 with Libadalang.Analysis;
+limited with LSP.Ada_Contexts;
 
 package LSP.Ada_Documents is
 
-   type Document is tagged limited private;
+   type Document (Context : access LSP.Ada_Contexts.Context'Class)
+     is tagged limited private;
    type Document_Access is access all LSP.Ada_Documents.Document;
    type Constant_Document_Access is access constant LSP.Ada_Documents.Document;
 
@@ -58,7 +60,9 @@ package LSP.Ada_Documents is
 
 private
 
-   type Document is tagged limited record
+   type Document (Context : access LSP.Ada_Contexts.Context'Class) is
+     tagged limited
+   record
       URI  : LSP.Messages.DocumentUri;
       LAL  : Libadalang.Analysis.Analysis_Context;
       Unit : Libadalang.Analysis.Analysis_Unit;


### PR DESCRIPTION
On Windows we have `file:///C:\PATH`, so we should strip one more slash
to have full path name. Issue #30