### PR TITLE
S329-013 Send alsKind in textDocument/references responses.

### DIFF
--- a/doc/reference_kinds.md
+++ b/doc/reference_kinds.md
@@ -4,7 +4,7 @@
 
 This feature allows the LSP server to provide reference kinds in
 results for the `textDocument/references` request. A reference can
-be 'read', 'write', 'call', etc.
+be 'write', 'static call', 'dispatching call', etc.
 
 ## Change description
 
@@ -13,18 +13,18 @@ extra field to the `Location` type:
 
 ```typescript
 
-export type AlsReferenceKind = 'read' | 'write' | 'call';
+export type AlsReferenceKind = 'w' | 'c' | 'd';
 
 export namespace AlsReferenceKind {
-   export const Read  : AlsReferenceKind = 'read';
-   export const Write : AlsReferenceKind = 'write';
-   export const Call  : AlsReferenceKind = 'call';
+   export const Write            : AlsReferenceKind = 'w';
+   export const Static_Call      : AlsReferenceKind = 'c';
+   export const Dispatching_Call : AlsReferenceKind = 'd';
 }
 
 interface Location {
 	uri: DocumentUri;
 	range: Range;
-        AlsKind?: AlsReferenceKind;
+        alsKind?: AlsReferenceKind[];
 }
 ```
 

--- a/source/ada/lsp-ada_documents.adb
+++ b/source/ada/lsp-ada_documents.adb
@@ -140,8 +140,9 @@ package body LSP.Ada_Documents is
          Item.name := To_LSP_String (Element.Text);
          Item.kind := Get_Decl_Kind (Element.As_Defining_Name.P_Basic_Decl);
          Item.location :=
-           (uri  => Self.URI,
-            span => To_Span (Element.Sloc_Range));
+           (uri     => Self.URI,
+            span    => To_Span (Element.Sloc_Range),
+            alsKind => LSP.Messages.Empty_Set);
 
          Result.Append (Item);
       end loop;

--- a/source/protocol/lsp-messages.ads
+++ b/source/protocol/lsp-messages.ads
@@ -289,15 +289,41 @@ package LSP.Messages is
    package Optional_Spans is new LSP.Generic_Optional (Span);
    type Optional_Span is new Optional_Spans.Optional_Type;
 
+   --  reference_kinds ALS extension:
+   --
+   --  export type AlsReferenceKind = 'w' | 'c' | 'd';
+   --
+   --  export namespace AlsReferenceKind {
+   --     export const Write            : AlsReferenceKind = 'w';
+   --     export const Static_Call      : AlsReferenceKind = 'c';
+   --     export const Dispatching_Call : AlsReferenceKind = 'd';
+   --  }
+
+   type AlsReferenceKind is (Write, Static_Call, Dispatching_Call);
+   type AlsReferenceKind_Set is array (AlsReferenceKind) of Boolean;
+   function Empty_Set return AlsReferenceKind_Set is
+      (AlsReferenceKind => False);
+
+   procedure Read_AlsReferenceKind_Set
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out AlsReferenceKind_Set);
+   procedure Write_AlsReferenceKind_Set
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : AlsReferenceKind_Set);
+   for AlsReferenceKind_Set'Read use Read_AlsReferenceKind_Set;
+   for AlsReferenceKind_Set'Write use Write_AlsReferenceKind_Set;
+
    --```typescript
    --interface Location {
    --	uri: DocumentUri;
    --	range: Range;
+   --   AlsKind?: AlsReferenceKind[];
    --}
    --```
    type Location is record
       uri: DocumentUri;
       span: LSP.Messages.Span;  --  range: is reserved word
+      alsKind : AlsReferenceKind_Set := Empty_Set;
    end record;
 
    procedure Read_Location

--- a/testsuite/ada_lsp/find_all_refs/find_all_refs.json
+++ b/testsuite/ada_lsp/find_all_refs/find_all_refs.json
@@ -86,7 +86,8 @@
                             "line": 1,
                             "character": 13
                         }
