### PR TITLE
S603-029  implement "is called by" as a custom request

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -41,3 +41,7 @@ related resources.
 
 ## List of features
  * [Reference kinds](reference_kinds.md)
+
+ * `textDocument/ALS_called_by`: This request implements 'is called by',
+   returning the list of calls to a subprogram, organised by their
+   calling entity. See the ALS-specific section in `als-messages.ads`.

--- a/doc/README.md
+++ b/doc/README.md
@@ -42,6 +42,4 @@ related resources.
 ## List of features
  * [Reference kinds](reference_kinds.md)
 
- * `textDocument/ALS_called_by`: This request implements 'is called by',
-   returning the list of calls to a subprogram, organised by their
-   calling entity. See the ALS-specific section in `als-messages.ads`.
+ * [Called by][called_by.md]

--- a/doc/called_by.md
+++ b/doc/called_by.md
@@ -1,0 +1,35 @@
+# Reference kinds
+
+## Short introduction
+
+This implements the functionality 'is called by', allowing to query
+all the calls to a function, organized by the entities where these
+calls happen.
+
+## Change description
+
+We introduce a new type to represent the results:
+
+```typescript
+
+interface ALSSubprogramAndReferences {
+
+   loc: Location; /* The location of the entity containing the references */
+   name: string; /* The name of the entity containing the references */
+
+   refs: Location[];  /* The references contained in this entity */
+}
+```
+
+And a new request:
+
+  method: `textDocument/ALS_called_by`
+  params: `TextDocumentPositionParams`
+
+Returning the references to the method identified at the given position:
+
+  result: `ALSSubprogramAndReferences[]`
+
+We also introduce a new boolean field `ALS_calledbyProvider` in the
+interface `ServerCapabilities` indicating whether the server supports
+this extension.

--- a/doc/called_by.md
+++ b/doc/called_by.md
@@ -6,6 +6,11 @@ This implements the functionality 'is called by', allowing to query
 all the calls to a function, organized by the entities where these
 calls happen.
 
+## Capabilities
+
+The `initialize` request returns a boolean `alsCalledByProvider` as part of
+the `capabilities`, set to true if the server supports this functionality.
+
 ## Change description
 
 We introduce a new type to represent the results:

--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -314,7 +314,7 @@ REQUESTS = [
      'ExecuteCommandParams', 'ExecuteCommand_Response'),
 
     # ALS-specific requests
-    ('textDocument/ALS_called_by', 'ALS_Called_By', 'TextDocumentPositionParams',
+    ('textDocument/alsCalledBy', 'ALS_Called_By', 'TextDocumentPositionParams',
      'ALS_Called_By_Response'),
 ]
 # Names of requests in the form (protocol name, Ada name, parameter name,

--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -312,6 +312,10 @@ REQUESTS = [
      'Symbol_Response'),
     ('workspace/executeCommand', 'Workspace_Execute_Command',
      'ExecuteCommandParams', 'ExecuteCommand_Response'),
+
+    # ALS-specific requests
+    ('textDocument/ALS_called_by', 'ALS_Called_By', 'TextDocumentPositionParams',
+     'ALS_Called_By_Response'),
 ]
 # Names of requests in the form (protocol name, Ada name, parameter name,
 #   response name)

--- a/source/ada/lsp-ada_handlers.adb
+++ b/source/ada/lsp-ada_handlers.adb
@@ -113,6 +113,8 @@ package body LSP.Ada_Handlers is
           triggerCharacters => Empty_Vector & To_LSP_String (".")));
       Response.result.capabilities.hoverProvider := True;
 
+      Response.result.capabilities.ALS_calledbyProvider := True;
+
       if not LSP.Types.Is_Empty (Value.rootUri) then
          Root := Self.Context.URI_To_File (Value.rootUri);
       else

--- a/source/ada/lsp-ada_handlers.adb
+++ b/source/ada/lsp-ada_handlers.adb
@@ -113,7 +113,7 @@ package body LSP.Ada_Handlers is
           triggerCharacters => Empty_Vector & To_LSP_String (".")));
       Response.result.capabilities.hoverProvider := True;
 
