### PR TITLE
S910-023 Add support for aggregate projects

### DIFF
--- a/source/ada/lsp-ada_handlers.ads
+++ b/source/ada/lsp-ada_handlers.ads
@@ -61,6 +61,10 @@ private
       --  There should always be at least one "project" context, and exactly
       --  one "projectless" context.
 
+      Root : Virtual_File;
+      --  The directory passed under rootURI/rootPath during the initialize
+      --  request.
+
       Diagnostics_Enabled : Boolean := True;
       --  Whether to publish diagnostics
    end record;

--- a/source/ada/lsp-ada_unit_providers.ads
+++ b/source/ada/lsp-ada_unit_providers.ads
@@ -26,16 +26,20 @@ with Libadalang.Common;     use Libadalang.Common;
 package LSP.Ada_Unit_Providers is
 
    type Unit_Provider
-     (Project_Tree : not null GNATCOLL.Projects.Project_Tree_Access) is
+     (Project_Tree : not null GNATCOLL.Projects.Project_Tree_Access;
+      Project      : not null GNATCOLL.Projects.Project_Type_Access) is
         new Libadalang.Analysis.Unit_Provider_Interface with private;
 --  The unit provider is improved version of libadalang one.
 --  It normalizes file path to avoid double directory separators.
 --  This aids correct file name comparison.
+--  This provider will resolve unit names in the project hierarchy denoted
+--  by Project - this is a non-aggregate project roots inside Project_Tree.
 
 private
 
    type Unit_Provider
-     (Project_Tree : not null GNATCOLL.Projects.Project_Tree_Access)
+     (Project_Tree : not null GNATCOLL.Projects.Project_Tree_Access;
+      Project      : not null GNATCOLL.Projects.Project_Type_Access)
    is new Libadalang.Analysis.Unit_Provider_Interface with null record;
 
    overriding function Get_Unit_Filename

--- a/testsuite/ada_lsp/aggregate.simple/agg.gpr
+++ b/testsuite/ada_lsp/aggregate.simple/agg.gpr
@@ -1,0 +1,3 @@
+aggregate project Agg is
+   for Project_Files use ("p/p.gpr", "q/q.gpr");
+end Agg;

--- a/testsuite/ada_lsp/aggregate.simple/common/common.gpr
+++ b/testsuite/ada_lsp/aggregate.simple/common/common.gpr
@@ -1,0 +1,2 @@
+project common is
+end common;

--- a/testsuite/ada_lsp/aggregate.simple/common/common_pack.ads
+++ b/testsuite/ada_lsp/aggregate.simple/common/common_pack.ads
@@ -1,0 +1,3 @@
+package common_pack is
+   Foo : Integer := 42;
+end common_pack;

--- a/testsuite/ada_lsp/aggregate.simple/p/main.adb
+++ b/testsuite/ada_lsp/aggregate.simple/p/main.adb
@@ -1,0 +1,6 @@
+with common_pack; use common_pack;
+procedure Main is
+   A : Integer := Foo;
+begin
+   null;
+end;

--- a/testsuite/ada_lsp/aggregate.simple/p/p.gpr
+++ b/testsuite/ada_lsp/aggregate.simple/p/p.gpr
@@ -1,0 +1,3 @@
+with "../common/common";
+project p is
+end p;

--- a/testsuite/ada_lsp/aggregate.simple/q/main.adb
+++ b/testsuite/ada_lsp/aggregate.simple/q/main.adb
@@ -1,0 +1,6 @@
+with common_pack; use common_pack;
+procedure Main is
+   A : Integer := Foo;
+begin
+   null;
+end;

--- a/testsuite/ada_lsp/aggregate.simple/q/q.gpr
+++ b/testsuite/ada_lsp/aggregate.simple/q/q.gpr
@@ -1,0 +1,3 @@
+with "../common/common";
+project q is
+end q;

