### PR TITLE
Report error to LSP client on exception as required by LSP.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,8 @@ check: all
 	$(TESTER) $(TD)/0003-get_symbols.json
 	$(TESTER) $(TD)/def_name.json
 	$(TESTER) $(TD)/project_search.json
+	$(TESTER) $(TD)/project_config.json
+	$(TESTER) $(TD)/project_config_2.json
 	@echo All test passed!
 
 deploy: check

--- a/source/server/lsp-request_dispatchers.adb
+++ b/source/server/lsp-request_dispatchers.adb
@@ -15,6 +15,10 @@
 -- of the license.                                                          --
 ------------------------------------------------------------------------------
 
+with Ada.Exceptions;
+
+with GNATCOLL.JSON;
+
 package body LSP.Request_Dispatchers is
 
    --------------
@@ -35,6 +39,17 @@ package body LSP.Request_Dispatchers is
       end if;
 
       return Maps.Element (Cursor) (Stream, Handler);
+   exception
+      when E : others =>
+         --  Unexpected exception, reply to client with an error
+         return Response : LSP.Messages.ResponseMessage do
+            Response.error :=
+              (Is_Set => True,
+               Value => (code => LSP.Messages.InternalError,
+                         data => GNATCOLL.JSON.Create_Object,
+                         message => LSP.Types.To_LSP_String
+                           (Ada.Exceptions.Exception_Information (E))));
+         end return;
    end Dispatch;
 
    --------------

--- a/source/server/lsp-servers.adb
+++ b/source/server/lsp-servers.adb
@@ -227,6 +227,13 @@ package body LSP.Servers is
          Result := JS.Read;
          JS.Key (+"error");
          LSP.Messages.Optional_ResponseError'Read (Stream, Error);
+         --  We have got error from LSP client. Save it in the trace:
+         Server_Trace.Trace ("Got Error responce:");
+
+         if Error.Is_Set then
+            Server_Trace.Trace
+              (LSP.Types.To_UTF_8_String (Error.Value.message));
+         end if;
 
          return;
       elsif LSP.Types.Assigned (Request_Id) then

--- a/testsuite/ada_lsp/project_config.json
+++ b/testsuite/ada_lsp/project_config.json
@@ -1,0 +1,113 @@
+[
+    {
+        "comment":[
+            "This test check language server is able to find a project file",
+            "specified in configuration.",
+            "To check it we search for a custom named subprogram."
+        ]
+    },  {
+        "start": {
+            "cmd": [".obj/server/ada_language_server"]
+        }
+    },  {
+        "send": {
+            "request": {"jsonrpc":"2.0","id":0,"method":"initialize","params":{
+                "processId":1,
+                "rootUri":"$URI{project_config}",
+                "capabilities":{}}
+            },
+            "wait":[{
+                "id": 0,
+                "result":{
+                    "capabilities":{
+                        "textDocumentSync":1,
+                        "definitionProvider":true
+                    }
+                }
+            }]
+        }
+    },  {
+        "send": {
+            "request": {
+                "jsonrpc":"2.0",
+                "method":"workspace/didChangeConfiguration",
+                "params":{
+                    "settings":{
+                        "ada":{
+                            "projectFile": "right_project.gpr"
+                        }
+                    }
+                }
+            },
+            "wait":[]
+        }
+    },  {
+        "send": {
+            "request": {
+                "jsonrpc":"2.0",
+                "method":"textDocument/didOpen",
+                "params":{
+                    "textDocument": {
+                        "uri": "$URI{project_config/aaa.adb}",
+                        "languageId": "ada",
+                        "version": 1,
+                        "text": "with To_Be_Called;\nprocedure Aaa is\n   Text : String := \"cba\";\nbegin\n   To_Be_Called (Text);\nend Aaa;\n"
+                    }
+                }
+            },
+            "wait":[]
+        }
+    },  {
+        "send": {
+            "request": {
+                "jsonrpc":"2.0",
+                "id":"defname-1",
+                "method":"textDocument/definition",
+                "params":{
+                    "textDocument": {
+                        "uri": "$URI{project_config/aaa.adb}"
+                    },
+                    "position": {
+                        "line": 4,
+                        "character": 11
+                    }
+                }
+            },
+            "wait":[{
+                "id": "defname-1",
+                "result":[{
+                    "uri": "$URI{project_config/second.ads}",
+                    "range": {
+                        "start": {
+                            "line": 0,
+                            "character": 10
+                        },
+                        "end": {
+                            "line": 0,
+                            "character": 22
+                        }
+                    }
+                }]
+            }]
+        }
+    },  {
+        "send": {
+            "request": {
+                "jsonrpc":"2.0",
+                "id": "shutdown",
+                "method":"shutdown",
+                "params":null
+            },
+            "wait":[{ "id": "shutdown" }]
+        }
+    },  {
+        "send": {
+            "request": {"jsonrpc":"2.0", "method":"exit", "params":{}},
+            "wait":[]
+        }
+    }, {
+        "stop": {
+            "exit_code": 0
+        }
+    }
+]

