### PR TITLE
S125-009 Add Search_Path function to Spawn API

### DIFF
--- a/gnat/spawn.gpr
+++ b/gnat/spawn.gpr
@@ -63,6 +63,8 @@ project Spawn is
                use "spawn-environments-internal__posix.adb";
             for Body ("Spawn.Processes")
                use "spawn-processes__posix.adb";
+            for Body ("Spawn.Environments.Search_In_Path")
+               use "spawn-environments-search_in_path__posix.adb";
             for Body ("Spawn.Processes.Monitor")
                use "spawn-processes-monitor__posix.adb";
          when "Windows_NT" =>
@@ -78,6 +80,8 @@ project Spawn is
                use "spawn-environments-internal__windows.adb";
             for Body ("Spawn.Processes")
                use "spawn-processes__windows.adb";
+            for Body ("Spawn.Environments.Search_In_Path")
+               use "spawn-environments-search_in_path__windows.adb";
             for Body ("Spawn.Processes.Monitor")
                use "spawn-processes-monitor__windows.adb";
       end case;

--- a/gnat/spawn_glib.gpr
+++ b/gnat/spawn_glib.gpr
@@ -58,6 +58,8 @@ project Spawn_Glib is
                use "spawn-environments-internal__glib.ads";
             for Body ("Spawn.Environments.Internal")
                use "spawn-environments-internal__glib.adb";
+            for Body ("Spawn.Environments.Search_In_Path")
+               use "spawn-environments-search_in_path__posix.adb";
             for Body ("Spawn.Processes")
                use "spawn-processes__glib.adb";
          when "Windows_NT" =>
@@ -71,6 +73,8 @@ project Spawn_Glib is
                use "spawn-environments-internal__windows.ads";
             for Body ("Spawn.Environments.Internal")
                use "spawn-environments-internal__windows.adb";
+            for Body ("Spawn.Environments.Search_In_Path")
+               use "spawn-environments-search_in_path__windows.adb";
             for Body ("Spawn.Processes")
                use "spawn-processes__glib_windows.adb";
       end case;