-                    }
+                    },
+                    "alsKind": "<ABSENT>"
                 }, {
                     "uri": "$URI{bbb.adb}",
                     "range": {
@@ -98,7 +99,8 @@
                             "line": 3,
                             "character": 23
                         }
-                    }
+                    },
+                    "alsKind": ["c"]
                 }, {
                     "uri": "$URI{ccc.adb}",
                     "range": {
@@ -110,7 +112,8 @@
                             "line": 2,
                             "character": 23
                         }
-                    }
+                    },
+                    "alsKind": ["c"]
                 }]
             }]
         }

--- a/testsuite/ada_lsp/find_all_refs_kinds/aaa.adb
+++ b/testsuite/ada_lsp/find_all_refs_kinds/aaa.adb
@@ -1,0 +1,9 @@
+with Ada.Streams;
+
+procedure Aaa (Stream : not null access Ada.Streams.Root_Stream_Type'Class) is
+    Local : Ada.Streams.Stream_Element_Array (1 .. 5);
+    Last : Ada.Streams.Stream_Element_Count;
+begin
+    Ada.Streams.Read (Stream.all, Local, Last);
+    Aaa (Stream);
+end Aaa;

--- a/testsuite/ada_lsp/find_all_refs_kinds/find_all_refs_kinds.json
+++ b/testsuite/ada_lsp/find_all_refs_kinds/find_all_refs_kinds.json
@@ -1,0 +1,209 @@
+[
+    {
+        "comment":[
+            "This test checks 'c','d','w' kinds in find all references"
+        ]
+    },  {
+        "start": {
+            "cmd": ["${ALS}"]
+        }
+    },  {
+        "send": {
+            "request": {"jsonrpc":"2.0","id":0,"method":"initialize","params":{
+                "processId":1,
+                "rootUri":"$URI{.}",
+                "capabilities":{}}
+            },
+            "wait":[{
+                "id": 0,
+                "result":{
+                    "capabilities":{
+                        "textDocumentSync":1,
+                        "referencesProvider":true
+                    }
+                }
+            }]
+        }
+    },  {
+        "send": {
+            "request": {
+                "jsonrpc":"2.0",
+                "method":"workspace/didChangeConfiguration",
+                "params":{
+                    "settings":{
+                            "projectFile": ""
+                    }
+                }
+            },
+            "wait":[]
+        }
+    },  {
+        "send": {
+            "request": {
+                "jsonrpc":"2.0",
+                "method":"textDocument/didOpen",
+                "params":{
+                    "textDocument": {
+                        "uri": "$URI{aaa.adb}",
+                        "languageId": "ada",
+                        "version": 1,
+                        "text": "with Ada.Streams;\n\nprocedure Aaa (Stream : not null access Ada.Streams.Root_Stream_Type'Class) is\n    Local : Ada.Streams.Stream_Element_Array (1 .. 5);\n    Last : Ada.Streams.Stream_Element_Count;\nbegin\n    Ada.Streams.Read (Stream.all, Local, Last);\n    Aaa (Stream);\nend Aaa;"
+                    }
+                }
+            },
+            "wait":[{
+                "jsonrpc": "2.0",
+                "method": "textDocument/publishDiagnostics",
+                "params": {
+                    "uri": "$URI{aaa.adb}",
+                    "diagnostics":[]
+                }
+            }]
+        }
+    },  {
+        "send": {
+            "request": {
+                "jsonrpc":"2.0",
+                "id":"references-1",
+                "method":"textDocument/references",
+                "params":{
+                    "textDocument": {
+                        "uri": "$URI{aaa.adb}"
+                    },
+                    "position": {
+                        "line": 6,
+                        "character": 18
+                    },
+                    "context": {
+                        "includeDeclaration":false
+                    }
+                }
+            },
+            "sortReply": { "result": "uri" },
+            "wait":[{
+                "id": "references-1",
+                "result":[{
+                    "uri": "$URI{aaa.adb}",
+                    "range": {
+                        "start": {
+                            "line": 6,
+                            "character": 16
+                        },
+                        "end": {
+                            "line": 6,
+                            "character": 20
+                        }
+                    },
+                    "alsKind": ["d"]
+                }]
+            }]
+        }
+    },  {
+        "send": {
+            "request": {
+                "jsonrpc":"2.0",
+                "id":"references-2",
+                "method":"textDocument/references",
+                "params":{
+                    "textDocument": {
+                        "uri": "$URI{aaa.adb}"
+                    },
+                    "position": {
+                        "line": 7,
+                        "character": 6
+                    },
+                    "context": {
+                        "includeDeclaration":false
+                    }
+                }
+            },
+            "sortReply": { "result": "uri" },
+            "wait":[{
+                "id": "references-2",
+                "result":[{
+                    "uri": "$URI{aaa.adb}",
+                    "range": {
+                        "start": {
+                            "line": 7,
+                            "character": 4
+                        },
+                        "end": {
+                            "line": 7,
+                            "character": 7
+                        }
+                    },
+                    "alsKind": ["c"]
+                }, {
+                    "uri": "$URI{aaa.adb}",
+                    "range": {
+                        "start": {
+                            "line": 8,
+                            "character": 4
+                        },
+                        "end": {
+                            "line": 8,
+                            "character": 7
+                        }
+                    }
+                }]
+            }]
+        }
+    },  {
+        "send": {
+            "request": {
+                "jsonrpc":"2.0",
+                "id":"references-3",
+                "method":"textDocument/references",
+                "params":{
+                    "textDocument": {
+                        "uri": "$URI{aaa.adb}"
+                    },
+                    "position": {
+                        "line": 3,
+                        "character": 7
+                    },
+                    "context": {
+                        "includeDeclaration":false
+                    }
+                }
+            },
+            "sortReply": { "result": "uri" },
+            "wait":[{
+                "id": "references-3",
+                "result":[{
+                    "uri": "$URI{aaa.adb}",
+                    "range": {
+                        "start": {
+                            "line": 6,
+                            "character": 34
+                        },
+                        "end": {
+                            "line": 6,
+                            "character": 39
+                        }
+                    },
+                    "alsKind": ["w"]
+                }]
+            }]
+        }
+    },  {
+        "send": {
+            "request": {
+                "jsonrpc":"2.0",
+                "id": "shutdown",
+                "method":"shutdown",
+                "params":null
+            },
+            "wait":[{ "id": "shutdown", "result": null }]
+        }
+    },  {
+        "send": {
+            "request": {"jsonrpc":"2.0", "method":"exit", "params":{}},
+            "wait":[]
+        }
+    }, {
+        "stop": {
+            "exit_code": 0
+        }
+    }
+]

--- a/testsuite/ada_lsp/find_all_refs_kinds/p.gpr
+++ b/testsuite/ada_lsp/find_all_refs_kinds/p.gpr
@@ -1,0 +1,2 @@
+project p is
+end p;

--- a/testsuite/ada_lsp/find_all_refs_kinds/test.yaml
+++ b/testsuite/ada_lsp/find_all_refs_kinds/test.yaml
@@ -1,0 +1,1 @@
+title: 'find_all_refs_kinds'

--- a/testsuite/ada_lsp/find_all_refs_subp/find_all_refs_subp.json
+++ b/testsuite/ada_lsp/find_all_refs_subp/find_all_refs_subp.json
@@ -182,7 +182,8 @@
                            "character": 6
                         }
                      }, 
-                     "uri": "$URI{main.adb}"
+                     "uri": "$URI{main.adb}",
+                     "alsKind": ["c"]
                   }, 
                   {
                      "range": {
@@ -195,7 +196,8 @@
                            "character": 6
                         }
                      }, 
-                     "uri": "$URI{subsrc/other_main.adb}"
+                     "uri": "$URI{subsrc/other_main.adb}",
+                     "alsKind": ["c"]
                   }, 
                   {
                      "range": {
@@ -208,7 +210,8 @@
                            "character": 16
                         }
                      }, 
-                     "uri": "$URI{subsrc/p.ads}"
+                     "uri": "$URI{subsrc/p.ads}",
+                     "alsKind": "<ABSENT>"
                   }
                ]
             }]


### PR DESCRIPTION
Add an extension to LSP to return reference kinds in
responses to textDocument/references.