### PR TITLE
S515-039 Fix handling of overfull pipe

### DIFF
--- a/source/client/lsp-raw_clients.adb
+++ b/source/client/lsp-raw_clients.adb
@@ -81,9 +81,7 @@ package body LSP.Raw_Clients is
       Ada.Strings.Unbounded.Append (Self.To_Write, Header);
       Ada.Strings.Unbounded.Append (Self.To_Write, Text);
 
-      if Self.Standard_Input_Available then
-         Self.Listener.Standard_Input_Available;
-      end if;
+      Self.Listener.Standard_Input_Available;
    end Send_Message;
 
    -------------------

--- a/source/client/lsp-raw_clients.ads
+++ b/source/client/lsp-raw_clients.ads
@@ -104,6 +104,9 @@ private
       Listener  : aliased Raw_Clients.Listener (Raw_Client'Unchecked_Access);
 
       Standard_Input_Available : Boolean := False;
+      --  ??? Needs doc: what does this mean, when is it set, when is it unset?
+      --  ??? It would be nice to name this differently, since
+      --  Standard_Input_Available is also the name of a subprogram above.
 
       To_Write  : Ada.Strings.Unbounded.Unbounded_String; --  Output data
       Written   : Natural := 0;  --  How much we have written from To_Write


### PR DESCRIPTION
Do not check the flag Standard_Input_Available before
calling Standard_Input_Available.

Add a ??? comment.