### PR TITLE
SA07-038 Fix version and file names.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Current features:
  * Document symbol search
 
 We also provide [Visual Studio Code](https://code.visualstudio.com/)
-[extension as .vsix file](https://dl.bintray.com/reznikmm/ada-language-server/ada-0.0.1.vsix).
+[extension as .vsix file](https://dl.bintray.com/reznikmm/ada-language-server/ada-20.0.999.vsix).
 
 ## Install
 
@@ -26,11 +26,11 @@ To install binary image download an archive corresponding to your OS and unpack 
 somewhere. You will find `ada_language_server` inside unpacked folder.
 We provide binaries for
  * Linux x86_64 - take
-[linux.tar.gz](https://dl.bintray.com/reznikmm/ada-language-server/linux.tar.gz)
+[linux.tar.gz](https://dl.bintray.com/reznikmm/ada-language-server/linux-latest.tar.gz)
  * Window 64 bit - take
-[win32.zip](https://dl.bintray.com/reznikmm/ada-language-server/win32.zip)
+[win32.zip](https://dl.bintray.com/reznikmm/ada-language-server/win32-latest.zip)
  * Mac OS X - take
-[darwin.tar.gz](https://dl.bintray.com/reznikmm/ada-language-server/darwin.tar.gz)
+[darwin.tar.gz](https://dl.bintray.com/reznikmm/ada-language-server/darwin-latest.tar.gz)
 
 To build is from source install dependencies and run
 ```

--- a/integration/travis/deploy.sh
+++ b/integration/travis/deploy.sh
@@ -74,7 +74,10 @@ function vsix_deploy()
     sed -e 's/:white_check_mark:/Yes               /g' README.md > \
       integration/vscode/ada/README.md
     cp -f LICENSE integration/vscode/ada/
-    sed -i -e "s/VERSION/$TAG/g" integration/vscode/ada/package.json
+
+    [ -z "$TRAVIS_TAG" ] || sed -i -e "/version/s/[0-9][0-9.]*/$TAG/" \
+      integration/vscode/ada/package.json
+
     pushd integration/vscode/ada
 
     wget -nv -Owin32.zip \

--- a/integration/vscode/ada/package.json
+++ b/integration/vscode/ada/package.json
@@ -2,7 +2,7 @@
     "name": "ada",
     "displayName": "Language Support for Ada",
     "description": "A Language Server providing Ada and SPARK support in Visual Studio Code",
-    "version": "VERSION",
+    "version": "20.0.999",
     "publisher": "MaximReznik",
     "license": "GPL-3.0",
     "repository": {


### PR DESCRIPTION
As I introduced versioning for ALS community release I accidentally broke
vscode package. Also binary archives for master branch changed their names.

I fix this in patch. So, for master branch:
 * vsix extension now has version 20.0.999 (that correspond to GPS 20.0w)
 * its file name is ada-20.0.999.vsix
 * ALS for Linux is linux-latest.tar.gz
 * ALS for Windows is win32-latest.zip
 * ALS for Darwin is darwin-latest.tar.gz