### PR TITLE
S815-010 S709-013 Initial code for multi-project support

### DIFF
--- a/source/ada/lsp-ada_contexts.adb
+++ b/source/ada/lsp-ada_contexts.adb
@@ -209,11 +209,18 @@ package body LSP.Ada_Contexts is
    ----------------
 
    procedure Initialize
-     (Self  : in out Context;
-      Root  : LSP.Types.LSP_String) is
+     (Self : in out Context;
+      Root : LSP.Types.LSP_String) is
    begin
       Self.Root := Root;
       Self.Source_Files := new File_Array'(1 .. 0 => <>);
+
+      Self.Charset := Ada.Strings.Unbounded.To_Unbounded_String
+        ("iso-8859-1");
+      Self.LAL_Context := Libadalang.Analysis.Create_Context
+        (Unit_Provider => Self.Unit_Provider,
+         With_Trivia   => True,
+         Charset       => Self.Get_Charset);
    end Initialize;
 
    ------------------------
@@ -222,12 +229,21 @@ package body LSP.Ada_Contexts is
 
    function Is_Part_Of_Project
      (Self : Context;
-      File : Virtual_File) return Boolean
-   is
-      Set   : constant File_Info_Set := Self.Project_Tree.Info_Set (File);
-      First : constant File_Info'Class := File_Info'Class (Set.First_Element);
+      File : Virtual_File) return Boolean is
    begin
-      return First.Project /= No_Project;
+      --  If there is no project, it's easy to answer this question
+      if Self.Project_Tree = null then
+         return False;
+      end if;
+
+      declare
+         Set   : constant File_Info_Set :=
+           Self.Project_Tree.Info_Set (File);
+         First : constant File_Info'Class :=
+           File_Info'Class (Set.First_Element);
+      begin
+         return First.Project /= No_Project;
+      end;
    end Is_Part_Of_Project;
 
    -------------------
@@ -255,7 +271,11 @@ package body LSP.Ada_Contexts is
             --  File that we are loading doesn't belong to the project, so
             --  firstly recompute project view just in case this is a new file
             --  in the project. Then update list of source files.
-            Self.Project_Tree.Recompute_View;
+
+            if Self.Project_Tree /= null then
+               Self.Project_Tree.Recompute_View;
+            end if;
+
             Self.Update_Source_Files;
          end if;
       end;
@@ -415,38 +435,45 @@ package body LSP.Ada_Contexts is
    -------------------------
 
    procedure Update_Source_Files (Self : in out Context) is