-      Response.result.capabilities.ALS_calledbyProvider := True;
+      Response.result.capabilities.alsCalledByProvider := True;
 
       if not LSP.Types.Is_Empty (Value.rootUri) then
          Root := Self.Context.URI_To_File (Value.rootUri);

--- a/source/ada/lsp-ada_handlers.ads
+++ b/source/ada/lsp-ada_handlers.ads
@@ -124,6 +124,11 @@ private
       Value : LSP.Messages.ExecuteCommandParams)
       return LSP.Messages.ExecuteCommand_Response;
 
+   overriding function On_ALS_Called_By_Request
+     (Self  : access Message_Handler;
+      Value : LSP.Messages.TextDocumentPositionParams)
+      return LSP.Messages.ALS_Called_By_Response;
+
    overriding procedure On_Initialized_Notification
      (Self  : access Message_Handler) is null;
 

--- a/source/ada/lsp-lal_utils.adb
+++ b/source/ada/lsp-lal_utils.adb
@@ -19,6 +19,10 @@ with Libadalang.Common; use Libadalang.Common;
 
 package body LSP.Lal_Utils is
 
+   function Containing_Entity (Ref : Ada_Node) return Defining_Name;
+   --  Return the declaration of the subprogram or task that contains Ref.
+   --  Return No_Defining_Name if this fails.
+
    ----------------------
    -- Get_Node_As_Name --
    ----------------------
@@ -70,5 +74,133 @@ package body LSP.Lal_Utils is
          return Result;
       end if;
    end Resolve_Name;