--- a/source/spawn/spawn-environments-search_in_path__posix.adb
+++ b/source/spawn/spawn-environments-search_in_path__posix.adb
@@ -1,0 +1,56 @@
+------------------------------------------------------------------------------
+--                         Language Server Protocol                         --
+--                                                                          --
+--                     Copyright (C) 2018-2019, AdaCore                     --
+--                                                                          --
+-- This is free software;  you can redistribute it  and/or modify it  under --
+-- terms of the  GNU General Public License as published  by the Free Soft- --
+-- ware  Foundation;  either version 3,  or (at your option) any later ver- --
+-- sion.  This software is distributed in the hope  that it will be useful, --
+-- but WITHOUT ANY WARRANTY;  without even the implied warranty of MERCHAN- --
+-- TABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public --
+-- License for  more details.  You should have  received  a copy of the GNU --
+-- General  Public  License  distributed  with  this  software;   see  file --
+-- COPYING3.  If not, go to http://www.gnu.org/licenses for a complete copy --
+-- of the license.                                                          --
+------------------------------------------------------------------------------
+
+with Ada.Strings.Fixed;
+with Ada.Directories;
+
+separate (Spawn.Environments)
+function Search_In_Path
+  (File : UTF_8_String;
+   Path : UTF_8_String) return UTF_8_String
+is
+   From : Natural := Path'First;
+begin
+   loop
+      declare
+         use all type Ada.Directories.File_Kind;
+
+         To : constant Natural := Ada.Strings.Fixed.Index (Path, ":", From);
+
+         Directory : constant UTF_8_String :=
+           (if To = 0 then
+               Path (From .. Path'Last)
+            else
+               Path (From .. To - 1));
+
+         Candidate : constant UTF_8_String :=
+           Ada.Directories.Compose (Directory, File);
+      begin
+         if Ada.Directories.Exists (Candidate)
+           and then Ada.Directories.Kind (Candidate) = Ordinary_File
+         then
+            return Ada.Directories.Full_Name (Candidate);
+         end if;
+
+         exit when To = 0;
+
+         From := To + 1;
+      end;
+   end loop;
+
+   return "";
+end Search_In_Path;

--- a/source/spawn/spawn-environments-search_in_path__windows.adb
+++ b/source/spawn/spawn-environments-search_in_path__windows.adb
@@ -1,0 +1,60 @@
+------------------------------------------------------------------------------
+--                         Language Server Protocol                         --
+--                                                                          --
+--                     Copyright (C) 2018-2019, AdaCore                     --
+--                                                                          --
+-- This is free software;  you can redistribute it  and/or modify it  under --
+-- terms of the  GNU General Public License as published  by the Free Soft- --
+-- ware  Foundation;  either version 3,  or (at your option) any later ver- --
+-- sion.  This software is distributed in the hope  that it will be useful, --
+-- but WITHOUT ANY WARRANTY;  without even the implied warranty of MERCHAN- --
+-- TABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public --
+-- License for  more details.  You should have  received  a copy of the GNU --
+-- General  Public  License  distributed  with  this  software;   see  file --
+-- COPYING3.  If not, go to http://www.gnu.org/licenses for a complete copy --
+-- of the license.                                                          --
+------------------------------------------------------------------------------
+
+with Ada.Strings.UTF_Encoding.Wide_Strings;
+with Interfaces.C;
+with Spawn.Windows_API;
+
+separate (Spawn.Environments)
+function Search_In_Path
+  (File : UTF_8_String;
+   Path : UTF_8_String) return UTF_8_String
+is
+   use type Spawn.Windows_API.DWORD;
+
+   Raw_Path : Interfaces.C.wchar_array :=
+     Interfaces.C.To_C
+       (Ada.Strings.UTF_Encoding.Wide_Strings.Decode (Path));
+
+   Raw_File : Interfaces.C.wchar_array :=
+     Interfaces.C.To_C
+       (Ada.Strings.UTF_Encoding.Wide_Strings.Decode (File));
+
+   Raw_Exe : Interfaces.C.wchar_array := Interfaces.C.To_C (".exe");
+
+   Buffer : Interfaces.C.wchar_array (1 .. Spawn.Windows_API.MAX_PATH);
+
+   Length : constant Spawn.Windows_API.DWORD :=
+     Spawn.Windows_API.SearchPath
+       (lpPath        => Raw_Path (Raw_Path'First)'Unchecked_Access,
+        lpFileName    => Raw_File (Raw_File'First)'Unchecked_Access,
+        lpExtension   => Raw_Exe (Raw_Exe'First)'Unchecked_Access,
+        nBufferLength => Buffer'Length,
+        lpBuffer      => Buffer (Buffer'First)'Unchecked_Access,
+        lpFilePart    => null);
+begin
+   if Length = 0 or Length > Buffer'Length then
+
+      return "";
+   else
+
+      return Ada.Strings.UTF_Encoding.Wide_Strings.Encode
+        (Interfaces.C.To_Ada
+           (Buffer (1 .. Interfaces.C.size_t (Length)),
+            Trim_Nul => False));
+   end if;
+end Search_In_Path;

--- a/source/spawn/spawn-environments.adb
+++ b/source/spawn/spawn-environments.adb
@@ -19,6 +19,11 @@ package body Spawn.Environments is
 
    procedure Initialize_Default (Default : out Process_Environment);
 
+   function Search_In_Path
+     (File : UTF_8_String;
+      Path : UTF_8_String) return UTF_8_String;
+   --  Look for File in given list of directories
+
    Default : Process_Environment;
 
    -----------
@@ -101,6 +106,28 @@ package body Spawn.Environments is
    begin
       Self.Map.Exclude (Name);
    end Remove;
+
+   function Search_In_Path
+     (File : UTF_8_String;
+      Path : UTF_8_String) return UTF_8_String is separate;
+
+   -----------------
+   -- Search_Path --
+   -----------------
+
+   function Search_Path
+    (Self : Process_Environment'Class;
+     File : UTF_8_String;
+     Name : UTF_8_String := "PATH") return UTF_8_String
+   is
+      Value : constant UTF_8_String := Self.Value (Name);
+   begin
+      if Value = "" then
+         return "";
+      else
+         return Search_In_Path (File, Value);
+      end if;
+   end Search_Path;
 
    ------------------------
    -- System_Environment --

--- a/source/spawn/spawn-environments.ads
+++ b/source/spawn/spawn-environments.ads
@@ -28,30 +28,46 @@ package Spawn.Environments is
    type Process_Environment is tagged private;
 
    procedure Clear (Self : in out Process_Environment'Class);
+   --  Reset given Process_Environment to an empty state.
 
    function Contains
     (Self : Process_Environment'Class; Name : UTF_8_String) return Boolean;
+   --  Check if given Process_Environment has variable with given Name.
 
    procedure Insert
     (Self  : in out Process_Environment'Class;
      Name  : UTF_8_String;
      Value : UTF_8_String);
+   --  Insert variable into Process_Environment, replace existing variable
+   --  with the same name if any.
 
    procedure Insert
     (Self        : in out Process_Environment'Class;
      Environemnt : Process_Environment'Class);
+   --  Insert all variables into Process_Environment.
 
    function Keys (Self : Process_Environment'Class)
      return Spawn.String_Vectors.UTF_8_String_Vector;
+   --  Return list of names of variables.
 
    procedure Remove
     (Self : in out Process_Environment'Class;
      Name : UTF_8_String);
+   --  Delete variable from Process_Environment. Do nothing if no such variable
 
    function Value
     (Self    : Process_Environment'Class;
      Name    : UTF_8_String;
      Default : UTF_8_String := "") return UTF_8_String;
+   --  Get value of an variable from Process_Environment
+
+   function Search_Path
+    (Self : Process_Environment'Class;
+     File : UTF_8_String;
+     Name : UTF_8_String := "PATH") return UTF_8_String;
+   --  Take an environment variable with given Name as directory list, then
+   --  search for the File in each of this directory. Return path to found file
+   --  or empty string if not found.
 
    function System_Environment return Process_Environment;
 

--- a/source/spawn/spawn-windows_api.ads
+++ b/source/spawn/spawn-windows_api.ads
@@ -223,4 +223,19 @@ package Spawn.Windows_API is
    --  he I/O operation has been aborted because of either a thread exit or an
    --  application request.
 
+   function SearchPath
+     (lpPath         : LPWSTR;
+      lpFileName     : LPWSTR;
+      lpExtension    : LPWSTR;
+      nBufferLength  : DWORD;
+      lpBuffer       : LPWSTR;
+      lpFilePart     : access LPWSTR)
+        return DWORD
+          with Import, Convention => Stdcall,
+               External_Name => "SearchPathW";
+   --  Searches for a specified file in a specified path
+
+   MAX_PATH : constant := 32767;
+   --  Max file name length. Legacy MAX_PATH was 256
+
 end Spawn.Windows_API;


### PR DESCRIPTION
to search full path of executable. We've considered to let Start
subprogram find full path, but this could be wrong if PATH environment
variable differs in child process environments. So client should find
full path in correct environment with new function Search_Path and pass
full path to Set_Program.