### PR TITLE
S528-016 Add a setting to deactivate diagnostics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 # Server executable file:
-export ALS=.obj/server/ada_language_server
+export ALS=$(shell pwd)/.obj/server/ada_language_server
 
 # Tester files
-TESTER=.obj/tester/tester-run
+TESTER=$(shell pwd)/.obj/tester/tester-run
 CODEC_TEST=.obj/codec_test/codec_test
 
 # Testsuite directory
@@ -72,7 +72,11 @@ vscode:
 	@echo code --extensionDevelopmentPath=`pwd`/integration/vscode/ada/ `pwd`
 
 check: all
-	set -e; for a in $(TD)/*/*.json; do echo $$a ; $(TESTER) $$a ; done
+	set -e; \
+        for a in $(TD)/*/*.json; do \
+           echo $$a ; \
+           (cd `dirname $$a ` ; $(TESTER) `basename $$a`) ;\
+        done
 	${CODEC_TEST} < testsuite/codecs/index.txt
 
 deploy: check

--- a/source/ada/lsp-ada_driver.adb
+++ b/source/ada/lsp-ada_driver.adb
@@ -48,14 +48,18 @@ procedure LSP.Ada_Driver is
    use GNATCOLL.VFS, GNATCOLL.Traces;
    use Ada.Exceptions, GNAT.Traceback.Symbolic;
 
-   ALS_Dir : constant Virtual_File := Get_Home_Directory / ".als";
-   Do_Exit : Boolean := False;
+   ALS_Dir   : constant Virtual_File := Get_Home_Directory / ".als";
+   GNATdebug : constant Virtual_File := Create_From_Base (".gnatdebug");
+   Do_Exit   : Boolean := False;
 begin
 
-   --  If we can find the .als directory in the home directory, then we want
-   --  to init the traces.
+   --  Look for a .gnatdebug file locally; if it exists, use its contents as
+   --  traces config file. If not, if the ".als" directory exists in the home
+   --  directory, initialize traces there.
+   if GNATdebug.Is_Regular_File then
+      Parse_Config_File (GNATdebug);
 
-   if ALS_Dir.Is_Directory then
+   elsif ALS_Dir.Is_Directory then
       --  Search for custom traces config in traces.cfg
       Parse_Config_File
         (+Virtual_File'(ALS_Dir / "traces.cfg").Full_Name);

--- a/source/ada/lsp-ada_handlers.adb
+++ b/source/ada/lsp-ada_handlers.adb
@@ -351,10 +351,13 @@ package body LSP.Ada_Handlers is
       Diag     : LSP.Messages.PublishDiagnosticsParams;
    begin
       Document.Apply_Changes (Value.contentChanges);
-      Document.Get_Errors (Diag.diagnostics);
 
-      Diag.uri := Value.textDocument.uri;
-      Self.Server.Publish_Diagnostics (Diag);
+      if Diagnostics_Trace.Active then
+         Document.Get_Errors (Diag.diagnostics);
+
+         Diag.uri := Value.textDocument.uri;
+         Self.Server.Publish_Diagnostics (Diag);
+      end if;
    end On_DidChangeTextDocument_Notification;
 
    ------------------------------------------

--- a/source/protocol/lsp.ads
+++ b/source/protocol/lsp.ads
@@ -24,4 +24,12 @@ package LSP is
    In_Trace : Trace_Handle := Create ("ALS.IN", Off);
    Out_Trace : Trace_Handle := Create ("ALS.OUT", Off);
    --  Traces that logs all input & output. For debugging purposes.
+
+   -----------------------------
+   -- Feature-specific traces --
+   -----------------------------
+
+   Diagnostics_Trace : Trace_Handle := Create ("ALS.DIAGNOSTICS", Off);
+   --  Whether to enable the diagnostics
+
 end LSP;

--- a/testsuite/ada_lsp/publish_diag/.gnatdebug
+++ b/testsuite/ada_lsp/publish_diag/.gnatdebug
@@ -1,0 +1,1 @@
+ALS.DIAGNOSTICS=yes


### PR DESCRIPTION
And document this setting, along with defaultCharset,
in the README.md.

Add a test for deactivation of diagnostics.

Improve the traces mechanism:
  - add a mechanism which accepts a ".gnatdebug" in the current
    dir to specify traces, overriding ~/.als/traces.cfg
  - add a .gnatdebug activating the diagnostics trace in the
    test ada_lsp/publish_diag
  - modify the Makefile to run each test in its directory,
    so that there can be local .gnatdebug files for each tests.