### PR TITLE
S516-036 avoid allocating large strings on the stack

### DIFF
--- a/source/ada/lsp-ada_documents.adb
+++ b/source/ada/lsp-ada_documents.adb
@@ -80,7 +80,7 @@ package body LSP.Ada_Documents is
             Self.Unit := Self.LAL.Get_From_Buffer
               (Filename => File,
                Charset  => "utf-8",
-               Buffer   => LSP.Types.To_UTF_8_String (Change.text));
+               Buffer   => LSP.Types.To_UTF_8_Unbounded_String (Change.text));
          end if;
       end loop;
       Server_Trace.Trace ("Done applying changes for document " & File);
@@ -272,7 +272,7 @@ package body LSP.Ada_Documents is
       Self.Unit := LAL.Get_From_Buffer
         (Filename => LSP.Types.To_UTF_8_String (File),
          Charset  => "utf-8",
-         Buffer   => LSP.Types.To_UTF_8_String (Item.text));
+         Buffer   => LSP.Types.To_UTF_8_Unbounded_String (Item.text));
       Self.URI := Item.uri;
       Self.LAL := LAL;
    end Initialize;

--- a/source/protocol/lsp-messages.adb
+++ b/source/protocol/lsp-messages.adb
@@ -16,6 +16,7 @@
 ------------------------------------------------------------------------------
 
 with Ada.Strings.UTF_Encoding;
+with Ada.Strings.Unbounded; use Ada.Strings.Unbounded;
 with Ada.Strings.Wide_Unbounded;
 
 with GNATCOLL.JSON;
@@ -696,7 +697,7 @@ package body LSP.Messages is
          Item := Empty_LSP_String;
       else
          --  Item := League.IRIs.From_Universal_String (Stream.Read.To_String);