--- a/testsuite/ada_lsp/aggregate.simple/test.json
+++ b/testsuite/ada_lsp/aggregate.simple/test.json
@@ -1,0 +1,203 @@
+[
+   {
+      "comment": [
+         "test 'reference' in a basic aggregate project"
+      ]
+   }, 
+   {
+      "start": {
+         "cmd": [
+            "${ALS}"
+         ]
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0", 
+            "params": {
+               "capabilities": {
+                  "workspace": {
+                     "applyEdit": false
+                  }
+               }, 
+               "rootUri": "$URI{.}"
+            }, 
+            "id": 1, 
+            "method": "initialize"
+         }, 
+         "wait": [
+            {
+               "id": 1, 
+               "result": {
+                  "capabilities": {
+                     "typeDefinitionProvider": true, 
+                     "alsReferenceKinds": [
+                        "write", 
+                        "call", 
+                        "dispatching call"
+                     ], 
+                     "hoverProvider": true, 
+                     "definitionProvider": true, 
+                     "renameProvider": true, 
+                     "alsCalledByProvider": true, 
+                     "referencesProvider": true, 
+                     "textDocumentSync": 1, 
+                     "completionProvider": {
+                        "triggerCharacters": [
+                           "."
+                        ], 
+                        "resolveProvider": false
+                     }, 
+                     "documentSymbolProvider": true
+                  }
+               }
+            }]
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0", 
+            "method": "initialized"
+         }, 
+         "wait": []
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0", 
+            "params": {
+               "settings": {
+                  "ada": {
+                     "projectFile": "agg.gpr", 
+                     "scenarioVariables": {}, 
+                     "enableDiagnostics": false, 
+                     "defaultCharset": "UTF-8"
+                  }
+               }
+            }, 
+            "method": "workspace/didChangeConfiguration"
+         }, 
+         "wait": []
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0", 
+            "params": {
+               "textDocument": {
+                  "text": "package common_pack is\n   Foo : Integer := 42;\nend common_pack;\n", 
+                  "version": 0, 
+                  "uri": "$URI{common/common_pack.ads}", 
+                  "languageId": "Ada"
+               }
+            }, 
+            "method": "textDocument/didOpen"
+         }, 
+         "wait": []
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0", 
+            "params": {
+               "position": {
+                  "line": 1, 
+                  "character": 5
+               }, 
+               "textDocument": {
+                  "uri": "$URI{common/common_pack.ads}"
+               }, 
+               "context": {
+                  "includeDeclaration": true
+               }
+            }, 
+            "id": 2, 
+            "method": "textDocument/references"
+         }, 
+         "wait": [
+            {
+               "id": 2, 
+               "result": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 2, 
+                           "character": 18
+                        }, 
+                        "end": {
+                           "line": 2, 
+                           "character": 21
+                        }
+                     }, 
+                     "uri": "$URI{p/main.adb}"
+                  }, 
+                  {
+                     "range": {
+                        "start": {
+                           "line": 2, 
+                           "character": 18
+                        }, 
+                        "end": {
+                           "line": 2, 
+                           "character": 21
+                        }
+                     }, 
+                     "uri": "$URI{q/main.adb}"
+                  }, 
+                  {
+                     "range": {
+                        "start": {
+                           "line": 1, 
+                           "character": 3
+                        }, 
+                        "end": {
+                           "line": 1, 
+                           "character": 6
+                        }
+                     }, 
+                     "uri": "$URI{common/common_pack.ads}"
+                  }
+               ]
+            }]
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0", 
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{common/common_pack.ads}"
+               }
+            }, 
+            "method": "textDocument/didClose"
+         }, 
+         "wait": []
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0", 
+            "id": 3, 
+            "method": "shutdown"
+         }, 
+         "wait": [
+            {
+               "id": 3, 
+               "result": null
+            }
+         ]
+      }
+   }, 
+   {
+      "stop": {
+         "exit_code": 0
+      }
+   }
+]

--- a/testsuite/ada_lsp/aggregate.simple/test.yaml
+++ b/testsuite/ada_lsp/aggregate.simple/test.yaml
@@ -1,0 +1,1 @@
+title: 'aggregate.simple'


### PR DESCRIPTION
Add support for aggregate projects. To do this, move
project loading from the Context to the Message_Handler: the
Message_Handler is responsible for creating one Context per
project hierarchy within the aggregate project.

Add a first test to check the result of finding all references
in a simple aggregate project tree.