+
+   -------------------------
+   -- Find_All_References --
+   -------------------------
+
+   function Find_All_References
+     (Definition         : Defining_Name;
+      Sources            : GNATCOLL.VFS.File_Array_Access;
+      Charset            : String;
+      Include_Definition : Boolean := False)
+         return Ada_Node_Array
+   is
+      Context : constant Analysis_Context := Definition.Unit.Context;
+      Source_Units : Analysis_Unit_Array (Sources'Range);
+   begin
+      for N in Sources'Range loop
+         Source_Units (N) := Context.Get_From_File
+           (Sources (N).Display_Full_Name,
+            Charset => Charset);
+      end loop;
+
+      declare
+         References : constant Ada_Node_Array :=
+           Definition.P_Find_All_References (Source_Units);
+      begin
+         if Include_Definition then
+            return References & (1 => Definition.As_Ada_Node);
+         else
+            return References;
+         end if;
+      end;
+   end Find_All_References;
+
+   -----------------------
+   -- Containing_Entity --
+   -----------------------
+
+   function Containing_Entity (Ref : Ada_Node) return Defining_Name is
+      Parents : constant Ada_Node_Array := Ref.Parents;
+   begin
+      for Parent of Parents loop
+         if Parent.Kind in Ada_Subp_Decl
+                         | Ada_Subp_Body
+                         | Ada_Task_Def
+                         | Ada_Task_Body
+                         | Ada_Package_Body
+                         | Ada_Package_Decl
+         then
+            return Parent.As_Basic_Decl.P_Canonical_Part.P_Defining_Name;
+         end if;
+      end loop;
+
+      return No_Defining_Name;
+   end Containing_Entity;
+
+   ------------------
+   -- Is_Called_By --
+   ------------------
+
+   function Is_Called_By
+     (Name_Node : Name;
+      Sources   : GNATCOLL.VFS.File_Array_Access;
+      Charset   : String)
+      return References_By_Subprogram.Map
+   is
+      use References_By_Subprogram;
+      use References_List;
+      Result     : Map;
+      Definition : Defining_Name;
+   begin
+      if Name_Node = No_Name then
+         return Result;
+      end if;
+
+      --  Attempt to resolve the name, return no results if we can't or if the
+      --  name does not resolve to a subprogram.
+      Definition := Resolve_Name (Name_Node);
+
+      if Definition = No_Defining_Name
+        or else Definition.P_Basic_Decl.Kind not in Ada_Subp_Decl
+      then
+         return Result;
+      end if;
+
+      --  Obtain all the references
+
+      declare
+         Refs : constant Ada_Node_Array := Find_All_References
+           (Definition, Sources, Charset, Include_Definition => False);
+         Containing : Defining_Name;
+      begin
+         --  Go through all references to Name, organising them by containing
+         --  subprogram.
+
+         for Ref of Refs loop
+            --  Only consider references that are calls.
+            --  ??? To be discussed: how do we want to handle an access to
+            --  a subprogram?
+            if Ref.As_Name.P_Is_Call then
+               --  We have a reference, and this a call: find the containing
+               --  subprogram or task
+               Containing := Containing_Entity (Ref);
+
+               if Containing /= No_Defining_Name then
+                  --  ??? Question: is it possible for the containing
+                  --  entity
+                  if Result.Contains (Containing) then
+                     declare
+                        L : List := Result.Element (Containing);
+                     begin
+                        L.Append (Ref);
+                        Result.Replace (Containing, L);
+                     end;
+                  else
+                     declare
+                        L : List;
+                     begin
+                        L.Append (Ref);
+                        Result.Insert (Containing, L);
+                     end;
+                  end if;
+               end if;
+            end if;
+         end loop;
+      end;
+      --  TODO: sort?
+      return Result;
+   end Is_Called_By;
 
 end LSP.Lal_Utils;

--- a/source/ada/lsp-lal_utils.adb
+++ b/source/ada/lsp-lal_utils.adb
@@ -178,8 +178,6 @@ package body LSP.Lal_Utils is
                Containing := Containing_Entity (Ref);
 
                if Containing /= No_Defining_Name then
-                  --  ??? Question: is it possible for the containing
-                  --  entity
                   if Result.Contains (Containing) then
                      declare
                         L : List := Result.Element (Containing);

--- a/source/ada/lsp-lal_utils.ads
+++ b/source/ada/lsp-lal_utils.ads
@@ -17,6 +17,11 @@
 --
 --  This package provides some Libadalang related utility subprograms.
 
+with Ada.Containers.Ordered_Maps;
+with Ada.Containers.Doubly_Linked_Lists;
+
+with GNATCOLL.VFS;
+
 with Libadalang.Analysis; use Libadalang.Analysis;
 
 package LSP.Lal_Utils is
@@ -26,5 +31,43 @@ package LSP.Lal_Utils is
    function Get_Name_As_Defining (Name_Node : Name) return Defining_Name;
 
    function Resolve_Name (Name_Node : Name) return Defining_Name;
+
+   function Find_All_References
+     (Definition         : Defining_Name;
+      Sources            : GNATCOLL.VFS.File_Array_Access;
+      Charset            : String;
+      Include_Definition : Boolean := False)
+         return Ada_Node_Array;
+   --  Finds all references to a given defining name in the given list
+   --  of units. Charset is the character set to use when loading
+   --  files from the disk.
+   --  If Include_Definition is True, include the definition as well.
+
+   ---------------
+   -- Called_By --
+   ---------------
+
+   package References_List is new Ada.Containers.Doubly_Linked_Lists
+     (Ada_Node);
+
+   function "<" (Left, Right : Defining_Name) return Boolean is
+      (Left.Text < Right.Text);
+
+   package References_By_Subprogram is new Ada.Containers.Ordered_Maps
+     (Key_Type     => Defining_Name,
+      Element_Type => References_List.List,
+      "<"          => "<",
+      "="          => References_List."=");
+
+   function Is_Called_By
+     (Name_Node : Name;
+      Sources   : GNATCOLL.VFS.File_Array_Access;
+      Charset   : String)
+      return References_By_Subprogram.Map;
+   --  Return the list of all the calls made to the subprogram pointed at by
+   --  the node given by Name, organized by the subprograms in which these
+   --  calls are listed, ordered by the name of these subprograms.
+   --  Sources is the list of sources to search in; Charset the encoding
+   --  with which to read files from disk.
 
 end LSP.Lal_Utils;

--- a/source/protocol/generated/lsp-messages-requests.adb
+++ b/source/protocol/generated/lsp-messages-requests.adb
@@ -200,6 +200,17 @@ package body LSP.Messages.Requests is
          end;
       end if;
 
+      if To_UTF_8_String (Method) = "textDocument/ALS_called_by" then
+         declare
+            R : ALS_Called_By_Request;
+         begin
+            Set_Common_Request_Fields (R, JS);
+            JS.Key ("params");
+            TextDocumentPositionParams'Read (JS'Access, R.params);
+            return R;
+         end;
+      end if;
+
       raise Program_Error; --  Request not found
    end Decode_Request;
 
