### PR TITLE
S911-041 Rationalize project loading

### DIFF
--- a/testsuite/ada_lsp/README.md
+++ b/testsuite/ada_lsp/README.md
@@ -51,7 +51,7 @@ in the array item to compare.
 Where _wait_ object is expected server answer. Each property of this object
 should be in server response, but some string values have a special meaning:
  * `<ANY>`  - matches any string value
- * `<ABSENT>` - ensures than there is no such property at all
+ * `<ABSENT>` - ensures that there is no such property at all
 
 ### Command `comment`
 


### PR DESCRIPTION
Load the project at one of two opportunities:
  - in reaction to didChangeConfiguration
  - if this didn't happen, when opening a source editor
This makes sure we don't load a same project twice, and prevents
emitting spurious errors in reaction to initialize.