### PR TITLE
S510-020 Make sure to send error responses when exceptions occur

### DIFF
--- a/source/tester/tester-tests.adb
+++ b/source/tester/tester-tests.adb
@@ -292,6 +292,13 @@ package body Tester.Tests is
                   return True;
                end;
 
+            when GNATCOLL.JSON.JSON_String_Type =>
+               if String'(GNATCOLL.JSON.Get (Right)) = "<ANY>" then
+                  return True;
+               else
+                  return Left = Right;
+               end if;
+
             when others =>
 
                return Left = Right;

--- a/testsuite/ada_lsp/S510-020.exceptions_reporting/test.json
+++ b/testsuite/ada_lsp/S510-020.exceptions_reporting/test.json
@@ -1,0 +1,53 @@
+[
+    {
+        "start": {
+            "cmd": ["${ALS}"]
+        }
+    },
+    {
+        "send": {
+            "request": {"jsonrpc":"2.0","id":0,"method":"initialize","params":{
+                "processId":1,
+                "rootUri":"$URI{.}",
+                "capabilities":{}}
+            },
+            "wait":[{
+                "id": 0,
+                "result":{
+                    "capabilities":{
+                        "textDocumentSync":1,
+                        "referencesProvider":true
+                    }
+                }
+            }]
+        }
+    },  {
+        "send": {
+            "request": {
+                "jsonrpc":"2.0",
+                "id":"references-1",
+                "method":"textDocument/references",
+                "params":{
+                    "textDocument": {
+                        "uri": "DOES NOT EXIST"
+                    },
+                    "position": {
+                        "line": 1,
+                        "character": 12
+                    },
+                    "context": {
+                        "includeDeclaration":true
+                    }
+                }
+            },
+            "comment": " -- we expect an exception here, code -32603",
+            "wait":[{"jsonrpc":"2.0", "error": {"code":-32603,"message":"<ANY>"}}]
+        }
+    },
+
+    {
+        "stop": {
+            "exit_code": 0
+        }
+    }
+]

--- a/testsuite/ada_lsp/S510-020.exceptions_reporting/test.yaml
+++ b/testsuite/ada_lsp/S510-020.exceptions_reporting/test.yaml
@@ -1,0 +1,1 @@
+title: 'S510-020.exceptions_reporting'


### PR DESCRIPTION
When decoding of requests or processing of requests generate
exceptions, send a response with a detailed message.

Add an automated test. To support the writing of the test,
add a special case that allows writing `"<ANY>"` in the test
driver to match any string.