-      All_Sources     : File_Array_Access :=
-        Self.Project_Tree.Root_Project.Source_Files (Recursive => True);
-      All_Ada_Sources : File_Array (1 .. All_Sources'Length);
-      Free_Index      : Natural := All_Ada_Sources'First;
-      Set             : File_Info_Set;
    begin
-      --  Iterate through all sources, returning only those that have Ada as
-      --  language.
-      for J in All_Sources'Range loop
-         Set := Self.Project_Tree.Info_Set (All_Sources (J));
-         if not Set.Is_Empty then
-            --  The file can be listed in several projects with different
-            --  Info_Sets, in the case of aggregate project. However, assume
-            --  that the language is the same in all projects, so look only
-            --  at the first entry in the set.
-            declare
-               Info : constant File_Info'Class :=
-                 File_Info'Class (Set.First_Element);
-            begin
-               if To_Lower (Info.Language) = "ada" then
-                  All_Ada_Sources (Free_Index) := All_Sources (J);
-                  Free_Index := Free_Index + 1;
-               end if;
-            end;
-         end if;
-      end loop;
+      if Self.Project_Tree = null then
+         return;
+      end if;
 
-      Unchecked_Free (All_Sources);
-      Unchecked_Free (Self.Source_Files);
+      declare
+         All_Sources : File_Array_Access :=
+           Self.Project_Tree.Root_Project.Source_Files (Recursive => True);
+         All_Ada_Sources : File_Array (1 .. All_Sources'Length);
+         Free_Index      : Natural := All_Ada_Sources'First;
+         Set             : File_Info_Set;
+      begin
+         --  Iterate through all sources, returning only those that have Ada as
+         --  language.
+         for J in All_Sources'Range loop
+            Set := Self.Project_Tree.Info_Set (All_Sources (J));
+            if not Set.Is_Empty then
+               --  The file can be listed in several projects with different
+               --  Info_Sets, in the case of aggregate project. However, assume
+               --  that the language is the same in all projects, so look only
+               --  at the first entry in the set.
+               declare
+                  Info : constant File_Info'Class :=
+                    File_Info'Class (Set.First_Element);
+               begin
+                  if To_Lower (Info.Language) = "ada" then
+                     All_Ada_Sources (Free_Index) := All_Sources (J);
+                     Free_Index := Free_Index + 1;
+                  end if;
+               end;
+            end if;
+         end loop;
 
-      Self.Source_Files :=
-        new File_Array'(All_Ada_Sources (1 .. Free_Index - 1));
+         Unchecked_Free (All_Sources);
+         Unchecked_Free (Self.Source_Files);
+
+         Self.Source_Files :=
+           new File_Array'(All_Ada_Sources (1 .. Free_Index - 1));
+      end;
    end Update_Source_Files;
 
    -----------------
@@ -461,26 +488,6 @@ package body LSP.Ada_Contexts is
    begin
       return LSP.Types.To_LSP_String (Result);
    end URI_To_File;
-
-   -----------------------------
-   -- Set_Diagnostics_Enabled --
-   -----------------------------
-
-   procedure Set_Diagnostics_Enabled
-     (Self    : in out Context;
-      Enabled : Boolean) is
-   begin
-      Self.Diagnostics_Enabled := Enabled;
-   end Set_Diagnostics_Enabled;
-
-   -----------------------------
-   -- Get_Diagnostics_Enabled --
-   -----------------------------
-
-   function Get_Diagnostics_Enabled (Self : Context) return Boolean is
-   begin
-      return Self.Diagnostics_Enabled;
-   end Get_Diagnostics_Enabled;
 
    -----------------
    -- Get_Node_At --
@@ -498,24 +505,39 @@ package body LSP.Ada_Contexts is
       Unit : Libadalang.Analysis.Analysis_Unit;
 
       URI : constant LSP.Messages.DocumentUri := Position.textDocument.uri;
-
+      File : Virtual_File;
    begin
+      --  We're about to get a node from an analysis unit. Either the document
+      --  is open for it, in which case we read the document, or the
+      --  document is not open for it. In this case, resolve this only
+      --  if the file belongs to the project: we don't want to pollute the
+      --  LAL context with units that are not in the project.
+
       if Self.Has_Document (URI) then
          return Self.Get_Document (URI).Get_Node_At (Position.position);
       else
-         Unit := Self.LAL_Context.Get_From_File
-           (LSP.Types.To_UTF_8_String (URI_To_File (URI)),
-            Charset => Self.Get_Charset);
+         File := Create
+           (Filesystem_String
+              (LSP.Types.To_UTF_8_String (URI_To_File (URI))),
+            Normalize => True);
 
-         if Unit.Root = Libadalang.Analysis.No_Ada_Node then
+         if not Self.Is_Part_Of_Project (File) then
             return Libadalang.Analysis.No_Ada_Node;
-         end if;
+         else
+            Unit := Self.LAL_Context.Get_From_File
+              (LSP.Types.To_UTF_8_String (URI_To_File (URI)),
+               Charset => Self.Get_Charset);
 
-         return Unit.Root.Lookup
-           ((Line   => Langkit_Support.Slocs.Line_Number
-                         (Position.position.line) + 1,
-             Column => Langkit_Support.Slocs.Column_Number
-                         (Position.position.character) + 1));
+            if Unit.Root = Libadalang.Analysis.No_Ada_Node then
+               return Libadalang.Analysis.No_Ada_Node;
+            end if;
+
+            return Unit.Root.Lookup
+              ((Line   => Langkit_Support.Slocs.Line_Number
+                (Position.position.line) + 1,
+                Column => Langkit_Support.Slocs.Column_Number
+                  (Position.position.character) + 1));
+         end if;
       end if;
    end Get_Node_At;
 

--- a/source/ada/lsp-ada_contexts.ads
+++ b/source/ada/lsp-ada_contexts.ads
@@ -39,10 +39,9 @@ package LSP.Ada_Contexts is
    --  tree and others data.
 
    procedure Initialize
-     (Self  : in out Context;
-      Root  : LSP.Types.LSP_String);
+     (Self : in out Context;
+      Root : LSP.Types.LSP_String);
    --  Reset context. Set Root directory as LSP client provides it.
-   --  Use Trace to log errors.
 
    function Is_Initialized (Self : Context) return Boolean;
    --  Check if context has been initialized
@@ -60,14 +59,6 @@ package LSP.Ada_Contexts is
    --  In case of errors create and load default project.
    --  Set the charset as well.
    --  Return warnings and errors in Errors parameter.
-
-   procedure Set_Diagnostics_Enabled
-     (Self    : in out Context;
-      Enabled : Boolean);
-   --  Enable/Disable diagnostics; by default, diagnostics are enabled
-
-   function Get_Diagnostics_Enabled (Self : Context) return Boolean;
-   --  Return whether diagnostics are enabled
 
    procedure Reload (Self : in out Context);
    --  Reload the current context. This will invalidate and destroy any
@@ -121,6 +112,11 @@ package LSP.Ada_Contexts is
    --  Finds all references to a given defining name in all units of the
    --  context.
 
+   function Is_Part_Of_Project
+     (Self : Context;
+      File : GNATCOLL.VFS.Virtual_File) return Boolean;
+   --  Check if given file belongs to the project loaded in the Context
+
 private
    use type Types.LSP_String;
    use type GNATCOLL.Projects.Project_Tree_Access;
@@ -147,24 +143,18 @@ private
    type Context (Trace : GNATCOLL.Traces.Trace_Handle) is tagged limited record
       Unit_Provider  : Libadalang.Analysis.Unit_Provider_Reference;
       LAL_Context    : Libadalang.Analysis.Analysis_Context;
-
-      Project_Tree   : GNATCOLL.Projects.Project_Tree_Access;
       Root           : LSP.Types.LSP_String;
       Charset        : Ada.Strings.Unbounded.Unbounded_String;
 
       Source_Files   : GNATCOLL.VFS.File_Array_Access;
       --  Cache for the list of Ada source files in the loaded project tree
 
+      Project_Tree   : GNATCOLL.Projects.Project_Tree_Access;
+      --  The currently loaded project tree, or null for contexts that
+      --  don't have a project.
+
       Documents      : Document_Maps.Map;
-
-      Diagnostics_Enabled : Boolean := True;
-      --  Whether to publish diagnostics
    end record;
-
-   function Is_Part_Of_Project
-     (Self : Context;
-      File : GNATCOLL.VFS.Virtual_File) return Boolean;
-   --  Check if given file belongs to the project loaded in the Context
 
    procedure Update_Source_Files (Self : in out Context);
    --  Update Self.Source_Files value

--- a/source/ada/lsp-ada_driver.adb
+++ b/source/ada/lsp-ada_driver.adb
@@ -30,7 +30,6 @@ with GNATCOLL.VFS;            use GNATCOLL.VFS;
 with LSP.Servers;
 with LSP.Stdio_Streams;
 
-with LSP.Ada_Contexts;
 with LSP.Ada_Handlers;
 
 --------------------
@@ -48,9 +47,8 @@ procedure LSP.Ada_Driver is
 
    Server  : aliased LSP.Servers.Server;
    Stream  : aliased LSP.Stdio_Streams.Stdio_Stream;
-   Context : aliased LSP.Ada_Contexts.Context (Server_Trace);
    Handler : aliased LSP.Ada_Handlers.Message_Handler
-     (Server'Access, Context'Access, Server_Trace);
+     (Server'Access, Server_Trace);
 
    function Getenv (Var : String) return String;
    --  Return the value set for the given environment variable

--- a/testsuite/ada_lsp/non_project_files/non_prj/p2.adb
+++ b/testsuite/ada_lsp/non_project_files/non_prj/p2.adb
@@ -1,0 +1,6 @@
+package body P is
+   procedure Proc is
+   begin
+      return;
+   end Proc;
+end P;

--- a/testsuite/ada_lsp/non_project_files/non_project_files.json
+++ b/testsuite/ada_lsp/non_project_files/non_project_files.json
@@ -1,0 +1,223 @@
+[
+    {
+        "comment":[
+            "Loading non-project file shouldn't break navigation in the project"
+        ]
+    },  {
+        "start": {
+            "cmd": ["${ALS}"]
+        }
+    },  {
+        "send": {
+            "request": {"jsonrpc":"2.0","id":0,"method":"initialize","params":{
+                "processId":1,
+                "rootUri":"$URI{.}",
+                "capabilities":{}}
+            },
+            "wait":[{
+                "id": 0,
+                "result":{
+                    "capabilities":{
+                        "textDocumentSync":1,
+                        "definitionProvider":true
+                    }
+                }
+            }]
+        }
+    },  {
+        "send": {
+            "request": {
+                "jsonrpc":"2.0",
+                "method":"workspace/didChangeConfiguration",
+                "params":{
+                    "settings":{
+                    }
+                }
+            },
+            "wait":[]
+        }
+    },  {
+        "send": {
+            "request": {
+                "jsonrpc":"2.0",
+                "method":"textDocument/didOpen",
+                "params":{
+                    "textDocument": {
+                        "uri": "$URI{p.adb}",
+                        "languageId": "ada",
+                        "version": 1,
+                        "text": "package body P is\n   procedure Proc is\n   begin\n      null;\n   end Proc;\nend P;"
+                    }
+                }
+            },
+            "wait":[]
+        }
+    },  {
+        "send": {
+            "request": {
+                "jsonrpc":"2.0",
+                "id":"defname-1",
+                "method":"textDocument/definition",
+                "params":{
+                    "textDocument": {
+                        "uri": "$URI{p.adb}"
+                    },
+                    "position": {
+                        "line": 0,
+                        "character": 13
+                    }
+                }
+            },
+            "wait":[{
+                "id": "defname-1",
+                "result":[{
+                    "uri": "$URI{p.ads}",
+                    "range": {
+                        "start": {
+                            "line": 0,
+                            "character": 8
+                        },
+                        "end": {
+                            "line": 0,
+                            "character": 9
+                        }
+                    }
+                }]
+            }]
+        }
+    },  {
+        "send": {
+            "request": {
+                "jsonrpc":"2.0",
+                "method":"textDocument/didOpen",
+                "params":{
+                    "textDocument": {
+                        "uri": "$URI{non_prj/p2.adb}",
+                        "languageId": "ada",
+                        "version": 1,
+                        "text": "package body P is\n   procedure Proc is\n   begin\n      return;\n   end Proc;\nend P;"
+                    }
+                }
+            },
+            "wait":[]
+        }
+    },  {
+        "send": {
+            "request": {
+                "jsonrpc":"2.0",
+                "id":"defname-2",
+                "method":"textDocument/definition",
+                "params":{
+                    "textDocument": {
+                        "uri": "$URI{non_prj/p2.adb}"
+                    },
+                    "position": {
+                        "line": 0,
+                        "character": 13
+                    }
+                }
+            },
+            "wait":[{
+                "id": "defname-2",
+                "result":[{
+                    "uri": "$URI{p.ads}",
+                    "range": {
+                        "start": {
+                            "line": 0,
+                            "character": 8
+                        },
+                        "end": {
+                            "line": 0,
+                            "character": 9
+                        }
+                    }
+                }]
+            }]
+        }
+    },  {
+        "send": {
+            "request": {
+                "jsonrpc":"2.0",
+                "id":"defname-3",
+                "method":"textDocument/definition",
+                "params":{
+                    "textDocument": {
+                        "uri": "$URI{p.ads}"
+                    },
+                    "position": {
+                        "line": 0,
+                        "character": 8
+                    }
+                }
+            },
+            "wait":[{
+                "id": "defname-3",
+                "result":[{
+                    "uri": "$URI{p.adb}",
+                    "range": {
+                        "start": {
+                            "line": 0,
+                            "character": 13
+                        },
+                        "end": {
+                            "line": 0,
+                            "character": 14
+                        }
+                    }
+                }]
+            }]
+        }
+    },  {
+        "send": {
+            "request": {
+                "jsonrpc":"2.0",
+                "id":"defname-4",
+                "method":"textDocument/definition",
+                "params":{
+                    "textDocument": {
+                        "uri": "$URI{p.adb}"
+                    },
+                    "position": {
+                        "line": 0,
+                        "character": 13
+                    }
+                }
+            },
+            "wait":[{
+                "id": "defname-4",
+                "result":[{
+                    "uri": "$URI{p.ads}",
+                    "range": {
+                        "start": {
+                            "line": 0,
+                            "character": 8
+                        },
+                        "end": {
+                            "line": 0,
+                            "character": 9
+                        }
+                    }
+                }]
+            }]
+        }
+    },  {
+        "send": {
+            "request": {
+                "jsonrpc":"2.0",
+                "id": "shutdown",
+                "method":"shutdown",
+                "params":null
+            },
+            "wait":[{ "id": "shutdown", "result": null }]
+        }
+    },  {
+        "send": {
+            "request": {"jsonrpc":"2.0", "method":"exit", "params":{}},
+            "wait":[]
+        }
+    }, {
+        "stop": {
+            "exit_code": 0
+        }
+    }
+]

--- a/testsuite/ada_lsp/non_project_files/p.adb
+++ b/testsuite/ada_lsp/non_project_files/p.adb
@@ -1,0 +1,6 @@
+package body P is
+   procedure Proc is
+   begin
+      null;
+   end Proc;
+end P;

--- a/testsuite/ada_lsp/non_project_files/p.ads
+++ b/testsuite/ada_lsp/non_project_files/p.ads
@@ -1,0 +1,3 @@
+package P is
+   procedure Proc;
+end P;

--- a/testsuite/ada_lsp/non_project_files/test.yaml
+++ b/testsuite/ada_lsp/non_project_files/test.yaml
@@ -1,0 +1,1 @@
+title: 'non_project_files'


### PR DESCRIPTION
This is a first step for supporting multiple projects: add support
for more than one Context, and organise the requests so that
they either get the results from all contexts and aggregate
them, or only query the results from the appropriate context.

At the moment, there is only one project loaded, and we have
added one context to hold all files that are not associated
to a project.

Move the diagnostics preference from the Context to the
Message_Handler.