### PR TITLE
SA09-029 Fix non-determinism in cancelRequest test.

### DIFF
--- a/source/server/lsp-servers.adb
+++ b/source/server/lsp-servers.adb
@@ -732,8 +732,13 @@ package body LSP.Servers is
    ------------------------
 
    function Input_Queue_Length (Self : Server) return Natural is
+      Result : Natural := Natural (Self.Input_Queue.Current_Use);
    begin
-      return Natural (Self.Input_Queue.Current_Use);
+      if Self.Look_Ahead /= null then
+         Result := Result + 1;  --  One extra message in the look ahead buffer
+      end if;
+
+      return Result;
    end Input_Queue_Length;
 
    ---------------------

--- a/testsuite/ada_lsp/cancel/cancel.json
+++ b/testsuite/ada_lsp/cancel/cancel.json
@@ -87,7 +87,13 @@
                 "method": "$/cancelRequest",
                 "params": {"id": "defname-1"}
             },
-            "wait":[]
+            "wait":[{
+                "id": "defname-1",
+                "error": {
+                    "code":-32800,
+                    "message":"Request was canceled"
+                }
+            }]
         }
     }, {
         "send": {
@@ -106,12 +112,6 @@
                 }
             },
             "wait":[{
-                "id": "defname-1",
-                "error": {
-                    "code":-32800,
-                    "message":"Request was canceled"
-                }
-            }, {
                 "id": "defname-2",
                 "result":[{
                     "uri": "$URI{aaa.adb}",


### PR DESCRIPTION
The "Cancel Test" is buggy because it waits to "canceled" response too late,
we should wit for it in cancel notification directly, otherwise test could
miss it.
On the other side implemetation of Input_Queue_Length is incorrect, because
it doesn't take into account the look ahead buffer.