### PR TITLE
Consistently use short-circuit boolean operators

### DIFF
--- a/source/ada/lsp-lal_utils.adb
+++ b/source/ada/lsp-lal_utils.adb
@@ -65,7 +65,7 @@ package body LSP.Lal_Utils is
         Name_Node.P_Xref
           (Imprecise_Fallback => Name_Node.Unit.Has_Diagnostics);
    begin
-      if Name_Node.P_Is_Defining and Result = No_Defining_Name then
+      if Name_Node.P_Is_Defining and then Result = No_Defining_Name then
          --  When Name_Node is part of defining_name and it isn't a completion
          --  of another declaration, then P_Xref returns No_Defining_Name.
          --  In this case we return current defining_name.

--- a/source/client/lsp-raw_clients.adb
+++ b/source/client/lsp-raw_clients.adb
@@ -33,7 +33,7 @@ package body LSP.Raw_Clients is
 
    function Can_Send_Message (Self : Raw_Client'Class) return Boolean is
    begin
-      return Self.Is_Server_Running and Self.Standard_Input_Available;
+      return Self.Is_Server_Running and then Self.Standard_Input_Available;
    end Can_Send_Message;
 
    --------------------

--- a/source/protocol/lsp-messages.adb
+++ b/source/protocol/lsp-messages.adb
@@ -3234,7 +3234,7 @@ package body LSP.Messages is
       JS.Write (GNATCOLL.JSON.Create (Error_Map (V.code)));
       Write_String (JS, +"message", V.message);
 
-      if not V.data.Is_Empty and not V.data.Is_Empty then
+      if not V.data.Is_Empty and then not V.data.Is_Empty then
          JS.Key ("data");
          JS.Write (V.data);
       end if;

--- a/source/server/lsp-servers.adb
+++ b/source/server/lsp-servers.adb
@@ -101,7 +101,7 @@ package body LSP.Servers is
       --  Wait here until all the requests have been consumed, and all the
       --  outputs have been flushed.
       while Self.Requests_Queue.Current_Use > 0
-        or Self.Output_Queue.Current_Use > 0
+        or else Self.Output_Queue.Current_Use > 0
       loop
          delay 0.1;
       end loop;

--- a/source/spawn/spawn-environments-initialize_default__windows.adb
+++ b/source/spawn/spawn-environments-initialize_default__windows.adb
@@ -60,7 +60,7 @@ begin
             exit when Index = From;
             Append (Env (From .. Equal - 1), Env (Equal + 1 .. Index - 1));
             From := Index + 1;
-         elsif Index /= From and Env (Index) = '=' then
+         elsif Index /= From and then Env (Index) = '=' then
             Equal := Index;
          end if;
 

--- a/source/spawn/spawn-environments-search_in_path__windows.adb
+++ b/source/spawn/spawn-environments-search_in_path__windows.adb
@@ -47,7 +47,7 @@ is
         lpBuffer      => Buffer (Buffer'First)'Unchecked_Access,
         lpFilePart    => null);
 begin
-   if Length = 0 or Length > Buffer'Length then
+   if Length = 0 or else Length > Buffer'Length then
 
       return "";
    else

--- a/source/spawn/spawn-processes-windows.adb
+++ b/source/spawn/spawn-processes-windows.adb
@@ -415,7 +415,7 @@ package body Spawn.Processes.Windows is
    begin
       if dwErrorCode /= 0 then
          if not (Self.Status = Not_Running
-                 and dwErrorCode = Windows_API.ERROR_OPERATION_ABORTED)
+                 and then dwErrorCode = Windows_API.ERROR_OPERATION_ABORTED)
          then
             Self.Listener.Error_Occurred (Integer (dwErrorCode));
          end if;

--- a/source/tester/tester-tests.adb
+++ b/source/tester/tester-tests.adb
@@ -261,7 +261,7 @@ package body Tester.Tests is
 
                Success := not Left.Has_Field (Name);
 
-            elsif Success and Left.Has_Field (Name) then
+            elsif Success and then Left.Has_Field (Name) then
 
                declare
                   Prop : constant GNATCOLL.JSON.JSON_Value := Left.Get (Name);

--- a/source/uri/uris.adb
+++ b/source/uri/uris.adb
@@ -61,17 +61,17 @@ package body URIs is
             --  in more recent versions, this raises Use_Error.
             --  Add an explicit test here to support both versions.
               and then
-                not (Root = "" and
+                not (Root = "" and then
                        (Name = "/"
-                        or (Name'Length = 3 and then
-                            Name (Name'First + 1 .. Name'Last) = ":\")))
+                        or else (Name'Length = 3 and then
+                                 Name (Name'First + 1 .. Name'Last) = ":\")))
             then
                Add_All_Paths
                  (URI, Ada.Directories.Containing_Directory (Path), Root);
 
                URI.Add_Path_Segment (Name);
 
-            elsif Root = "" and Path'Length > 1 then
+            elsif Root = "" and then Path'Length > 1 then
                --  Found top dir in form of 'C:\', so add 'C:'
                URI.Add_Path_Segment (Path (Path'First .. Path'Last - 1));
             end if;


### PR DESCRIPTION
As per AdaCore's coding style, and to avoid logic errors: programmers
usually rely on Y not to be evaluated when X is False in (X AND Y),
likewise for OR operations.