@@ -393,6 +404,18 @@ package body LSP.Messages.Requests is
             R : LSP.Messages.ResponseMessage'Class :=
                Self.On_Workspace_Execute_Command_Request
                   (Workspace_Execute_Command_Request (Request).params);
+         begin
+            R.jsonrpc := +"2.0";
+            R.id := Request.id;
+            return R;
+         end;
+      end if;
+
+      if Request in ALS_Called_By_Request'Class then
+         declare
+            R : LSP.Messages.ResponseMessage'Class :=
+               Self.On_ALS_Called_By_Request
+                  (ALS_Called_By_Request (Request).params);
          begin
             R.jsonrpc := +"2.0";
             R.id := Request.id;
@@ -853,6 +876,34 @@ package body LSP.Messages.Requests is
       Write_Request_Prefix (S, V);
       JS.Key ("params");
       ExecuteCommandParams'Write (S, V.params);
+      JS.End_Object;
+   end Write;
+
+   procedure Read
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out ALS_Called_By_Request)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+   begin
+      JS.Start_Object;
+      Set_Common_Request_Fields (V, JS);
+      JS.Key ("params");
+      TextDocumentPositionParams'Read (S, V.params);
+      JS.End_Object;
+   end Read;
+
+   procedure Write
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : ALS_Called_By_Request)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+   begin
+      JS.Start_Object;
+      Write_Request_Prefix (S, V);
+      JS.Key ("params");
+      TextDocumentPositionParams'Write (S, V.params);
       JS.End_Object;
    end Write;
 

--- a/source/protocol/generated/lsp-messages-requests.adb
+++ b/source/protocol/generated/lsp-messages-requests.adb
@@ -200,7 +200,7 @@ package body LSP.Messages.Requests is
          end;
       end if;
 
-      if To_UTF_8_String (Method) = "textDocument/ALS_called_by" then
+      if To_UTF_8_String (Method) = "textDocument/alsCalledBy" then
          declare
             R : ALS_Called_By_Request;
          begin

--- a/source/protocol/generated/lsp-messages-requests.ads
+++ b/source/protocol/generated/lsp-messages-requests.ads
@@ -103,6 +103,11 @@ package LSP.Messages.Requests is
       params : ExecuteCommandParams;
    end record;
 
+   type ALS_Called_By_Request is new RequestMessage with
+   record
+      params : TextDocumentPositionParams;
+   end record;
+
    function On_Initialize_Request
      (Self  : access Server_Request_Handler;
       Value : LSP.Messages.InitializeParams)
@@ -181,6 +186,11 @@ package LSP.Messages.Requests is
      (Self  : access Server_Request_Handler;
       Value : LSP.Messages.ExecuteCommandParams)
       return LSP.Messages.ExecuteCommand_Response is abstract;
+
+   function On_ALS_Called_By_Request
+     (Self  : access Server_Request_Handler;
+      Value : LSP.Messages.TextDocumentPositionParams)
+      return LSP.Messages.ALS_Called_By_Response is abstract;
 
    procedure Handle_Error
      (Self  : access Server_Request_Handler) is null;
@@ -317,4 +327,12 @@ private
       V : Workspace_Execute_Command_Request);
    for Workspace_Execute_Command_Request'Read use Read;
    for Workspace_Execute_Command_Request'Write use Write;
+   procedure Read
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out ALS_Called_By_Request);
+   procedure Write
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : ALS_Called_By_Request);
+   for ALS_Called_By_Request'Read use Read;
+   for ALS_Called_By_Request'Write use Write;
 end LSP.Messages.Requests;

--- a/source/protocol/lsp-messages.adb
+++ b/source/protocol/lsp-messages.adb
@@ -1339,8 +1339,8 @@ package body LSP.Messages is
       JS.Key ("executeCommandProvider");
       ExecuteCommandOptions'Read (S, V.executeCommandProvider);
 
-      Read_Optional_Boolean (JS, +"ALS_calledbyProvider",
-                             V.ALS_calledbyProvider);
+      Read_Optional_Boolean (JS, +"alsCalledByProvider",
+                             V.alsCalledByProvider);
 
       JS.End_Object;
    end Read_ServerCapabilities;
