### PR TITLE
S925-011 log all "Property_Error" exceptions to traces

### DIFF
--- a/source/ada/lsp-ada_contexts.adb
+++ b/source/ada/lsp-ada_contexts.adb
@@ -18,14 +18,13 @@
 with Ada.Characters.Handling;  use Ada.Characters.Handling;
 with Ada.Unchecked_Deallocation;
 
-with GNAT.Traceback.Symbolic;  use GNAT.Traceback.Symbolic;
-
 with GNATCOLL.JSON;
 with GNATCOLL.Projects; use GNATCOLL.Projects;
 with GNATCOLL.VFS;      use GNATCOLL.VFS;
 
 with URIs;
 with LSP.Ada_Unit_Providers;
+with LSP.Common; use LSP.Common;
 
 with Libadalang.Common;
 with Langkit_Support.Slocs;
@@ -94,17 +93,13 @@ package body LSP.Ada_Contexts is
       exception
          when E : Libadalang.Common.Property_Error =>
             Imprecise_Results := True;
-            Self.Trace.Trace
-              ("Property_Error in Find_All_References (precise)");
-            Self.Trace.Trace (Symbolic_Traceback (E));
+            Log (Self.Trace, E, "in Find_All_References (precise)");
             return Definition.P_Find_All_References
               (Units, Imprecise_Fallback => True);
       end;
    exception
       when E : Libadalang.Common.Property_Error =>
-         Self.Trace.Trace
-           ("Property_Error in Find_All_References (imprecise)");
-         Self.Trace.Trace (Symbolic_Traceback (E));
+         Log (Self.Trace, E, "in Find_All_References (imprecise)");
          return (1 .. 0 => <>);
    end Find_All_References;
 
@@ -128,15 +123,13 @@ package body LSP.Ada_Contexts is
       exception
          when E : Libadalang.Common.Property_Error =>
             Imprecise_Results := True;
-            Self.Trace.Trace ("Property_Error in Is_Called_By (precise)");
-            Self.Trace.Trace (Symbolic_Traceback (E));
+            Log (Self.Trace, E, "in Is_Called_By (precise)");
             return Definition.P_Is_Called_By
               (Units, Imprecise_Fallback => True);
       end;
    exception
       when E : Libadalang.Common.Property_Error =>
-         Self.Trace.Trace ("Property_Error in Is_Called_By (imprecise)");
-         Self.Trace.Trace (Symbolic_Traceback (E));
+         Log (Self.Trace, E, "in Is_Called_By (imprecise)");
          return (1 .. 0 => <>);
    end Is_Called_By;
 

--- a/source/ada/lsp-ada_handlers.adb
+++ b/source/ada/lsp-ada_handlers.adb
@@ -30,6 +30,7 @@ with GNATCOLL.VFS_Utils;         use GNATCOLL.VFS_Utils;
 with LSP.Types; use LSP.Types;
 
 with LSP.Ada_Documents;
+with LSP.Common;       use LSP.Common;
 with LSP.Lal_Utils;
 with LSP.Ada_Contexts; use LSP.Ada_Contexts;
 with LSP.Messages.Server_Notifications;
@@ -349,6 +350,7 @@ package body LSP.Ada_Handlers is
 
       Definition := LSP.Lal_Utils.Resolve_Name
         (Name_Node,
+         Self.Trace,
          Imprecise => Imprecise);
 
       --  If we used the imprecise fallback to get to the definition, log it
@@ -624,7 +626,8 @@ package body LSP.Ada_Handlers is
 
                Next := Prev;
             exception
-               when Libadalang.Common.Property_Error =>
+               when E : Libadalang.Common.Property_Error =>
+                  Log (Self.Trace, E);
                   exit;
             end;
          end loop;
@@ -653,7 +656,8 @@ package body LSP.Ada_Handlers is
             return Next;
          end if;
       exception
-         when Libadalang.Common.Property_Error =>
+         when E :  Libadalang.Common.Property_Error =>
+            Log (Self.Trace, E);
             return No_Defining_Name;
       end Find_Next_Part;
 
@@ -1227,23 +1231,23 @@ package body LSP.Ada_Handlers is
          begin
             Result.As_Flags (LSP.Messages.Write) := Id.P_Is_Write_Reference;
          exception
-            when Libadalang.Common.Property_Error =>
-               null;
+            when E : Libadalang.Common.Property_Error =>
+               Log (Self.Trace, E);
          end;
 
          begin
             Result.As_Flags (LSP.Messages.Static_Call) := Id.P_Is_Static_Call;
          exception
-            when Libadalang.Common.Property_Error =>
-               null;
+            when E : Libadalang.Common.Property_Error =>
+               Log (Self.Trace, E);
          end;
 
          begin
             Result.As_Flags (LSP.Messages.Dispatching_Call) :=
               Id.P_Is_Dispatching_Call;
          exception
-            when Libadalang.Common.Property_Error =>
-               null;
+            when E : Libadalang.Common.Property_Error =>
+               Log (Self.Trace, E);
          end;
 
          return Result;
@@ -1514,6 +1518,7 @@ package body LSP.Ada_Handlers is
 
          Definition := LSP.Lal_Utils.Resolve_Name
            (Name_Node,
+            Self.Trace,
             Imprecise => Imprecise);
 
          --  If we used the imprecise fallback to get to the definition, stop

