### PR TITLE
S624-042 Pre-populate the lexical env for units

### DIFF
--- a/integration/travis/Dockerfile
+++ b/integration/travis/Dockerfile
@@ -9,7 +9,6 @@ RUN apt-get update && apt-get install -y \
  make \
  libc-dev \
  git \
- nodejs-legacy \
  chrpath \
  libgmp-dev \
  && git clone https://github.com/AdaCore/gnat_community_install_script.git \

--- a/source/ada/lsp-ada_documents.adb
+++ b/source/ada/lsp-ada_documents.adb
@@ -281,6 +281,12 @@ package body LSP.Ada_Documents is
          Buffer   => LSP.Types.To_UTF_8_Unbounded_String (Item.text));
       Self.URI := Item.uri;
       Self.LAL := LAL;
+
+      --  After creating an analysis unit, populate the lexical env with it:
+      --  we do this to allow Libadalang to do some work in reaction to
+      --  a file being open in the IDE, in order to speed up the response
+      --  to user queries.
+      Libadalang.Analysis.Populate_Lexical_Env (Self.Unit);
    end Initialize;
 
    -------------------

--- a/source/ada/lsp-ada_handlers.adb
+++ b/source/ada/lsp-ada_handlers.adb
@@ -515,7 +515,18 @@ package body LSP.Ada_Handlers is
          end if;
       end if;
 
+      --  Send notifications "loading document" / "done loading document"
+      --  around the load of documents: this gets logged by the IDE,
+      --  and helps tracking the performance of the language server.
+      Self.Server.Show_Message
+        ((LSP.Messages.Log,
+         "loading document " & Value.textDocument.uri));
+
       Document := Self.Context.Load_Document (Value.textDocument);
+
+      Self.Server.Show_Message
+        ((LSP.Messages.Log,
+         "done loading document " & Value.textDocument.uri));
 
       if Self.Context.Get_Diagnostics_Enabled then
          Document.Get_Errors (Diag.diagnostics);


### PR DESCRIPTION
In the hope to improve the response time for user requests,
populate the lexical env for units when the files are being
opened.

Send 'log' traces around the call to Load_Document, for
development purposes.