@@ -3203,7 +3203,7 @@ package body LSP.Messages is
       ExecuteCommandOptions'Write (S, V.executeCommandProvider);
 
       Write_Optional_Boolean
-        (JS, +"ALS_calledbyProvider", V.ALS_calledbyProvider);
+        (JS, +"alsCalledByProvider", V.alsCalledByProvider);
 
       JS.End_Object;
    end Write_ServerCapabilities;

--- a/source/protocol/lsp-messages.adb
+++ b/source/protocol/lsp-messages.adb
@@ -1338,6 +1338,10 @@ package body LSP.Messages is
       DocumentLinkOptions'Read (S, V.documentLinkProvider);
       JS.Key ("executeCommandProvider");
       ExecuteCommandOptions'Read (S, V.executeCommandProvider);
+
+      Read_Optional_Boolean (JS, +"ALS_calledbyProvider",
+                             V.ALS_calledbyProvider);
+
       JS.End_Object;
    end Read_ServerCapabilities;
 
@@ -3197,6 +3201,10 @@ package body LSP.Messages is
       DocumentLinkOptions'Write (S, V.documentLinkProvider);
       JS.Key ("executeCommandProvider");
       ExecuteCommandOptions'Write (S, V.executeCommandProvider);
+
+      Write_Optional_Boolean
+        (JS, +"ALS_calledbyProvider", V.ALS_calledbyProvider);
+
       JS.End_Object;
    end Write_ServerCapabilities;
 

--- a/source/protocol/lsp-messages.adb
+++ b/source/protocol/lsp-messages.adb
@@ -3755,4 +3755,93 @@ package body LSP.Messages is
       JS.End_Object;
    end Write_WorkspaceSymbolParams;
 
+   ----------------------------------------
+   -- Read_ALS_Subprogram_And_References --
+   ----------------------------------------
+
+   procedure Read_ALS_Subprogram_And_References
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out ALS_Subprogram_And_References)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+   begin
+      JS.Start_Object;
+      JS.Key ("location");
+      Location'Read (S, V.loc);
+      Read_String (JS, +"name", V.name);
+      JS.Key ("refs");
+      Location_Vector'Read (S, V.refs);
+      JS.End_Object;
+   end Read_ALS_Subprogram_And_References;
+
+   -----------------------------------------
+   -- Write_ALS_Subprogram_And_References --
+   -----------------------------------------
+
+   procedure Write_ALS_Subprogram_And_References
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : ALS_Subprogram_And_References)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+   begin
+      JS.Start_Object;
+      JS.Key ("location");
+      Location'Write (S, V.loc);
+      Write_String (JS, +"name", V.name);
+      JS.Key ("refs");
+      Location_Vector'Write (S, V.refs);
+      JS.End_Object;
+   end Write_ALS_Subprogram_And_References;
+
+   -----------------------------------------------
+   -- Read_ALS_Subprogram_And_References_Vector --
+   -----------------------------------------------
+
+   procedure Read_ALS_Subprogram_And_References_Vector
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out ALS_Subprogram_And_References_Vector)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+   begin
+      V.Clear;
+      JS.Start_Array;
+
+      while not JS.End_Of_Array loop
+         declare
+            Item : ALS_Subprogram_And_References;
+         begin
+            ALS_Subprogram_And_References'Read (S, Item);
+            V.Append (Item);
+         end;
+      end loop;
+
+      JS.End_Array;
+   end Read_ALS_Subprogram_And_References_Vector;
+
+   ------------------------------------------------
+   -- Write_ALS_Subprogram_And_References_Vector --
+   ------------------------------------------------
+
+   procedure Write_ALS_Subprogram_And_References_Vector
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : ALS_Subprogram_And_References_Vector)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+   begin
+      if V.Is_Empty then
+         JS.Write (GNATCOLL.JSON.Create (GNATCOLL.JSON.Empty_Array));
+         return;
+      end if;
+
+      JS.Start_Array;
+      for Item of V loop
+         ALS_Subprogram_And_References'Write (S, Item);
+      end loop;
+      JS.End_Array;
+   end Write_ALS_Subprogram_And_References_Vector;
+
 end LSP.Messages;

