### PR TITLE
S728-002 Do not store an Analysis_Unit in the Document

### DIFF
--- a/source/ada/lsp-ada_documents.ads
+++ b/source/ada/lsp-ada_documents.ads
@@ -77,9 +77,11 @@ private
    type Document (Context : access LSP.Ada_Contexts.Context'Class) is
      tagged limited
    record
-      URI  : LSP.Messages.DocumentUri;
-      LAL  : Libadalang.Analysis.Analysis_Context;
-      Unit : Libadalang.Analysis.Analysis_Unit;
+      URI    : LSP.Messages.DocumentUri;
+      LAL    : Libadalang.Analysis.Analysis_Context;
    end record;
+
+   function Unit (Self : Document) return Libadalang.Analysis.Analysis_Unit;
+   --  Return the analysis unit for Self
 
 end LSP.Ada_Documents;


### PR DESCRIPTION
Analysis Units are not meant to be stored. Instead, store
the latest known version of the buffer, encoded in UTF-8, and
compute the Analysis Unit on demand.