-         Item := To_LSP_String (Stream.Read.Get);
+         Item := To_LSP_String (Unbounded_String'(Stream.Read.Get));
       end if;
    end Read_If_String;
 
@@ -858,13 +859,16 @@ package body LSP.Messages is
    begin
       case Value.Kind is
          when GNATCOLL.JSON.JSON_String_Type =>
-            V := (Is_String => True, Value => To_LSP_String (Value.Get));
+            V := (Is_String => True,
+                  Value => To_LSP_String (Unbounded_String'(Value.Get)));
          when GNATCOLL.JSON.JSON_Object_Type =>
             --  We can't use Start_Object/End_Object here because JS.Read
             --  call has already skipped the array item.
             V := (Is_String => False,
-                  language => To_LSP_String (Value.Get ("language")),
-                  value    => To_LSP_String (Value.Get ("value")));
+                  language => To_LSP_String
+                    (Unbounded_String'(Value.Get ("language"))),
+                  value    => To_LSP_String
+                    (Unbounded_String'(Value.Get ("value"))));
          when others =>
             --  Unexpected JSON type
             V := (Is_String => True, Value => Empty_LSP_String);
@@ -1385,7 +1389,7 @@ package body LSP.Messages is
       Stream.Start_Array;
 
       while not Stream.End_Of_Array loop
-         Item.Append (To_LSP_String (Stream.Read.Get));
+         Item.Append (To_LSP_String (Unbounded_String'(Stream.Read.Get)));
       end loop;
 
       Stream.End_Array;
@@ -3136,7 +3140,7 @@ package body LSP.Messages is
      Item   : LSP.Types.LSP_String) is
    begin
       Stream.Key (Ada.Strings.Wide_Unbounded.Unbounded_Wide_String (Key));
-      Stream.Write (GNATCOLL.JSON.Create (To_UTF_8_String (Item)));
+      Stream.Write (GNATCOLL.JSON.Create (To_UTF_8_Unbounded_String (Item)));
    end Write_String;
 
    -------------------------

--- a/source/protocol/lsp-types.adb
+++ b/source/protocol/lsp-types.adb
@@ -15,11 +15,16 @@
 -- of the license.                                                          --
 ------------------------------------------------------------------------------
 
+with Ada.Strings.Unbounded; use Ada.Strings.Unbounded;
+with Ada.Unchecked_Conversion;
 with Ada.Strings.UTF_Encoding.Wide_Strings;
 
 with LSP.JSON_Streams;
 
 package body LSP.Types is
+
+   Chunk_Size    : constant := 512;
+   --  When processing strings in chunks, this is the size of the chunk
 
    --------------
    -- Assigned --
@@ -66,7 +71,7 @@ package body LSP.Types is
       JS : LSP.JSON_Streams.JSON_Stream'Class renames
         LSP.JSON_Streams.JSON_Stream'Class (S.all);
    begin
-      V := To_LSP_String (JS.Read.Get);
+      V := To_LSP_String (Unbounded_String'(JS.Read.Get));
    end Read;
 
    ---------------------------
@@ -88,7 +93,7 @@ package body LSP.Types is
                   String    => Empty_LSP_String);
       elsif Value.Kind in GNATCOLL.JSON.JSON_String_Type then
          Item := (Is_Number => False,
-                  String    => To_LSP_String (Value.Get));
+                  String    => To_LSP_String (Unbounded_String'(Value.Get)));
       else
          Item := (Is_Number => True, Number => Integer'(Value.Get));
       end if;
@@ -111,7 +116,8 @@ package body LSP.Types is
       if Value.Kind in GNATCOLL.JSON.JSON_Null_Type then
          Item := (Is_Set => False);
       else
-         Item := (Is_Set => True, Value => To_LSP_String (Value.Get));
+         Item := (Is_Set => True, Value => To_LSP_String
+                  (Unbounded_String'(Value.Get)));
       end if;
    end Read_Optional_String;
 
@@ -125,7 +131,7 @@ package body LSP.Types is
       Item   : out LSP.Types.LSP_String) is
    begin
       Stream.Key (Ada.Strings.Wide_Unbounded.Unbounded_Wide_String (Key));
-      Item := To_LSP_String (Stream.Read.Get);
+      Item := To_LSP_String (Unbounded_String'(Stream.Read.Get));
    end Read_String;
 
    -----------------
@@ -154,6 +160,50 @@ package body LSP.Types is
       return To_Unbounded_Wide_String (UTF_16);
    end To_LSP_String;
 
+   -------------------
+   -- To_LSP_String --
+   -------------------
+
+   function To_LSP_String
+     (Text : GNATCOLL.JSON.UTF8_Unbounded_String) return LSP_String
+   is
+      Res : LSP_String;
+      Len : constant Natural := Length (Text);
+      Current_Index : Positive := 1;
+
+      subtype Continuation_Character is Character range
+        Character'Val (2#1000_0000#) .. Character'Val (2#1011_1111#);
+   begin
+      loop
+         --  Process the decoding in chunks
+         declare
+            Bound : Natural := Natural'Min (Current_Index + Chunk_Size, Len);
+            Chunk : constant String (Current_Index .. Bound) := Slice
+              (Text, Current_Index, Bound);
+         begin
+            --  We don't want to cut a chunk in the middle of a long
+            --  character, so look at the last 4 bytes and cut before
+            --  any such long character, and cut if needs be.
+            if Bound /= Len then
+               for J in reverse 0 .. 3 loop
+                  if Chunk (Bound - J) not in Continuation_Character then
+                     --  This character is not a continuation character: it's
+                     --  OK to cut before it, and start the next chunk with it.
+                     Bound := Bound - J - 1;
+                     exit;
+                  end if;
+               end loop;
+            end if;
+            Append
+              (Res, Ada.Strings.UTF_Encoding.Wide_Strings.Decode
+                 (Chunk (Current_Index .. Bound)));
+            Current_Index := Bound + 1;
+            exit when Current_Index > Len;
+         end;
+      end loop;
+      return Res;
+   end To_LSP_String;
+
    ---------------------
    -- To_UTF_8_String --
    ---------------------
@@ -165,6 +215,30 @@ package body LSP.Types is
    begin
       return Ada.Strings.UTF_Encoding.Wide_Strings.Encode (Wide);
    end To_UTF_8_String;
+
+   -------------------------------
+   -- To_UTF_8_Unbounded_String --
+   -------------------------------
+
+   function To_UTF_8_Unbounded_String
+     (Value : LSP_String) return GNATCOLL.JSON.UTF8_Unbounded_String
+   is
+      Res  : Ada.Strings.Unbounded.Unbounded_String;
+      Len  : constant Natural := Length (Value);
+      Current_Index : Natural := 1;
+      Next_Index    : Natural;
+   begin
+      --  Perform the encoding chunk by chunk, so as not to blow the stack
+      loop
+         Next_Index := Natural'Min (Current_Index + Chunk_Size, Len);
+         Ada.Strings.Unbounded.Append
+           (Res, Ada.Strings.UTF_Encoding.Wide_Strings.Encode
+              (Slice (Value, Current_Index, Next_Index)));
+         Current_Index := Next_Index + 1;
+         exit when Current_Index > Len;
+      end loop;
+      return Res;
+   end To_UTF_8_Unbounded_String;
 
    -----------
    -- Write --

--- a/source/protocol/lsp-types.ads
+++ b/source/protocol/lsp-types.ads
@@ -60,11 +60,20 @@ package LSP.Types is
 
    function To_LSP_String (Text : Ada.Strings.UTF_Encoding.UTF_8_String)
      return LSP_String;
+   function To_LSP_String (Text : GNATCOLL.JSON.UTF8_Unbounded_String)
+     return LSP_String;
    --  Convert given UTF-8 string into LSP_String
 
    function To_UTF_8_String (Value : LSP_String)
      return Ada.Strings.UTF_Encoding.UTF_8_String;
-   --  Convert given LSP_String into UTF-8 string
+   --  Convert given LSP_String into UTF-8 string. Note that this
+   --  allocates strings on the stack: if the string is potentially
+   --  large (such as the content of a file), prefer calling
+   --  To_UTF_8_Unbounded_String below.
+
+   function To_UTF_8_Unbounded_String (Value : LSP_String)
+     return GNATCOLL.JSON.UTF8_Unbounded_String;
+   --  Same as To_UTF_8_String above, but returns an Unbounded_String.
 
    function Is_Empty (Text : LSP_String) return Boolean;
    --  Check if given Text is an empty string


### PR DESCRIPTION
Introduce a new function for string conversions
that avoids stack allocation, and use this in the
case of a giant string.