--- a/source/protocol/lsp-messages.ads
+++ b/source/protocol/lsp-messages.ads
@@ -3444,6 +3444,56 @@ package LSP.Messages is
       T               => Location_Vector);
    subtype Location_Response is Location_Responses.Response;
 
+   -----------------------------------------
+   -- ALS-specific messages and responses --
+   -----------------------------------------
+
+   --  These define protocol extensions.
+   --  These are tagged with "ALS_" to avoid namespace clashes.
+
+   type ALS_Subprogram_And_References is record
+      --  Location and name of the defining subprogram
+      loc  : Location;
+      name : LSP_String;
+
+      --  The list of result locations within the defining subprogram
+      refs : Location_Vector;
+   end record;
+
+   procedure Read_ALS_Subprogram_And_References
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out ALS_Subprogram_And_References);
+   for ALS_Subprogram_And_References'Read use
+     Read_ALS_Subprogram_And_References;
+
+   procedure Write_ALS_Subprogram_And_References
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : ALS_Subprogram_And_References);
+   for ALS_Subprogram_And_References'Write use
+     Write_ALS_Subprogram_And_References;
+
+   package ALS_Subprogram_And_References_Vectors is new Ada.Containers.Vectors
+     (Positive, ALS_Subprogram_And_References);
+   type ALS_Subprogram_And_References_Vector is
+     new ALS_Subprogram_And_References_Vectors.Vector with null record;
+
+   procedure Read_ALS_Subprogram_And_References_Vector
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out ALS_Subprogram_And_References_Vector);
+   for ALS_Subprogram_And_References_Vector'Read use
+     Read_ALS_Subprogram_And_References_Vector;
+
+   procedure Write_ALS_Subprogram_And_References_Vector
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : ALS_Subprogram_And_References_Vector);
+   for ALS_Subprogram_And_References_Vector'Write use
+     Write_ALS_Subprogram_And_References_Vector;
+
+   package ALS_Called_By_Responses is new LSP.Generic_Responses
+     (ResponseMessage => ResponseMessage,
+      T               => ALS_Subprogram_And_References_Vector);
+   subtype ALS_Called_By_Response is ALS_Called_By_Responses.Response;
+
 private
 
    procedure Write_String

--- a/source/protocol/lsp-messages.ads
+++ b/source/protocol/lsp-messages.ads
@@ -1593,7 +1593,10 @@ package LSP.Messages is
       renameProvider: Optional_Boolean;
       documentLinkProvider: DocumentLinkOptions;
       executeCommandProvider: ExecuteCommandOptions;
-   --	experimental?: any;
+      --	experimental?: any;
+
+      --  ALS-specific capabilities
+      ALS_calledbyProvider : Optional_Boolean;
    end record;
 
    procedure Read_ServerCapabilities

--- a/source/protocol/lsp-messages.ads
+++ b/source/protocol/lsp-messages.ads
@@ -1596,7 +1596,7 @@ package LSP.Messages is
       --	experimental?: any;
 
       --  ALS-specific capabilities
-      ALS_calledbyProvider : Optional_Boolean;
+      alsCalledByProvider : Optional_Boolean;
    end record;
 
    procedure Read_ServerCapabilities

--- a/testsuite/ada_lsp/called_by/called_by.json
+++ b/testsuite/ada_lsp/called_by/called_by.json
@@ -41,7 +41,8 @@
                         ], 
                         "resolveProvider": false
                      }, 
-                     "definitionProvider": true
+                     "definitionProvider": true,
+                     "alsCalledByProvider": true
                   }
                }
             }]
@@ -115,7 +116,7 @@
             }, 
             "jsonrpc": "2.0", 
             "id": 2, 
