### PR TITLE
S711-069 Do not emit empty diagnostics on 'didClose'...

### DIFF
--- a/source/ada/lsp-ada_handlers.adb
+++ b/source/ada/lsp-ada_handlers.adb
@@ -463,8 +463,10 @@ package body LSP.Ada_Handlers is
       Self.Context.Unload_Document (Value.textDocument);
 
       --  Clean diagnostics up on closing document
-      Diag.uri := Value.textDocument.uri;
-      Self.Server.Publish_Diagnostics (Diag);
+      if Self.Context.Get_Diagnostics_Enabled then
+         Diag.uri := Value.textDocument.uri;
+         Self.Server.Publish_Diagnostics (Diag);
+      end if;
    end On_DidCloseTextDocument_Notification;
 
    -----------------------------------------

--- a/testsuite/ada_lsp/called_by.null_subp/called_by.null_subp.json
+++ b/testsuite/ada_lsp/called_by.null_subp/called_by.null_subp.json
@@ -174,13 +174,6 @@
          }, 
          "wait": [           
             {
-               "params": {
-                  "uri": "$URI{pack.ads}", 
-                  "diagnostics": []
-               }, 
-               "method": "textDocument/publishDiagnostics"
-            }, 
-            {
                "id": 3, 
                "result": null
             }

--- a/testsuite/ada_lsp/invalidation.file_contents/test.json
+++ b/testsuite/ada_lsp/invalidation.file_contents/test.json
@@ -404,15 +404,7 @@
             "jsonrpc": "2.0", 
             "method": "textDocument/didClose"
          }, 
-         "wait": [
-            {
-               "params": {
-                  "uri": "$URI{main.adb}", 
-                  "diagnostics": []
-               }, 
-               "method": "textDocument/publishDiagnostics"
-            }
-         ]
+         "wait": []
       }
    }, 
    {
@@ -426,15 +418,7 @@
             "jsonrpc": "2.0", 
             "method": "textDocument/didClose"
          }, 
-         "wait": [
-            {
-               "params": {
-                  "uri": "$URI{p.ads}", 
-                  "diagnostics": []
-               }, 
-               "method": "textDocument/publishDiagnostics"
-            }
-         ]
+         "wait": []
       }
    }, 
    {
@@ -448,15 +432,7 @@
             "jsonrpc": "2.0", 
             "method": "textDocument/didClose"
          }, 
-         "wait": [
-            {
-               "params": {
-                  "uri": "$URI{q.ads}", 
-                  "diagnostics": []
-               }, 
-               "method": "textDocument/publishDiagnostics"
-            }
-         ]
+         "wait": []
       }
    }, 
    {

--- a/testsuite/ada_lsp/publish_diag/publish_diag.json
+++ b/testsuite/ada_lsp/publish_diag/publish_diag.json
@@ -101,7 +101,28 @@
                 }
             }]
         }
-    },  {
+    }, {
+        "send": {
+            "request": {
+                "jsonrpc":"2.0",
+                "method":"textDocument/didClose",
+                "params":{
+                    "textDocument": {
+                        "uri": "$URI{aaa.ads}"
+                    }
+                }
+            },
+            "wait":[
+               {
+               "params": {
+                  "uri": "$URI{aaa.ads}", 
+                  "diagnostics": []
+               }, 
+               "method": "textDocument/publishDiagnostics"
+              }
+           ]
+        }
+    }, {
         "send": {
             "request": {
                 "jsonrpc":"2.0",


### PR DESCRIPTION
... if diagnostics are deactivated.

Amend the testsuite with a check that these are indeed properly
emitted when diagnostics are enabled.