### PR TITLE
S607-007 Don't send "result" on errors

### DIFF
--- a/source/protocol/lsp-messages.adb
+++ b/source/protocol/lsp-messages.adb
@@ -3135,8 +3135,12 @@ package body LSP.Messages is
    begin
       JS.Start_Object;
       Write_Response_Prexif (S, V);
-      JS.Key ("result");
-      JS.Write (GNATCOLL.JSON.JSON_Null);
+
+      if not V.Is_Error then
+         JS.Key ("result");
+         JS.Write (GNATCOLL.JSON.JSON_Null);
+      end if;
+
       JS.End_Object;
    end Write_ResponseMessage;
 

--- a/source/tester/tester-tests.adb
+++ b/source/tester/tester-tests.adb
@@ -254,12 +254,21 @@ package body Tester.Tests is
            (Name  : String;
             Value : GNATCOLL.JSON.JSON_Value) is
          begin
-            if Success and Left.Has_Field (Name) then
+            if Success
+              and then Value.Kind = GNATCOLL.JSON.JSON_String_Type
+              and then String'(GNATCOLL.JSON.Get (Value)) = "<ABSENT>"
+            then
+
+               Success := not Left.Has_Field (Name);
+
+            elsif Success and Left.Has_Field (Name) then
+
                declare
                   Prop : constant GNATCOLL.JSON.JSON_Value := Left.Get (Name);
                begin
                   Success := Match (Prop, Value);
                end;
+
             else
                Success := False;
             end if;

--- a/testsuite/ada_lsp/README.md
+++ b/testsuite/ada_lsp/README.md
@@ -25,7 +25,7 @@ Here is list of supported commands.
 ### Command `start`
 
 Property value - an object:
- "cmd" - array of string.
+ * "cmd" - array of string.
 
 Start new LSP server using _cmd_ as command line.
 
@@ -43,15 +43,21 @@ Property value - an object:
 
  * "request" - JSON object to send to LSP server as request.
  * "wait" - array of _wait_ objects to expect them in any order.
+ * "sortReply" - an object with properies. Each property has string value of
+a _key_. The property name points to a property in the server reply to
+be sorted; it should be JSON array of object. While _key_ is property name
+in the array item to compare.
 
-Where _wait_ object is expected server answer. Each propert of this object
-should be in server response.
+Where _wait_ object is expected server answer. Each property of this object
+should be in server response, but some string values have a special meaning:
+ * `<ANY>`  - matches any string value
+ * `<ABSENT>` - ensures than there is no such property at all
 
 ### Command `comment`
 
-Property value - array of string.
+Property value - array of string or just string.
 
-Tester just ignore this command. We use it to add test desription and other
+Tester just ignores this command. We use it to add test desription and other
 comments to JSON test script.
 
 

--- a/testsuite/ada_lsp/S510-020.exceptions_reporting/test.json
+++ b/testsuite/ada_lsp/S510-020.exceptions_reporting/test.json
@@ -41,7 +41,15 @@
                 }
             },
             "comment": " -- we expect an exception here, code -32603",
-            "wait":[{"jsonrpc":"2.0", "error": {"code":-32603,"message":"<ANY>"}}]
+            "wait":[{
+                "jsonrpc": "2.0",
+                "id": "references-1",
+                "result": "<ABSENT>",
+                "error": {
+                    "code":-32603,
+                    "message":"<ANY>"
+                }
+            }]
         }
     },
 


### PR DESCRIPTION
 * lsp-messages.adb: Check Is_Error explicitly

 * lsp-servers.adb: Move exception handlers into
Process_Message_From_Stream. Send error responses only on
requests. Drop reading result from client's responses for now.
Add an extra enclosing block to separate decoding exceptions
and report errors with InvalidParams code.

 * tester-tests.adb: Add a special value "<ABSENT>" to allow
tester check extra properties in server reponses.

 * testsuite/ada_lsp/README.md: improve tester documentation.

 * S510-020.exceptions_reporting/test.json: Fix testcase.