--- a/testsuite/ada_lsp/project_config/aaa.adb
+++ b/testsuite/ada_lsp/project_config/aaa.adb
@@ -1,0 +1,6 @@
+with To_Be_Called;
+procedure Aaa is
+   Text : String := "cba";
+begin
+   To_Be_Called (Text);
+end Aaa;

--- a/testsuite/ada_lsp/project_config/right_project.gpr
+++ b/testsuite/ada_lsp/project_config/right_project.gpr
@@ -1,0 +1,5 @@
+project Right_Project is
+   package Naming is
+      for Spec ("To_Be_Called") use "second.ads";
+   end Naming;
+end Right_Project;

--- a/testsuite/ada_lsp/project_config/second.ads
+++ b/testsuite/ada_lsp/project_config/second.ads
@@ -1,0 +1,1 @@
+procedure To_Be_Called (Text : String);

--- a/testsuite/ada_lsp/project_config/third.ads
+++ b/testsuite/ada_lsp/project_config/third.ads
@@ -1,0 +1,3 @@
+generic
+package To_Be_Called is
+end;

--- a/testsuite/ada_lsp/project_config/wrong_project.gpr
+++ b/testsuite/ada_lsp/project_config/wrong_project.gpr
@@ -1,0 +1,5 @@
+project Wrong_Project is
+   package Naming is
+      for Spec ("To_Be_Called") use "third.ads";
+   end Naming;
+end Wrong_Project;

--- a/testsuite/ada_lsp/project_config_2.json
+++ b/testsuite/ada_lsp/project_config_2.json
@@ -1,0 +1,103 @@
+[
+    {
+        "comment":[
+            "This test check language server is able to find a project file",
+            "specified in configuration. It tries to load wrong project and",
+            "get error after search for a custom named subprogram."
+        ]
+    },  {
+        "start": {
+            "cmd": [".obj/server/ada_language_server"]
+        }
+    },  {
+        "send": {
+            "request": {"jsonrpc":"2.0","id":0,"method":"initialize","params":{
+                "processId":1,
+                "rootUri":"$URI{project_config}",
+                "capabilities":{}}
+            },
+            "wait":[{
+                "id": 0,
+                "result":{
+                    "capabilities":{
+                        "textDocumentSync":1,
+                        "definitionProvider":true
+                    }
+                }
+            }]
+        }
+    },  {
+        "send": {
+            "request": {
+                "jsonrpc":"2.0",
+                "method":"workspace/didChangeConfiguration",
+                "params":{
+                    "settings":{
+                        "ada":{
+                            "projectFile": "wrong_project.gpr"
+                        }
+                    }
+                }
+            },
+            "wait":[]
+        }
+    },  {
+        "send": {
+            "request": {
+                "jsonrpc":"2.0",
+                "method":"textDocument/didOpen",
+                "params":{
+                    "textDocument": {
+                        "uri": "$URI{project_config/aaa.adb}",
+                        "languageId": "ada",
+                        "version": 1,
+                        "text": "with To_Be_Called;\nprocedure Aaa is\n   Text : String := \"cba\";\nbegin\n   To_Be_Called (Text);\nend Aaa;\n"
+                    }
+                }
+            },
+            "wait":[]
+        }
+    },  {
+        "send": {
+            "request": {
+                "jsonrpc":"2.0",
+                "id":"defname-1",
+                "method":"textDocument/definition",
+                "params":{
+                    "textDocument": {
+                        "uri": "$URI{project_config/aaa.adb}"
+                    },
+                    "position": {
+                        "line": 4,
+                        "character": 11
+                    }
+                }
+            },
+            "wait":[{
+                "id": "defname-1",
+                "error":{
+                    "code": -32603
+                }
+            }]
+        }
+    },  {
+        "send": {
+            "request": {
+                "jsonrpc":"2.0",
+                "id": "shutdown",
+                "method":"shutdown",
+                "params":null
+            },
+            "wait":[{ "id": "shutdown" }]
+        }
+    },  {
+        "send": {
+            "request": {"jsonrpc":"2.0", "method":"exit", "params":{}},
+            "wait":[]
+        }
+    }, {
+        "stop": {
+            "exit_code": 0
+        }
+    }
+]


### PR DESCRIPTION
Add test to find correct .gpr when it's specified by configuration.