### PR TITLE
S603-002 Add "result" property to Shutdown response.

### DIFF
--- a/source/protocol/lsp-messages.adb
+++ b/source/protocol/lsp-messages.adb
@@ -3135,6 +3135,8 @@ package body LSP.Messages is
    begin
       JS.Start_Object;
       Write_Response_Prexif (S, V);
+      JS.Key ("result");
+      JS.Write (GNATCOLL.JSON.JSON_Null);
       JS.End_Object;
    end Write_ResponseMessage;
 

--- a/testsuite/ada_lsp/0002-shutdown/0002-shutdown.json
+++ b/testsuite/ada_lsp/0002-shutdown/0002-shutdown.json
@@ -15,7 +15,7 @@
     },  {
         "send": {
             "request": {"jsonrpc":"2.0", "id": 1, "method":"shutdown", "params":null},
-            "wait":[{ "id": 1 }]
+            "wait":[{ "id": 1, "result": null }]
         }
     },  {
         "send": {

--- a/testsuite/ada_lsp/0003-get_symbols/0003-get_symbols.json
+++ b/testsuite/ada_lsp/0003-get_symbols/0003-get_symbols.json
@@ -95,7 +95,7 @@
                 "method":"shutdown",
                 "params":null
             },
-            "wait":[{ "id": "shutdown" }]
+            "wait":[{ "id": "shutdown", "result": null }]
         }
     },  {
         "send": {

--- a/testsuite/ada_lsp/S516-013.no_file/no_file.json
+++ b/testsuite/ada_lsp/S516-013.no_file/no_file.json
@@ -83,7 +83,7 @@
                 "method":"shutdown",
                 "params":null
             },
-            "wait":[{ "id": "shutdown" }]
+            "wait":[{ "id": "shutdown", "result": null }]
         }
     },  {
         "send": {

--- a/testsuite/ada_lsp/def_name/def_name.json
+++ b/testsuite/ada_lsp/def_name/def_name.json
@@ -120,7 +120,7 @@
                 "method":"shutdown",
                 "params":null
             },
-            "wait":[{ "id": "shutdown" }]
+            "wait":[{ "id": "shutdown", "result": null }]
         }
     },  {
         "send": {

--- a/testsuite/ada_lsp/def_name/uri_with_slash.json
+++ b/testsuite/ada_lsp/def_name/uri_with_slash.json
@@ -120,7 +120,7 @@
                 "method":"shutdown",
                 "params":null
             },
-            "wait":[{ "id": "shutdown" }]
+            "wait":[{ "id": "shutdown", "result": null }]
         }
     },  {
         "send": {

--- a/testsuite/ada_lsp/find_all_refs/find_all_refs.json
+++ b/testsuite/ada_lsp/find_all_refs/find_all_refs.json
@@ -122,7 +122,7 @@
                 "method":"shutdown",
                 "params":null
             },
-            "wait":[{ "id": "shutdown" }]
+            "wait":[{ "id": "shutdown", "result": null }]
         }
     },  {
         "send": {

--- a/testsuite/ada_lsp/find_all_refs_subp/find_all_refs_subp.json
+++ b/testsuite/ada_lsp/find_all_refs_subp/find_all_refs_subp.json
@@ -223,9 +223,9 @@
             "method": "shutdown"
          }, 
          "wait": [
-           
             {
-               "id": 2
+               "id": 2,
+               "result": null
             }
          ]
       }

--- a/testsuite/ada_lsp/no_root/no_root.json
+++ b/testsuite/ada_lsp/no_root/no_root.json
@@ -120,7 +120,7 @@
                 "method":"shutdown",
                 "params":null
             },
-            "wait":[{ "id": "shutdown" }]
+            "wait":[{ "id": "shutdown", "result": null }]
         }
     },  {
         "send": {

--- a/testsuite/ada_lsp/no_root/uri_with_slash.json
+++ b/testsuite/ada_lsp/no_root/uri_with_slash.json
@@ -120,7 +120,7 @@
                 "method":"shutdown",
                 "params":null
             },
-            "wait":[{ "id": "shutdown" }]
+            "wait":[{ "id": "shutdown", "result": null }]
         }
     },  {
         "send": {

--- a/testsuite/ada_lsp/project_config/project_config.json
+++ b/testsuite/ada_lsp/project_config/project_config.json
@@ -98,7 +98,7 @@
                 "method":"shutdown",
                 "params":null
             },
-            "wait":[{ "id": "shutdown" }]
+            "wait":[{ "id": "shutdown", "result": null }]
         }
     },  {
         "send": {

--- a/testsuite/ada_lsp/project_config/project_config_2.json
+++ b/testsuite/ada_lsp/project_config/project_config_2.json
@@ -98,7 +98,7 @@
                 "method":"shutdown",
                 "params":null
             },
-            "wait":[{ "id": "shutdown" }]
+            "wait":[{ "id": "shutdown", "result": null }]
         }
     },  {
         "send": {

--- a/testsuite/ada_lsp/project_search/project_search.json
+++ b/testsuite/ada_lsp/project_search/project_search.json
@@ -95,7 +95,7 @@
                 "method":"shutdown",
                 "params":null
             },
-            "wait":[{ "id": "shutdown" }]
+            "wait":[{ "id": "shutdown", "result": null }]
         }
     },  {
         "send": {

--- a/testsuite/ada_lsp/publish_diag/diag_on_open.json
+++ b/testsuite/ada_lsp/publish_diag/diag_on_open.json
@@ -93,7 +93,7 @@
                 "method":"shutdown",
                 "params":null
             },
-            "wait":[{ "id": "shutdown" }]
+            "wait":[{ "id": "shutdown", "result": null }]
         }
     },  {
         "send": {

--- a/testsuite/ada_lsp/publish_diag/publish_diag.json
+++ b/testsuite/ada_lsp/publish_diag/publish_diag.json
@@ -114,7 +114,7 @@
                 "method":"shutdown",
                 "params":null
             },
-            "wait":[{ "id": "shutdown" }]
+            "wait":[{ "id": "shutdown", "result": null }]
         }
     },  {
         "send": {

--- a/testsuite/ada_lsp/publish_diag/publish_diag_disabled.json
+++ b/testsuite/ada_lsp/publish_diag/publish_diag_disabled.json
@@ -76,7 +76,7 @@
                 "method":"shutdown",
                 "params":null
             },
-            "wait":[{ "id": "shutdown" }]
+            "wait":[{ "id": "shutdown", "result": null }]
         }
     },  {
         "send": {

--- a/testsuite/ada_lsp/publish_diag/test.yaml
+++ b/testsuite/ada_lsp/publish_diag/test.yaml
@@ -1,0 +1,1 @@
+title: 'publish_diag'

--- a/testsuite/ada_lsp/spec_from_body/spec_from_body.json
+++ b/testsuite/ada_lsp/spec_from_body/spec_from_body.json
@@ -210,7 +210,7 @@
                 "method":"shutdown",
                 "params":null
             },
-            "wait":[{ "id": "shutdown" }]
+            "wait":[{ "id": "shutdown", "result": null }]
         }
     },  {
         "send": {


### PR DESCRIPTION
According to JSON-RPC documentation this member is required on success.

Also add "result" properties to existing tests.