### PR TITLE
S328-046 Introduce asynchronous processing

### DIFF
--- a/source/ada/lsp-ada_driver.adb
+++ b/source/ada/lsp-ada_driver.adb
@@ -15,7 +15,6 @@
 -- of the license.                                                          --
 ------------------------------------------------------------------------------
 
-with Ada.Command_Line;
 with Ada.Exceptions;
 with Ada.IO_Exceptions;
 
@@ -78,6 +77,7 @@ begin
 
       begin
          if Do_Exit then
+            Server.Finalize;
             return;
          end if;
 
@@ -92,8 +92,7 @@ begin
             Do_Exit := False;
 
          when Ada.IO_Exceptions.End_Error =>
-            Server_Trace.Trace ("Received EOF: exiting with error code...");
-            Ada.Command_Line.Set_Exit_Status (1);
+            Server_Trace.Trace ("Received EOF.");
 
          when E : others =>
             Server_Trace.Trace

--- a/source/server/lsp-servers.ads
+++ b/source/server/lsp-servers.ads
@@ -116,9 +116,7 @@ private
    type Server is limited
      new LSP.Client_Notifications.Client_Notification_Handler with
    record
-      Initialized : Boolean;
-      Stop        : Boolean := False;
-      --  Mark Server as uninitialized until get 'initalize' request
+      Stop          : Boolean := False;
       Stream        : access Ada.Streams.Root_Stream_Type'Class;
       Last_Request  : LSP.Types.LSP_Number := 1;
       Vector        : Ada.Strings.Unbounded.Unbounded_String;

--- a/source/server/lsp-servers.ads
+++ b/source/server/lsp-servers.ads
@@ -23,10 +23,9 @@ with LSP.Messages;
 with LSP.Server_Notifications;
 with LSP.Types;
 
-private with LSP.Notification_Dispatchers;
-private with LSP.Request_Dispatchers;
-
 private with Ada.Strings.Unbounded;
+with Ada.Containers.Synchronized_Queue_Interfaces;
+with Ada.Containers.Unbounded_Synchronized_Queues;
 
 package LSP.Servers is
 
@@ -39,8 +38,13 @@ package LSP.Servers is
       Request      : not null LSP.Message_Handlers.Request_Handler_Access;
       Notification : not null
         LSP.Server_Notifications.Server_Notification_Handler_Access);
+   --  Initialize a server
+
+   procedure Finalize (Self : in out Server);
+   --  Clean up memory, file handles, tasks, etc.
 
    procedure Run (Self  : in out Server);
+   --  Run the server
 
    procedure Stop (Self  : in out Server);
    --  Ask server to stop after processing current message
@@ -50,24 +54,80 @@ package LSP.Servers is
       Params   : LSP.Messages.ApplyWorkspaceEditParams;
       Applied  : out Boolean;
       Error    : out LSP.Messages.Optional_ResponseError);
+   --  ??? Needs doc
+   --  ??? In the current implementation, Applied is always True and
+   --  Error is always unset.
 
 private
+
+   -------------------------
+   --  Tasking in the ALS --
+   -------------------------
+
+   --  The server has 3 tasks:
+   --    The input task (currently: the main thread)
+   --         This reads input coming from stdin, forms requests, and places
+   --         them on the requests queue.
+   --    The processing task:
+   --         This is the task where libadalang lives. This task receives
+   --         requests from the request queue, processes them, and returns
+   --         the responses from them on the output queue.
+   --    The output task:
+   --         This task reads the responses coming from the output queue,
+   --         and writes them to the standard output.
+
+   type Stream_Access is access all Ada.Streams.Root_Stream_Type'Class;
+
+   package Unbounded_String_Queue_Interface is new
+     Ada.Containers.Synchronized_Queue_Interfaces
+       (Ada.Strings.Unbounded.Unbounded_String);
+   package Requests_Queues is new
+     Ada.Containers.Unbounded_Synchronized_Queues
+       (Unbounded_String_Queue_Interface);
+   package Output_Queues is new
+     Ada.Containers.Unbounded_Synchronized_Queues
+       (Unbounded_String_Queue_Interface);
+
+   type Requests_Queue_Access is access Requests_Queues.Queue;
+   type Output_Queue_Access is access Output_Queues.Queue;
+
+   --  The processing task
+   task type Processing_Task_Type is
+      entry Start
+        (In_Queue     : Requests_Queue_Access;
+         Out_Queue    : Output_Queue_Access;
+         Request      : not null LSP.Message_Handlers.Request_Handler_Access;
+         Notification : not null
+           LSP.Server_Notifications.Server_Notification_Handler_Access);
+      entry Stop;
+      --  Clean shutdown of the task
+   end Processing_Task_Type;
+
+   --  The output task
+   task type Output_Task_Type is
+      entry Start (Queue         : Output_Queue_Access;
+                   Output_Stream : Stream_Access);
+      --  Start the task. Should be called once, with the stream to output to.
+
+      entry Stop;
+      --  Clean shutdown of the task. Can only be called after Start.
+   end Output_Task_Type;
 
    type Server is limited
      new LSP.Client_Notifications.Client_Notification_Handler with
    record
-      Initilized : Boolean;
-      Stop       : Boolean := False;
+      Initialized : Boolean;
+      Stop        : Boolean := False;
       --  Mark Server as uninitialized until get 'initalize' request
       Stream        : access Ada.Streams.Root_Stream_Type'Class;
-      Req_Handler   : LSP.Message_Handlers.Request_Handler_Access;
-      Notif_Handler :
-        LSP.Server_Notifications.Server_Notification_Handler_Access;
-      Requests      : aliased LSP.Request_Dispatchers.Request_Dispatcher;
-      Notifications : aliased LSP.Notification_Dispatchers
-        .Notification_Dispatcher;
       Last_Request  : LSP.Types.LSP_Number := 1;
       Vector        : Ada.Strings.Unbounded.Unbounded_String;
+
+      --  Queues and tasks used for asynchronous processing, see doc above
+      Requests_Queue : Requests_Queue_Access;
+      Output_Queue   : Output_Queue_Access;
+      Processing_Task : Processing_Task_Type;
+      Output_Task     : Output_Task_Type;
    end record;
 
    procedure Send_Notification

--- a/testsuite/ada_lsp/0001-start_stop/0001-start_stop.json
+++ b/testsuite/ada_lsp/0001-start_stop/0001-start_stop.json
@@ -6,7 +6,7 @@
     },
     {
         "stop": {
-            "exit_code": 1
+            "exit_code": 0
         }
     }
 ]


### PR DESCRIPTION
Introduce a separate task for the actual processing, synchronized
to the main task via a queue of requests. This allows the main
task to never be blocking on input when libadalang is performing
an expensive computation. This will also be used to implement
a basic support for cancelling requests.

Also process the output in a separate task.