### PR TITLE
S516-036 avoid allocating large strings on the stack

### DIFF
--- a/source/ada/lsp-ada_documents.adb
+++ b/source/ada/lsp-ada_documents.adb
@@ -80,7 +80,7 @@ package body LSP.Ada_Documents is
             Self.Unit := Self.LAL.Get_From_Buffer
               (Filename => File,
                Charset  => "utf-8",
-               Buffer   => LSP.Types.To_UTF_8_String (Change.text));
+               Buffer   => LSP.Types.To_UTF_8_Unbounded_String (Change.text));
          end if;
       end loop;
       Server_Trace.Trace ("Done applying changes for document " & File);
@@ -272,7 +272,7 @@ package body LSP.Ada_Documents is
       Self.Unit := LAL.Get_From_Buffer
         (Filename => LSP.Types.To_UTF_8_String (File),
          Charset  => "utf-8",
-         Buffer   => LSP.Types.To_UTF_8_String (Item.text));
+         Buffer   => LSP.Types.To_UTF_8_Unbounded_String (Item.text));
       Self.URI := Item.uri;
       Self.LAL := LAL;
    end Initialize;

--- a/source/protocol/lsp-messages.adb
+++ b/source/protocol/lsp-messages.adb
@@ -16,6 +16,7 @@
 ------------------------------------------------------------------------------
 
 with Ada.Strings.UTF_Encoding;
+with Ada.Strings.Unbounded; use Ada.Strings.Unbounded;
 with Ada.Strings.Wide_Unbounded;
 
 with GNATCOLL.JSON;
@@ -696,7 +697,7 @@ package body LSP.Messages is
          Item := Empty_LSP_String;
       else
          --  Item := League.IRIs.From_Universal_String (Stream.Read.To_String);
-         Item := To_LSP_String (Stream.Read.Get);
+         Item := To_LSP_String (Unbounded_String'(Stream.Read.Get));
       end if;
    end Read_If_String;
 
@@ -858,13 +859,16 @@ package body LSP.Messages is
    begin
       case Value.Kind is
          when GNATCOLL.JSON.JSON_String_Type =>
-            V := (Is_String => True, Value => To_LSP_String (Value.Get));
+            V := (Is_String => True,
+                  Value => To_LSP_String (Unbounded_String'(Value.Get)));
          when GNATCOLL.JSON.JSON_Object_Type =>
             --  We can't use Start_Object/End_Object here because JS.Read
             --  call has already skipped the array item.
             V := (Is_String => False,
-                  language => To_LSP_String (Value.Get ("language")),
-                  value    => To_LSP_String (Value.Get ("value")));
+                  language => To_LSP_String
+                    (Unbounded_String'(Value.Get ("language"))),
+                  value    => To_LSP_String
+                    (Unbounded_String'(Value.Get ("value"))));
          when others =>
             --  Unexpected JSON type
             V := (Is_String => True, Value => Empty_LSP_String);
@@ -1385,7 +1389,7 @@ package body LSP.Messages is
       Stream.Start_Array;
 
       while not Stream.End_Of_Array loop
-         Item.Append (To_LSP_String (Stream.Read.Get));
+         Item.Append (To_LSP_String (Unbounded_String'(Stream.Read.Get)));
       end loop;
 
       Stream.End_Array;
@@ -3136,7 +3140,7 @@ package body LSP.Messages is
      Item   : LSP.Types.LSP_String) is
    begin
       Stream.Key (Ada.Strings.Wide_Unbounded.Unbounded_Wide_String (Key));
-      Stream.Write (GNATCOLL.JSON.Create (To_UTF_8_String (Item)));
+      Stream.Write (GNATCOLL.JSON.Create (To_UTF_8_Unbounded_String (Item)));
    end Write_String;
 
    -------------------------

--- a/source/protocol/lsp-types.ads
+++ b/source/protocol/lsp-types.ads
@@ -60,11 +60,20 @@ package LSP.Types is
 
    function To_LSP_String (Text : Ada.Strings.UTF_Encoding.UTF_8_String)
      return LSP_String;
+   function To_LSP_String (Text : GNATCOLL.JSON.UTF8_Unbounded_String)
+     return LSP_String;
    --  Convert given UTF-8 string into LSP_String
 
    function To_UTF_8_String (Value : LSP_String)
      return Ada.Strings.UTF_Encoding.UTF_8_String;
-   --  Convert given LSP_String into UTF-8 string
+   --  Convert given LSP_String into UTF-8 string. Note that this
+   --  allocates strings on the stack: if the string is potentially
+   --  large (such as the content of a file), prefer calling
+   --  To_UTF_8_Unbounded_String below.
+
+   function To_UTF_8_Unbounded_String (Value : LSP_String)
+     return GNATCOLL.JSON.UTF8_Unbounded_String;
+   --  Same as To_UTF_8_String above, but returns an Unbounded_String.
 
    function Is_Empty (Text : LSP_String) return Boolean;
    --  Check if given Text is an empty string


### PR DESCRIPTION
Introduce a new function for string conversions
that avoids stack allocation, and use this in the
case of a giant string.

Adding test as part of the GPS testsuite.