### PR TITLE
SB15-028 Filter out some diagnostics

### DIFF
--- a/source/ada/lsp-ada_documents.adb
+++ b/source/ada/lsp-ada_documents.adb
@@ -110,9 +110,13 @@ package body LSP.Ada_Documents is
               (Ada.Strings.Wide_Wide_Unbounded.To_Wide_Wide_String
                  (Error.Message));
 
-            Errors.Append (Item);
-            Nb_Diags := Nb_Diags + 1;
-            exit when Nb_Diags >= MAX_NB_DIAGNOSTICS;
+            --  Filter out diagnostics that simply report "Cannot parse <..>",
+            --  as these are generally not useful to the end user.
+            if not LSP.Types.Starts_With (Item.message, "Cannot parse <") then
+               Errors.Append (Item);
+               Nb_Diags := Nb_Diags + 1;
+               exit when Nb_Diags >= MAX_NB_DIAGNOSTICS;
+            end if;
          end loop;
       end if;
    end Get_Errors;

--- a/testsuite/ada_lsp/incorrect_fallback/incorrect_fallback.json
+++ b/testsuite/ada_lsp/incorrect_fallback/incorrect_fallback.json
@@ -170,19 +170,6 @@
                         "range": {
                            "start": {
                               "line": 7, 
-                              "character": 3
-                           }, 
-                           "end": {
-                              "line": 7, 
-                              "character": 6
-                           }
-                        }, 
-                        "message": "Cannot parse <name>"
-                     }, 
-                     {
-                        "range": {
-                           "start": {
-                              "line": 7, 
                               "character": 13
                            }, 
                            "end": {
@@ -191,6 +178,19 @@
                            }
                         }, 
                         "message": "Expected '<>', got ')'"
+                     },
+                     {
+                        "range": {
+                          "start": {
+                            "line": 7,
+                            "character": 13
+                          },
+                          "end": {
+                            "line": 7,
+                            "character": 14
+                          }
+                        },
+                        "message": "Missing ';'"
                      }
                   ]
                }, 

--- a/testsuite/ada_lsp/publish_diag/publish_diag.json
+++ b/testsuite/ada_lsp/publish_diag/publish_diag.json
@@ -71,32 +71,32 @@
                 "params":{
                     "uri":"$URI{aaa.ads}",
                     "diagnostics": [
-                      {
-                        "range": {
-                          "start": {
-                            "line": 1,
-                            "character": 3
+                        {
+                          "range": {
+                            "start": {
+                              "line": 1,
+                              "character": 20
+                            },
+                            "end": {
+                              "line": 1,
+                              "character": 21
+                            }
                           },
-                          "end": {
-                            "line": 1,
-                            "character": 4
-                          }
+                          "message": "Expected '(', got '''"
                         },
-                        "message": "Cannot parse <sub_object_decl>"
-                      },
-                      {
-                        "range": {
-                          "start": {
-                            "line": 1,
-                            "character": 20
+                        {
+                          "range": {
+                            "start": {
+                              "line": 1,
+                              "character": 20
+                            },
+                            "end": {
+                              "line": 1,
+                              "character": 21
+                            }
                           },
-                          "end": {
-                            "line": 1,
-                            "character": 21
-                          }
-                        },
-                        "message": "Expected '(', got '''"
-                      }
+                          "message": "Skipped token '"
+                        }
                     ]
                 }
             }]


### PR DESCRIPTION
Diagnostics of the form "Cannot parse <..>" are not
generally interesting to the end user: filter them out
from the list of diagnostics being reported.