-            "method": "textDocument/ALS_called_by"
+            "method": "textDocument/alsCalledBy"
          }, 
 
          "wait": [{"jsonrpc":"2.0","id":2,

--- a/testsuite/ada_lsp/called_by/called_by.json
+++ b/testsuite/ada_lsp/called_by/called_by.json
@@ -117,7 +117,6 @@
             "id": 2, 
             "method": "textDocument/ALS_called_by"
          }, 
-         "comment": "NOTE, we should not have a match in p.adb line 5, this is a LAL issue",
 
          "wait": [{"jsonrpc":"2.0","id":2,
                    "result":[
@@ -132,8 +131,7 @@
                           {"uri":"$URI{p.ads}",
                            "range":{"start":{"line":1,"character":12},"end":{"line":1,"character":15}}},
                            "name":"Foo",
-                           "refs":[{"uri":"$URI{p.adb}","range":{"start":{"line":3,"character":13},"end":{"line":3,"character":16}}},
-                                   {"uri":"$URI{p.adb}","range":{"start":{"line":4,"character":7},"end":{"line":4,"character":10}}}]},
+                           "refs":[{"uri":"$URI{p.adb}","range":{"start":{"line":3,"character":13},"end":{"line":3,"character":16}}}]},
                       {"location":
                           {"uri":"$URI{main.adb}","range":{"start":{"line":1,"character":10},"end":{"line":1,"character":14}}},
                            "name":"Main",

--- a/testsuite/ada_lsp/called_by/called_by.json
+++ b/testsuite/ada_lsp/called_by/called_by.json
@@ -1,0 +1,181 @@
+[
+   {
+      "comment": [
+         "test automatically generated"
+      ]
+   }, 
+   {
+      "start": {
+         "cmd": [
+            "${ALS}"
+         ]
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "processId": 13950, 
+               "capabilities": {
+                  "workspace": {
+                     "applyEdit": false
+                  }
+               }, 
+               "rootUri": "$URI{.}"
+            }, 
+            "jsonrpc": "2.0", 
+            "id": 1, 
+            "method": "initialize"
+         }, 
+         "wait": [{
+               "id": 1, 
+               "result": {
+                  "capabilities": {
+                     "hoverProvider": true, 
+                     "documentSymbolProvider": true, 
+                     "referencesProvider": true, 
+                     "textDocumentSync": 1, 
+                     "completionProvider": {
+                        "triggerCharacters": [
+                           "."
+                        ], 
+                        "resolveProvider": false
+                     }, 
+                     "definitionProvider": true
+                  }
+               }
+            }]
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0", 
+            "method": "initialized"
+         }, 
+         "wait": []
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "settings": {
+                  "ada": {
+                     "projectFile": "p.gpr", 
+                     "scenarioVariables": {}, 
+                     "defaultCharset": "ISO-8859-1"
+                  }
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "method": "workspace/didChangeConfiguration"
+         }, 
+         "wait": []
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "text": "with P; use P;\nprocedure Main is\n   function Exprfinmain return Boolean is (Foo = 43);\nbegin\n   if Foo > 10 then\n      raise Constraint_Error;\n   end if;\n\n   declare\n      package Bla is\n         X : Integer := Foo;\n      end Bla;\n\n      package body Bla is\n         Y : Integer := Foo + 2;\n      begin\n         X := Foo + 3;\n      end Bla;\n   begin\n      null;\n   end;\nend Main;\n", 
+                  "version": 0, 
+                  "uri": "$URI{main.adb}", 
+                  "languageId": "Ada"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "method": "textDocument/didOpen"
+         }, 
+         "wait": [
+            {
+               "params": {
+                  "uri": "$URI{main.adb}", 
+                  "diagnostics": []
+               }, 
+               "method": "textDocument/publishDiagnostics"
+            }]
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "position": {
+                  "line": 2, 
+                  "character": 45
+               }, 
+               "textDocument": {
+                  "uri": "$URI{main.adb}"
+               }, 
+               "context": {
+                  "includeDeclaration": true
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "id": 2, 
+            "method": "textDocument/ALS_called_by"
+         }, 
+         "comment": "NOTE, we should not have a match in p.adb line 5, this is a LAL issue",
+
+         "wait": [{"jsonrpc":"2.0","id":2,
+                   "result":[
+                      {"location":
+                          {"uri":"$URI{main.adb}",
+                           "range":{"start":{"line":9,"character":14},"end":{"line":9,"character":17}}},
+                           "name":"Bla",
+                           "refs":[{"uri":"$URI{main.adb}","range":{"start":{"line":10,"character":24},"end":{"line":10,"character":27}}},
+                                   {"uri":"$URI{main.adb}","range":{"start":{"line":14,"character":24},"end":{"line":14,"character":27}}},
+                                   {"uri":"$URI{main.adb}","range":{"start":{"line":16,"character":14},"end":{"line":16,"character":17}}}]},
+                      {"location":
+                          {"uri":"$URI{p.ads}",
+                           "range":{"start":{"line":1,"character":12},"end":{"line":1,"character":15}}},
+                           "name":"Foo",
+                           "refs":[{"uri":"$URI{p.adb}","range":{"start":{"line":3,"character":13},"end":{"line":3,"character":16}}},
+                                   {"uri":"$URI{p.adb}","range":{"start":{"line":4,"character":7},"end":{"line":4,"character":10}}}]},
+                      {"location":
+                          {"uri":"$URI{main.adb}","range":{"start":{"line":1,"character":10},"end":{"line":1,"character":14}}},
+                           "name":"Main",
+                           "refs":[{"uri":"$URI{main.adb}","range":{"start":{"line":2,"character":43},"end":{"line":2,"character":46}}},
+                                   {"uri":"$URI{main.adb}","range":{"start":{"line":4,"character":6},"end":{"line":4,"character":9}}}]},
+                      {"location":
+                          {"uri":"$URI{p.ads}","range":{"start":{"line":0,"character":8},"end":{"line":0,"character":9}}},
+                           "name":"P",
+                           "refs":[{"uri":"$URI{p.ads}","range":{"start":{"line":2,"character":37},"end":{"line":2,"character":40}}},
+                                   {"uri":"$URI{p.ads}","range":{"start":{"line":3,"character":43},"end":{"line":3,"character":46}}}]},
+                      {"location":
+                           {"uri":"$URI{p.adb}","range":{"start":{"line":7,"character":13},"end":{"line":7,"character":14}}},
+                           "name":"T",
+                           "refs":[{"uri":"$URI{p.adb}","range":{"start":{"line":10,"character":11},"end":{"line":10,"character":14}}}]}]}]
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{main.adb}"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "method": "textDocument/didClose"
+         }, 
+         "wait": [
+            {
+            "jsonrpc": "2.0", 
+               "params": {
+                  "uri": "$URI{main.adb}", 
+                  "diagnostics": []
+               }, 
+               "method": "textDocument/publishDiagnostics"
+            }
+         ]
+      }
+   }, 
+   {
+      "stop": {
+         "exit_code": 0
+      }
+   }
+]

