### PR TITLE
SA11-040 Add a fallback mechanism for 'definition'

### DIFF
--- a/source/ada/lsp-lal_utils.ads
+++ b/source/ada/lsp-lal_utils.ads
@@ -41,6 +41,27 @@ package LSP.Lal_Utils is
    --  Imprecise is set to True if LAL's imprecise fallback mechanism has been
    --  used to compute the cross reference.
 
+   function Find_Next_Part
+     (Definition : Defining_Name;
+      Trace      : GNATCOLL.Traces.Trace_Handle) return Defining_Name;
+   --  Wrapper around P_Next_Part which returns No_Defining_Name if this
+   --  called returns Definition, and catches and traces Property_Error.
+
+   function Find_Canonical_Part
+     (Definition : Defining_Name;
+      Trace      : GNATCOLL.Traces.Trace_Handle) return Defining_Name;
+   --  Wrapper around P_Next_Part which catches the case when it returns self,
+   --  and catches and traces Property_Error.
+
+   function Find_Other_Part_Fallback
+     (Definition : Defining_Name;
+      Trace      : GNATCOLL.Traces.Trace_Handle) return Defining_Name;
+   --  Attempt to find the other part of a definition manually, with
+   --  simple heuristics that look at the available entities with matching
+   --- names and profiles.
+   --  This should be called only if straightforward Libadalang calls
+   --  have failed.
+
    ---------------
    -- Called_By --
    ---------------

--- a/testsuite/ada_lsp/SA11-040.definition.fallback/p.adb
+++ b/testsuite/ada_lsp/SA11-040.definition.fallback/p.adb
@@ -1,0 +1,29 @@
+package body P is
+
+   ---------
+   -- Foo --
+   ---------
+
+   procedure Foo (A : Integer) is
+   begin
+      null;
+   end Foo;
+
+   ------------
+   -- Nested --
+   ------------
+
+   package body Nested is
+
+      procedure Foo (A : Integer) is
+      begin
+         null;
+      end Foo;
+
+      procedure Bla (A : Integer; Other_Param : Boolean) is null;
+
+   end Nested;
+
+   procedure Bla is null;
+
+end P;

--- a/testsuite/ada_lsp/SA11-040.definition.fallback/p.ads
+++ b/testsuite/ada_lsp/SA11-040.definition.fallback/p.ads
@@ -1,0 +1,13 @@
+package P is
+
+   procedure Foo (A : Integer; Other_Param : Boolean);
+
+   package Nested is
+      procedure Foo (A : Integer);
+
+      procedure Bla (A : Integer);
+   end Nested;
+
+   procedure Bla (A : Integer);
+
+end P;

--- a/testsuite/ada_lsp/SA11-040.definition.fallback/p.gpr
+++ b/testsuite/ada_lsp/SA11-040.definition.fallback/p.gpr
@@ -1,0 +1,2 @@
+project P is
+end P;

