### PR TITLE
S506-022 make the URIs package accessible to clients

### DIFF
--- a/gnat/lsp.gpr
+++ b/gnat/lsp.gpr
@@ -30,7 +30,9 @@ project LSP is
    );
    Build_Mode : Any_Build_Mode := external ("BUILD_MODE", "dev");
 
-   for Source_Dirs use ("../source/protocol", "../source/protocol/generated");
+   for Source_Dirs use ("../source/protocol", 
+                        "../source/protocol/generated",
+                        "../source/uri");
    for Object_Dir use "../.obj/lsp";
    for Main use ();
 

--- a/gnat/lsp_server.gpr
+++ b/gnat/lsp_server.gpr
@@ -21,7 +21,7 @@ with "lsp";
 
 project LSP_Server is
 
-   for Source_Dirs use ("../source/server", "../source/ada", "../source/uri");
+   for Source_Dirs use ("../source/server", "../source/ada");
    for Object_Dir use "../.obj/server";
    for Main use ("lsp-ada_driver");
 

--- a/gnat/tester.gpr
+++ b/gnat/tester.gpr
@@ -20,7 +20,7 @@ with "gnatcoll";
 
 project Tester is
 
-   for Source_Dirs use ("../source/tester", "../source/uri");
+   for Source_Dirs use ("../source/tester");
    for Object_Dir use "../.obj/tester";
    for Main use ("tester-run.adb");
 

--- a/source/uri/uris.adb
+++ b/source/uri/uris.adb
@@ -15,6 +15,7 @@
 -- of the license.                                                          --
 ------------------------------------------------------------------------------
 
+with Ada.Directories;
 with Ada.Characters.Handling;
 with Ada.Strings.UTF_Encoding.Wide_Wide_Strings;
 with Ada.Wide_Wide_Characters.Handling;

--- a/source/uri/uris.ads
+++ b/source/uri/uris.ads
@@ -20,11 +20,11 @@
 --
 
 with Ada.Containers.Doubly_Linked_Lists;
-with Ada.Directories;
 with Ada.Iterator_Interfaces;
-with Ada.Strings.Fixed.Equal_Case_Insensitive;
 with Ada.Strings.Unbounded;
 with Ada.Strings.UTF_Encoding;
+
+with GNAT.OS_Lib;
 
 package URIs is
 
@@ -95,10 +95,7 @@ package URIs is
 
    package Conversions is
       function From_File (Full_Path : String) return URI_String
-        with Pre =>
-          Ada.Strings.Fixed.Equal_Case_Insensitive
-            (Ada.Directories.Full_Name (Full_Path),
-             Full_Path);
+        with Pre => GNAT.OS_Lib.Is_Absolute_Path (Full_Path);
       --  Convert from file to URI in form of file://path
       --  Argument should be a absolute path (not relative one)
 


### PR DESCRIPTION
This is very convenient for clients to be able to convert from
file names to URIs without having to reimplement their routines.

Also change the test for checking that file names are absolute to
one that works with final directory separators.