--- a/testsuite/ada_lsp/called_by/main.adb
+++ b/testsuite/ada_lsp/called_by/main.adb
@@ -1,0 +1,22 @@
+with P; use P;
+procedure Main is
+   function Exprfinmain return Boolean is (Foo = 43);
+begin
+   if Foo > 10 then
+      raise Constraint_Error;
+   end if;
+
+   declare
+      package Bla is
+         X : Integer := Foo;
+      end Bla;
+
+      package body Bla is
+         Y : Integer := Foo + 2;
+      begin
+         X := Foo + 3;
+      end Bla;
+   begin
+      null;
+   end;
+end Main;

--- a/testsuite/ada_lsp/called_by/p.adb
+++ b/testsuite/ada_lsp/called_by/p.adb
@@ -1,0 +1,13 @@
+package body P is
+   function Foo return Integer is
+   begin
+      return Foo + 1;
+   end Foo;
+
+   task T;
+   task body T is
+      X : Integer;
+   begin
+      X := Foo + 1;
+   end T;
+end P;

--- a/testsuite/ada_lsp/called_by/p.ads
+++ b/testsuite/ada_lsp/called_by/p.ads
@@ -1,0 +1,5 @@
+package P is
+   function Foo return Integer;
+   function Exprf return Boolean is (Foo = 42);
+   procedure Look_My_Param (X : Integer := Foo) is null;
+end P;

--- a/testsuite/ada_lsp/called_by/p.gpr
+++ b/testsuite/ada_lsp/called_by/p.gpr
@@ -1,0 +1,2 @@
+project p is
+end p;


### PR DESCRIPTION
Introduce a custom request "textDocument/ALS_called_by".

Add a subprogram in LSP.LAL_Utils to implement the functionality,
add support for marshalling/unmarshalling the response to the
JSON stream, and add support for serving this request in the LSP
server.

Move the utility function Find_All_References to LSP.LAL_Utils.

Add a test for the 'called_by' functionality.