### PR TITLE
Fix logic in URI parsing

### DIFF
--- a/source/uri/uris.adb
+++ b/source/uri/uris.adb
@@ -302,6 +302,8 @@ package body URIs is
          Has_Port     : Boolean;
          pragma Unreferenced (Has_Port);
       begin
+         Port := 0;
+
          if Index + 1 <= Text'Last
            and then Text (Index .. Index + 1) = "//"
          then


### PR DESCRIPTION
Prevent storing an uninitialized variable. Detected by valgrind.