--- a/testsuite/ada_lsp/SA11-040.definition.fallback/test.json
+++ b/testsuite/ada_lsp/SA11-040.definition.fallback/test.json
@@ -1,0 +1,258 @@
+[
+   {
+      "comment": [
+         "test the fallback navigation to subprograms that don't have an exact profile"
+      ]
+   }, 
+   {
+      "start": {
+         "cmd": [
+            "${ALS}"
+         ]
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "capabilities": {
+                  "workspace": {
+                     "applyEdit": false
+                  }
+               }, 
+               "rootUri": "$URI{.}"
+            }, 
+            "jsonrpc": "2.0", 
+            "id": 1, 
+            "method": "initialize"
+         }, 
+         "wait": [
+            {
+               "id": 1, 
+               "result": {
+                  "capabilities": {
+                     "typeDefinitionProvider": true, 
+                     "alsReferenceKinds": [
+                        "write", 
+                        "call", 
+                        "dispatching call"
+                     ], 
+                     "hoverProvider": true, 
+                     "definitionProvider": true, 
+                     "renameProvider": true, 
+                     "alsCalledByProvider": true, 
+                     "referencesProvider": true, 
+                     "textDocumentSync": 1, 
+                     "completionProvider": {
+                        "triggerCharacters": [
+                           "."
+                        ], 
+                        "resolveProvider": false
+                     }, 
+                     "documentSymbolProvider": true
+                  }
+               }
+            }
+         ]
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0", 
+            "method": "initialized"
+         }, 
+         "wait": []
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "settings": {
+                  "ada": {
+                     "scenarioVariables": {}, 
+                     "enableDiagnostics": false, 
+                     "defaultCharset": "ISO-8859-1"
+                  }
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "method": "workspace/didChangeConfiguration"
+         }, 
+         "wait": []
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "text": "package P is\n\n   procedure Foo (A : Integer; Other_Param : Boolean);\n\n   package Nested is\n      procedure Foo (A : Integer);\n\n      procedure Bla (A : Integer);\n   end Nested;\n\n   procedure Bla (A : Integer);\n\nend P;\n", 
+                  "version": 0, 
+                  "uri": "$URI{p.ads}", 
+                  "languageId": "Ada"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "method": "textDocument/didOpen"
+         }, 
+         "wait": []
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "position": {
+                  "line": 2, 
+                  "character": 13
+               }, 
+               "textDocument": {
+                  "uri": "$URI{p.ads}"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "id": 2, 
+            "method": "textDocument/definition"
+         }, 
+         "wait": [
+            {
+               "params": {
+                  "message": "The result of 'definition' is approximate.", 
+                  "type": 2
+               }, 
+               "method": "window/showMessage"
+            }, 
+            {
+               "id": 2, 
+               "result": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 6, 
+                           "character": 13
+                        }, 
+                        "end": {
+                           "line": 6, 
+                           "character": 16
+                        }
+                     }, 
+                     "uri": "$URI{p.adb}"
+                  }
+               ]
+            }
+         ]
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "text": "package body P is\n\n   ---------\n   -- Foo --\n   ---------\n\n   procedure Foo (A : Integer) is\n   begin\n      null;\n   end Foo;\n\n   ------------\n   -- Nested --\n   ------------\n\n   package body Nested is\n\n      procedure Foo (A : Integer) is\n      begin\n         null;\n      end Foo;\n\n      procedure Bla (A : Integer; Other_Param : Boolean) is null;\n\n   end Nested;\n\n   procedure Bla is null;\n\nend P;\n", 
+                  "version": 0, 
+                  "uri": "$URI{p.adb}", 
+                  "languageId": "Ada"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "method": "textDocument/didOpen"
+         }, 
+         "wait": []
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "position": {
+                  "line": 22, 
+                  "character": 16
+               }, 
+               "textDocument": {
+                  "uri": "$URI{p.adb}"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "id": 3, 
+            "method": "textDocument/definition"
+         }, 
+         "wait": [
+            {
+               "params": {
+                  "message": "The result of 'definition' is approximate.", 
+                  "type": 2
+               }, 
+               "method": "window/showMessage"
+            }, 
+            {
+               "id": 3, 
+               "result": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 7, 
+                           "character": 16
+                        }, 
+                        "end": {
+                           "line": 7, 
+                           "character": 19
+                        }
+                     }, 
+                     "uri": "$URI{p.ads}"
+                  }
+               ]
+            }
+         ]
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{p.ads}"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "method": "textDocument/didClose"
+         }, 
+         "wait": []
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{p.adb}"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "method": "textDocument/didClose"
+         }, 
+         "wait": []
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0", 
+            "id": 4, 
+            "method": "shutdown"
+         }, 
+         "wait": [
+            {
+               "id": 4, 
+               "result": null
+            }
+         ]
+      }
+   }, 
+   {
+      "stop": {
+         "exit_code": 0
+      }
+   }
+]

--- a/testsuite/ada_lsp/SA11-040.definition.fallback/test.yaml
+++ b/testsuite/ada_lsp/SA11-040.definition.fallback/test.yaml
@@ -1,0 +1,1 @@
+title: 'SA11-040.definition.fallback'


### PR DESCRIPTION
This mechanism is based on a naive heuristics and is meant
for the language server to be able to provide navigation from
a subprogram spec to the body (and vice versa) after modifying
the profile in one of the parts but not the other.

Add a test.