### PR TITLE
S528-016 Add a setting to deactivate diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,13 @@ You can configure the [GNAT Project File]() and scenario variables via the
 `.vscode/settings.json` settings file, via the keys `"ada.projectFile"` and
 `"ada.scenarioVariables"`.
 
+You can set the character set to use when the server has to use when reading
+files from disk by specifying an `"ada.defaultCharset"` key. The default is
+`iso-8859-1`.
+
+You can explicitly deactivate the emission of diagnostics, via the
+`"ada.enableDiagnostics` key. By default, diagnostics are enabled.
+
 Here is an example config file from the gnatcov project:
 
 ```json
@@ -161,7 +168,9 @@ Here is an example config file from the gnatcov project:
     "ada.scenarioVariables": {
         "BINUTILS_BUILD_DIR": "/null",
         "BINUTILS_SRC_DIR": "/null"
-    }
+    },
+   "ada.defaultCharset": "utf-8",
+   "ada.enableDiagnostics": false,
 }
 ```
 

--- a/source/ada/lsp-ada_contexts.adb
+++ b/source/ada/lsp-ada_contexts.adb
@@ -395,4 +395,24 @@ package body LSP.Ada_Contexts is
       return LSP.Types.To_LSP_String (Result);
    end URI_To_File;
 
+   -----------------------------
+   -- Set_Diagnostics_Enabled --
+   -----------------------------
+
+   procedure Set_Diagnostics_Enabled
+     (Self    : in out Context;
+      Enabled : Boolean) is
+   begin
+      Self.Diagnostics_Enabled := Enabled;
+   end Set_Diagnostics_Enabled;
+
+   -----------------------------
+   -- Get_Diagnostics_Enabled --
+   -----------------------------
+
+   function Get_Diagnostics_Enabled (Self : Context) return Boolean is
+   begin
+      return Self.Diagnostics_Enabled;
+   end Get_Diagnostics_Enabled;
+
 end LSP.Ada_Contexts;

--- a/source/ada/lsp-ada_contexts.ads
+++ b/source/ada/lsp-ada_contexts.ads
@@ -60,6 +60,14 @@ package LSP.Ada_Contexts is
    function Get_Charset (Self : in out Context) return String;
    --  Return the charset with which the context was initialized
 
+   procedure Set_Diagnostics_Enabled
+     (Self    : in out Context;
+      Enabled : Boolean);
+   --  Enable/Disable diagnostics; by default, diagnostics are enabled
+
+   function Get_Diagnostics_Enabled (Self : Context) return Boolean;
+   --  Return whether diagnostics are enabled
+
    procedure Reload (Self : in out Context);
    --  Reload the current context. This will invalidate and destroy any
    --  Libadalang related data, and recreate it from scratch.
@@ -125,6 +133,9 @@ private
       Charset        : Ada.Strings.Unbounded.Unbounded_String;
 
       Documents      : Document_Maps.Map;
+
+      Diagnostics_Enabled : Boolean := True;
+      --  Whether to publish diagnostics
    end record;
 
    procedure Find_Project_File

--- a/testsuite/ada_lsp/publish_diag/publish_diag_disabled.json
+++ b/testsuite/ada_lsp/publish_diag/publish_diag_disabled.json
@@ -1,0 +1,91 @@
+[
+    {
+        "comment":[
+            "This test checks diagnostics after editing a file"
+        ]
+    },  {
+        "start": {
+            "cmd": ["${ALS}"]
+        }
+    },  {
+        "send": {
+            "request": {"jsonrpc":"2.0","id":0,"method":"initialize","params":{
+                "processId":1,
+                "rootUri":"$URI{.}",
+                "capabilities":{}}
+            },
+            "wait":[{
+                "id": 0,
+                "result":{
+                    "capabilities":{
+                        "textDocumentSync":1
+                    }
+                }
+            }]
+        }
+    },  {
+        "send": {
+            "request": {
+                "jsonrpc":"2.0",
+                "method":"workspace/didChangeConfiguration",
+                "params":{
+                    "settings":
+                         {"ada": {"enableDiagnostics": false}
+                         }
+                    }
+            },
+            "wait":[]
+        }
+    },  {
+        "send": {
+            "request": {
+                "jsonrpc":"2.0",
+                "method":"textDocument/didOpen",
+                "params":{
+                    "textDocument": {
+                        "uri": "$URI{aaa.ads}",
+                        "languageId": "ada",
+                        "version": 1,
+                        "text": "package Aaa is\n   C : Character := '1';\nend;"
+                    }
+                }
+            },
+            "wait":[]
+        }
+    },  {
+        "send": {
+            "request": {
+                "jsonrpc":"2.0",
+                "method":"textDocument/didChange",
+                "params": {
+                    "textDocument":{
+                        "uri":"$URI{aaa.ads}",
+                        "version":2},
+                    "contentChanges":[{
+                        "text":"package Aaa is\n   C : Character := '1;\nend;"
+                    }]
+                }
+            },
+            "wait":[]
+        }
+    },  {
+        "send": {
+            "request": {
+                "jsonrpc":"2.0",
+                "id": "shutdown",
+                "method":"shutdown",
+                "params":null
+            },
+            "wait":[{ "id": "shutdown" }]
+        }
+    },  {
+        "send": {
+            "request": {"jsonrpc":"2.0", "method":"exit", "params":{}},
+            "wait":[]
+        }
+    }, {
+        "stop": {
+            "exit_code": 0
+        }
+    }
+]


### PR DESCRIPTION
And document this setting, along with defaultCharset,
in the README.md.

Add a test for deactivation of diagnostics.