### PR TITLE
Add support for local traces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 # Server executable file:
-export ALS=.obj/server/ada_language_server
+export ALS=$(shell pwd)/.obj/server/ada_language_server
 
 # Tester files
-TESTER=.obj/tester/tester-run
+TESTER=$(shell pwd)/.obj/tester/tester-run
 CODEC_TEST=.obj/codec_test/codec_test
 
 # Testsuite directory
@@ -72,7 +72,11 @@ vscode:
 	@echo code --extensionDevelopmentPath=`pwd`/integration/vscode/ada/ `pwd`
 
 check: all
-	set -e; for a in $(TD)/*/*.json; do echo $$a ; $(TESTER) $$a ; done
+	set -e; \
+        for a in $(TD)/*/*.json; do \
+           echo $$a ; \
+           (cd `dirname $$a ` ; $(TESTER) `basename $$a`) ;\
+        done
 	${CODEC_TEST} < testsuite/codecs/index.txt
 
 deploy: check

--- a/source/ada/lsp-ada_driver.adb
+++ b/source/ada/lsp-ada_driver.adb
@@ -48,14 +48,18 @@ procedure LSP.Ada_Driver is
    use GNATCOLL.VFS, GNATCOLL.Traces;
    use Ada.Exceptions, GNAT.Traceback.Symbolic;
 
-   ALS_Dir : constant Virtual_File := Get_Home_Directory / ".als";
-   Do_Exit : Boolean := False;
+   ALS_Dir   : constant Virtual_File := Get_Home_Directory / ".als";
+   GNATdebug : constant Virtual_File := Create_From_Base (".gnatdebug");
+   Do_Exit   : Boolean := False;
 begin
 
-   --  If we can find the .als directory in the home directory, then we want
-   --  to init the traces.
+   --  Look for a .gnatdebug file locally; if it exists, use its contents as
+   --  traces config file. If not, if the ".als" directory exists in the home
+   --  directory, initialize traces there.
+   if GNATdebug.Is_Regular_File then
+      Parse_Config_File (GNATdebug);
 
-   if ALS_Dir.Is_Directory then
+   elsif ALS_Dir.Is_Directory then
       --  Search for custom traces config in traces.cfg
       Parse_Config_File
         (+Virtual_File'(ALS_Dir / "traces.cfg").Full_Name);


### PR DESCRIPTION
If there is a '.gnatdebug' file in the directory where the ALS
is launched, use this as traces configuration file. Useful
essentially for developers.

Modify the test driver so that each test is run in its
directory, in case we need to add .gnatdebug files local
to specific tests.