### PR TITLE
S822-037 inform alsReferenceKind in the result of alsCalledBy

### DIFF
--- a/testsuite/ada_lsp/called_by_dispatching/child.ads
+++ b/testsuite/ada_lsp/called_by_dispatching/child.ads
@@ -1,0 +1,9 @@
+with root; use root;
+
+package child is
+
+   type child_t is new root_t with null record;
+   
+   overriding procedure foo (t : child_t) is null;
+
+end child;

--- a/testsuite/ada_lsp/called_by_dispatching/main.adb
+++ b/testsuite/ada_lsp/called_by_dispatching/main.adb
@@ -1,0 +1,10 @@
+with root; use root;
+
+procedure main is
+   x : root_t'class := create;
+begin
+
+   foo (x);
+
+
+end main;

--- a/testsuite/ada_lsp/called_by_dispatching/p.gpr
+++ b/testsuite/ada_lsp/called_by_dispatching/p.gpr
@@ -1,0 +1,2 @@
+project p is
+end p;

--- a/testsuite/ada_lsp/called_by_dispatching/root.ads
+++ b/testsuite/ada_lsp/called_by_dispatching/root.ads
@@ -1,0 +1,8 @@
+package root is
+
+   type root_t is tagged null record;
+   
+   procedure foo (t : root_t);
+
+   function create return root_t'class;
+end root;

--- a/testsuite/ada_lsp/called_by_dispatching/test.json
+++ b/testsuite/ada_lsp/called_by_dispatching/test.json
@@ -1,0 +1,212 @@
+[
+   {
+      "comment": [
+         "test of the presence of the 'dispatching call' in alsReferenceKind"
+      ]
+   }, 
+   {
+      "start": {
+         "cmd": [
+            "${ALS}"
+         ]
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "processId": 10247, 
+               "capabilities": {
+                  "workspace": {
+                     "applyEdit": false
+                  }
+               }, 
+               "rootUri": "$URI{.}"
+            }, 
+            "jsonrpc": "2.0", 
+            "id": 1, 
+            "method": "initialize"
+         }, 
+         "wait": [
+            {
+               "id": 1, 
+               "result": {
+                  "capabilities": {
+                     "typeDefinitionProvider": true, 
+                     "alsReferenceKinds": [
+                        "write", 
+                        "call", 
+                        "dispatching call"
+                     ], 
+                     "hoverProvider": true, 
+                     "definitionProvider": true, 
+                     "renameProvider": true, 
+                     "alsCalledByProvider": true, 
+                     "referencesProvider": true, 
+                     "textDocumentSync": 1, 
+                     "completionProvider": {
+                        "triggerCharacters": [
+                           "."
+                        ], 
+                        "resolveProvider": false
+                     }, 
+                     "documentSymbolProvider": true
+                  }
+               }
+            }
+         ]
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0", 
+            "method": "initialized"
+         }, 
+         "wait": []
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "settings": {
+                  "ada": {
+                     "projectFile": "p.gpr", 
+                     "scenarioVariables": {}, 
+                     "enableDiagnostics": false, 
+                     "defaultCharset": "ISO-8859-1"
+                  }
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "method": "workspace/didChangeConfiguration"
+         }, 
+         "wait": []
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "text": "with root; use root;\n\nprocedure main is\n   x : root_t'class := create;\nbegin\n\n   foo (x);\n\n\nend main;\n", 
+                  "version": 0, 
+                  "uri": "$URI{main.adb}", 
+                  "languageId": "Ada"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "method": "textDocument/didOpen"
+         }, 
+         "wait": []
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "position": {
+                  "line": 6, 
+                  "character": 3
+               }, 
+               "textDocument": {
+                  "uri": "$URI{main.adb}"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "id": 2, 
+            "method": "textDocument/alsCalledBy"
+         }, 
+         "wait": [
+            {
+               "id": 2, 
+               "result": [
+                  {
+                     "refs": [
+                        {
+                           "range": {
+                              "start": {
+                                 "line": 6, 
+                                 "character": 3
+                              }, 
+                              "end": {
+                                 "line": 6, 
+                                 "character": 6
+                              }
+                           }, 
+                           "alsKind": [
+                              "dispatching call"
+                           ], 
+                           "uri": "$URI{main.adb}"
+                        }
+                     ], 
+                     "location": {
+                        "range": {
+                           "start": {
+                              "line": 2, 
+                              "character": 10
+                           }, 
+                           "end": {
+                              "line": 2, 
+                              "character": 14
+                           }
+                        }, 
+                        "uri": "$URI{main.adb}"
+                     }, 
+                     "name": "main"
+                  }
+               ]
+            }
+         ]
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{child.ads}"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "method": "textDocument/didClose"
+         }, 
+         "wait": []
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{main.adb}"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "method": "textDocument/didClose"
+         }, 
+         "wait": []
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0", 
+            "id": 3, 
+            "method": "shutdown"
+         }, 
+         "wait": [
+            {
+               "id": 3, 
+               "result": null
+            }
+         ]
+      }
+   }, 
+   {
+      "stop": {
+         "exit_code": 0
+      }
+   }
+]

--- a/testsuite/ada_lsp/called_by_dispatching/test.yaml
+++ b/testsuite/ada_lsp/called_by_dispatching/test.yaml
@@ -1,0 +1,1 @@
+title: 'called_by_dispatching'


### PR DESCRIPTION
This allows the client to differentiate calls that are made
through dispatching, for instance.

Add test.