### PR TITLE
S506-022 Add defensive code

### DIFF
--- a/source/ada/lsp-ada_contexts.adb
+++ b/source/ada/lsp-ada_contexts.adb
@@ -412,8 +412,8 @@ package body LSP.Ada_Contexts is
    is
       pragma Unreferenced (Self);
 
-      Result : constant String := URIs.Conversions.To_File
-        (LSP.Types.To_UTF_8_String (URI));
+      To     : constant URIs.URI_String := LSP.Types.To_UTF_8_String (URI);
+      Result : constant String := URIs.Conversions.To_File (To);
    begin
       return LSP.Types.To_LSP_String (Result);
    end URI_To_File;

--- a/source/ada/lsp-ada_driver.adb
+++ b/source/ada/lsp-ada_driver.adb
@@ -33,6 +33,10 @@ with LSP.Ada_Handlers;
 
 with Libadalang.Common; use Libadalang.Common;
 
+--------------------
+-- LSP.Ada_Driver --
+--------------------
+
 procedure LSP.Ada_Driver is
 
    Server  : aliased LSP.Servers.Server;
@@ -71,17 +75,13 @@ begin
       Handler'Unchecked_Access);
 
    loop
-
       --  Here, we do Server.Run in a loop, in order to be able to recover from
       --  exceptions. However, in the common case we don't want to keep running
       --  the server when it has been stopped. We use the Do_Exit variable to
       --  signal that.
 
       begin
-         if Do_Exit then
-            Server.Finalize;
-            return;
-         end if;
+         exit when Do_Exit;
 
          Do_Exit := True;
 
@@ -106,4 +106,5 @@ begin
       end;
    end loop;
 
+   Server.Finalize;
 end LSP.Ada_Driver;

--- a/source/server/lsp-servers.adb
+++ b/source/server/lsp-servers.adb
@@ -20,6 +20,9 @@ with Ada.Strings.UTF_Encoding;
 with Ada.Strings.Unbounded;      use Ada.Strings.Unbounded;
 with Ada.Unchecked_Deallocation;
 
+with Ada.Exceptions;          use Ada.Exceptions;
+with GNAT.Traceback.Symbolic; use GNAT.Traceback.Symbolic;
+
 with LSP.Servers.Handlers;
 with LSP.JSON_Streams;
 with LSP.Messages.Requests;
@@ -479,8 +482,21 @@ package body LSP.Servers is
                goto BEGIN_TASK_LOOP;
             end select;
 
-            --  Send the output to the stream
-            Write_JSON_RPC (Stream, Vector);
+            begin
+               --  Send the output to the stream
+               Write_JSON_RPC (Stream, Vector);
+            exception
+               when E : others =>
+                  --  Catch-all case: make sure no exception in output writing
+                  --  can cause an exit of the task loop.
+                  GNATCOLL.Traces.Trace
+                    (LSP.Server_Trace,
+                     "Exception when writing output:" & ASCII.LF
+                     & To_String (Vector) & ASCII.LF
+                     & Exception_Name (E) & " - " &  Exception_Message (E));
+                  Server_Trace.Trace (Symbolic_Traceback (E));
+
+            end;
          end loop;
       end loop;
    end Output_Task_Type;
@@ -718,6 +734,16 @@ package body LSP.Servers is
             begin
                Process_Message_From_Stream (Request, Result, Error);
                --  ??? Should we do something with Results, Error?
+            exception
+               when E : others =>
+                  --  Catch-all case: make sure no exception in any request
+                  --  processing can cause an exit of the task main loop.
+                  GNATCOLL.Traces.Trace
+                    (LSP.Server_Trace,
+                     "Exception when processing request:" & ASCII.LF
+                     & To_String (Request) & ASCII.LF
+                     & Exception_Name (E) & " - " &  Exception_Message (E));
+                  Server_Trace.Trace (Symbolic_Traceback (E));
             end;
          end loop;
 


### PR DESCRIPTION
Make sure any exception in finalization is fatal, preventing an
infinite loop on trying to exit.

Prevent any exception in task processing from quitting the task
main loops.