### PR TITLE
S703-028 Make Resolve_Name return canonical part of defining name

### DIFF
--- a/source/ada/lsp-lal_utils.adb
+++ b/source/ada/lsp-lal_utils.adb
@@ -92,7 +92,7 @@ package body LSP.Lal_Utils is
          Imprecise := Result /= No_Defining_Name;
       end if;
 
-      return Result;
+      return Result.P_Canonical_Part;
 
    exception
       when Property_Error =>

--- a/source/ada/lsp-lal_utils.ads
+++ b/source/ada/lsp-lal_utils.ads
@@ -36,7 +36,7 @@ package LSP.Lal_Utils is
    function Resolve_Name
      (Name_Node : Name;
       Imprecise : out Boolean) return Defining_Name;
-   --  Return the definition node of the given name.
+   --  Return the definition node (canonical part) of the given name.
    --  Imprecise is set to True if LAL's imprecise fallback mechanism has been
    --  used to compute the cross reference.
 

--- a/testsuite/ada_lsp/JB24-033.xrefs.no_refs_for_non_loaded_projects/test.json
+++ b/testsuite/ada_lsp/JB24-033.xrefs.no_refs_for_non_loaded_projects/test.json
@@ -117,6 +117,7 @@
             "id": 2,
             "method": "textDocument/references"
          },
+         "sortReply": { "result": "uri" },
          "wait": [
             {
                "id": 2,
@@ -161,7 +162,7 @@
                            "character": 16
                         }
                      },
-                     "uri": "$URI{c/c.ads}"
+                     "uri": "$URI{c/c.adb}"
                   },
                   {
                      "range": {
@@ -174,7 +175,7 @@
                            "character": 16
                         }
                      },
-                     "uri": "$URI{c/c.adb}"
+                     "uri": "$URI{c/c.ads}"
                   }
                ]
             }


### PR DESCRIPTION
to prevent "goto definition" jump to the body.