### PR TITLE
S625-031 Fix an empty response to textDocument/rename

### DIFF
--- a/source/protocol/lsp-messages.adb
+++ b/source/protocol/lsp-messages.adb
@@ -3837,18 +3837,25 @@ package body LSP.Messages is
       JS.Start_Object;
       if V.documentChanges.Is_Empty then
          JS.Key ("changes");
-         JS.Start_Object;
-         for Cursor in V.changes.Iterate loop
-            JS.Key
-              (Ada.Strings.Wide_Unbounded.Unbounded_Wide_String
-                 (TextDocumentEdit_Maps.Key (Cursor)));
-            JS.Start_Array;
-            for Edit of V.changes (Cursor) loop
-               TextEdit'Write (S, Edit);
+
+         if V.changes.Is_Empty then
+            --  Special case for an empty result: return 'changes:{}'
+            --  Without it JSON_Stream optimizes result to nothing.
+            JS.Write (GNATCOLL.JSON.Create_Object);
+         else
+            JS.Start_Object;
+            for Cursor in V.changes.Iterate loop
+               JS.Key
+                 (Ada.Strings.Wide_Unbounded.Unbounded_Wide_String
+                    (TextDocumentEdit_Maps.Key (Cursor)));
+               JS.Start_Array;
+               for Edit of V.changes (Cursor) loop
+                  TextEdit'Write (S, Edit);
+               end loop;
+               JS.End_Array;
             end loop;
-            JS.End_Array;
-         end loop;
-         JS.End_Object;
+            JS.End_Object;
+         end if;
       else
          JS.Key ("documentChanges");
          TextDocumentEdit_Vector'Write (S, V.documentChanges);

--- a/testsuite/ada_lsp/rename/rename.json
+++ b/testsuite/ada_lsp/rename/rename.json
@@ -125,6 +125,31 @@
         "send": {
             "request": {
                 "jsonrpc":"2.0",
+                "id":"rename-2",
+                "method":"textDocument/rename",
+                "params":{
+                    "textDocument": {
+                        "uri": "$URI{aaa.ads}"
+                    },
+                    "position": {
+                        "line": 0,
+                        "character": 1
+                    },
+                    "newName":"ZZ"
+                }
+            },
+            "wait":[{
+                "id": "rename-2",
+                "result":{
+                    "changes":{
+                    }
+                }
+            }]
+        }
+    },  {
+        "send": {
+            "request": {
+                "jsonrpc":"2.0",
                 "id": "shutdown",
                 "method":"shutdown",
                 "params":null


### PR DESCRIPTION
Before this patch ALS doesn't send 'result:' property at all.