--- a/source/ada/lsp-common.adb
+++ b/source/ada/lsp-common.adb
@@ -1,0 +1,40 @@
+------------------------------------------------------------------------------
+--                         Language Server Protocol                         --
+--                                                                          --
+--                     Copyright (C) 2018-2019, AdaCore                     --
+--                                                                          --
+-- This is free software;  you can redistribute it  and/or modify it  under --
+-- terms of the  GNU General Public License as published  by the Free Soft- --
+-- ware  Foundation;  either version 3,  or (at your option) any later ver- --
+-- sion.  This software is distributed in the hope  that it will be useful, --
+-- but WITHOUT ANY WARRANTY;  without even the implied warranty of MERCHAN- --
+-- TABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public --
+-- License for  more details.  You should have  received  a copy of the GNU --
+-- General  Public  License  distributed  with  this  software;   see  file --
+-- COPYING3.  If not, go to http://www.gnu.org/licenses for a complete copy --
+-- of the license.                                                          --
+------------------------------------------------------------------------------
+
+with Ada.Exceptions;           use Ada.Exceptions;
+with GNAT.Traceback.Symbolic;  use GNAT.Traceback.Symbolic;
+
+package body LSP.Common is
+
+   ---------
+   -- Log --
+   ---------
+
+   procedure Log
+     (Trace   : GNATCOLL.Traces.Trace_Handle;
+      E       : Ada.Exceptions.Exception_Occurrence;
+      Message : String := "") is
+   begin
+      if Message /= "" then
+         Trace.Trace (Message);
+      end if;
+
+      Trace.Trace (Exception_Name (E) & ": " & Exception_Message (E)
+                   & ASCII.LF & Symbolic_Traceback (E));
+   end Log;
+
+end LSP.Common;

--- a/source/ada/lsp-common.ads
+++ b/source/ada/lsp-common.ads
@@ -1,0 +1,31 @@
+------------------------------------------------------------------------------
+--                         Language Server Protocol                         --
+--                                                                          --
+--                     Copyright (C) 2018-2019, AdaCore                     --
+--                                                                          --
+-- This is free software;  you can redistribute it  and/or modify it  under --
+-- terms of the  GNU General Public License as published  by the Free Soft- --
+-- ware  Foundation;  either version 3,  or (at your option) any later ver- --
+-- sion.  This software is distributed in the hope  that it will be useful, --
+-- but WITHOUT ANY WARRANTY;  without even the implied warranty of MERCHAN- --
+-- TABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public --
+-- License for  more details.  You should have  received  a copy of the GNU --
+-- General  Public  License  distributed  with  this  software;   see  file --
+-- COPYING3.  If not, go to http://www.gnu.org/licenses for a complete copy --
+-- of the license.                                                          --
+------------------------------------------------------------------------------
+
+--  A place for commonly used utilities, such as trace or debug functions.
+
+with Ada.Exceptions;
+with GNATCOLL.Traces;
+
+package LSP.Common is
+
+   procedure Log
+     (Trace   : GNATCOLL.Traces.Trace_Handle;
+      E       : Ada.Exceptions.Exception_Occurrence;
+      Message : String := "");
+   --  Log an exception in the given traces, with an optional message
+
+end LSP.Common;

--- a/source/ada/lsp-lal_utils.adb
+++ b/source/ada/lsp-lal_utils.adb
@@ -15,6 +15,7 @@
 -- of the license.                                                          --
 ------------------------------------------------------------------------------
 
+with LSP.Common;        use LSP.Common;
 with Libadalang.Common; use Libadalang.Common;
 
 package body LSP.Lal_Utils is
@@ -59,6 +60,7 @@ package body LSP.Lal_Utils is
 
    function Resolve_Name
      (Name_Node : Name;
+      Trace     : GNATCOLL.Traces.Trace_Handle;
       Imprecise : out Boolean) return Defining_Name
    is
       Result : Defining_Name;
@@ -74,7 +76,8 @@ package body LSP.Lal_Utils is
               (Imprecise_Fallback => False).P_Canonical_Part;
          end if;
       exception
-         when Property_Error =>
+         when E : Property_Error =>
+            Log (Trace, E);
             Result := No_Defining_Name;
       end;
 
@@ -95,7 +98,8 @@ package body LSP.Lal_Utils is
       return Result;
 
    exception
-      when Property_Error =>
+      when E : Property_Error =>
+         Log (Trace, E);
          return No_Defining_Name;
    end Resolve_Name;
 

--- a/source/ada/lsp-lal_utils.ads
+++ b/source/ada/lsp-lal_utils.ads
@@ -21,6 +21,7 @@ with Ada.Containers.Ordered_Maps;
 with Ada.Containers.Doubly_Linked_Lists;
 
 with GNATCOLL.VFS;
+with GNATCOLL.Traces;
 
 with LSP.Ada_Contexts;
 
@@ -35,6 +36,7 @@ package LSP.Lal_Utils is
 
    function Resolve_Name
      (Name_Node : Name;
+      Trace     : GNATCOLL.Traces.Trace_Handle;
       Imprecise : out Boolean) return Defining_Name;
    --  Return the definition node (canonical part) of the given name.
    --  Imprecise is set to True if LAL's imprecise fallback mechanism has been


### PR DESCRIPTION
We're often expecting this exception and catching it so that
the user does not see it: capture these in the traces, to ease
debugging and investigation.