### PR TITLE
SA22-029 Rename also in comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,11 @@ files from disk by specifying an `"ada.defaultCharset"` key. The default is
 `iso-8859-1`.
 
 You can explicitly deactivate the emission of diagnostics, via the
-`"ada.enableDiagnostics` key. By default, diagnostics are enabled.
+`"ada.enableDiagnostics"` key. By default, diagnostics are enabled.
+
+By default, the server indexes the source files after loading a project,
+to speed up subsequent requests. This behavior can be controlled
+via the `"ada.enableIndexing"` flag in this request.
 
 Here is an example config file from the gnatcov project:
 

--- a/doc/specification-3-14.md
+++ b/doc/specification-3-14.md
@@ -1,0 +1,4460 @@
+---
+title: Specification
+shortTitle: 3.14 - Current
+layout: specifications
+sectionid: specification-3-14
+toc: specification-3-14-toc
+index: 1
+redirect_from:
+  - /specification
+---
+# Language Server Protocol Specification - 3.14
+
+This document describes version 3.14.x of the language server protocol. An implementation for node of the 3.14.x version of the protocol can be found [here](https://github.com/Microsoft/vscode-languageserver-node).
+
+The 2.x version of this document can be found [here](https://github.com/Microsoft/language-server-protocol/blob/master/versions/protocol-2-x.md).
+The 1.x version of this document can be found [here](https://github.com/Microsoft/language-server-protocol/blob/master/versions/protocol-1-x.md).
+
+**Note:** edits to this specification can be made via a pull request against this markdown [document](https://github.com/Microsoft/language-server-protocol/blob/gh-pages/specification.md).
+
+## Base Protocol
+
+The base protocol consists of a header and a content part (comparable to HTTP). The header and content part are
+separated by a '\r\n'.
+
+### Header Part
+
+The header part consists of header fields. Each header field is comprised of a name and a value,
+separated by ': ' (a colon and a space).
+Each header field is terminated by '\r\n'.
+Considering the last header field and the overall header itself are each terminated with '\r\n',
+and that at least one header is mandatory, this means that two '\r\n' sequences always
+immediately precede the content part of a message.
+
+Currently the following header fields are supported:
+
+| Header Field Name | Value Type  | Description |
+|:------------------|:------------|:------------|
+| Content-Length    | number      | The length of the content part in bytes. This header is required. |
+| Content-Type      | string      | The mime type of the content part. Defaults to application/vscode-jsonrpc; charset=utf-8 |
+{: .table .table-bordered .table-responsive}
+
+The header part is encoded using the 'ascii' encoding. This includes the '\r\n' separating the header and content part.
+
+### Content Part
+
+Contains the actual content of the message. The content part of a message uses [JSON-RPC](http://www.jsonrpc.org/) to describe requests, responses and notifications. The content part is encoded using the charset provided in the Content-Type field. It defaults to `utf-8`, which is the only encoding supported right now. If a server or client receives a header with a different encoding then `utf-8` it should respond with an error.
+
+(Prior versions of the protocol used the string constant `utf8` which is not a correct encoding constant according to [specification](http://www.iana.org/assignments/character-sets/character-sets.xhtml).) For backwards compatibility it is highly recommended that a client and a server treats the string `utf8` as `utf-8`.
+
+### Example:
+
+```
+Content-Length: ...\r\n
+\r\n
+{
+	"jsonrpc": "2.0",
+	"id": 1,
+	"method": "textDocument/didOpen",
+	"params": {
+		...
+	}
+}
+```
+### Base Protocol JSON structures
+
+The following TypeScript definitions describe the base [JSON-RPC protocol](http://www.jsonrpc.org/specification):
+
+#### Abstract Message
+
+A general message as defined by JSON-RPC. The language server protocol always uses "2.0" as the `jsonrpc` version.
+
+```typescript
+interface Message {
+	jsonrpc: string;
+}
+```
+#### Request Message
+
+A request message to describe a request between the client and the server. Every processed request must send a response back to the sender of the request.
+
+```typescript
+interface RequestMessage extends Message {
+
+	/**
+	 * The request id.
+	 */
+	id: number | string;
+
+	/**
+	 * The method to be invoked.
+	 */
+	method: string;
+
+	/**
+	 * The method's params.
+	 */
+	params?: Array<any> | object;
+}
+```
+
+#### Response Message
+
+A Response Message sent as a result of a request. If a request doesn't provide a result value the receiver of a request still needs to return a response message to conform to the JSON RPC specification. The result property of the ResponseMessage should be set to `null` in this case to signal a successful request.
+
+```typescript
+interface ResponseMessage extends Message {
+	/**
+	 * The request id.
+	 */
+	id: number | string | null;
+
+	/**
+	 * The result of a request. This member is REQUIRED on success.
+	 * This member MUST NOT exist if there was an error invoking the method.
+	 */
+	result?: string | number | boolean | object | null;
+
+	/**
+	 * The error object in case a request fails.
+	 */
+	error?: ResponseError<any>;
+}
+
+interface ResponseError<D> {
+	/**
+	 * A number indicating the error type that occurred.
+	 */
+	code: number;
+
+	/**
+	 * A string providing a short description of the error.
+	 */
+	message: string;
+
+	/**
+	 * A Primitive or Structured value that contains additional
+	 * information about the error. Can be omitted.
+	 */
+	data?: D;
+}
+
+export namespace ErrorCodes {
+	// Defined by JSON RPC
+	export const ParseError: number = -32700;
+	export const InvalidRequest: number = -32600;
+	export const MethodNotFound: number = -32601;
+	export const InvalidParams: number = -32602;
+	export const InternalError: number = -32603;
+	export const serverErrorStart: number = -32099;
+	export const serverErrorEnd: number = -32000;
+	export const ServerNotInitialized: number = -32002;
+	export const UnknownErrorCode: number = -32001;
+
+	// Defined by the protocol.
+	export const RequestCancelled: number = -32800;
+	export const ContentModified: number = -32801;
+}
+```
+#### Notification Message
+
+A notification message. A processed notification message must not send a response back. They work like events.
+
+```typescript
+interface NotificationMessage extends Message {
+	/**
+	 * The method to be invoked.
+	 */
+	method: string;
+
+	/**
+	 * The notification's params.
+	 */
+	params?: Array<any> | object;
+}
+```
+
+#### $ Notifications and Requests
+
+Notification and requests whose methods start with '$/' are messages which are protocol implementation dependent and might not be implementable in all clients or servers. For example if the server implementation uses a single threaded synchronous programming language then there is little a server can do to react to a '$/cancelRequest' notification. If a server or client receives notifications starting with '$/' it is free to ignore the notification. If a server or client receives a requests starting with '$/' it must error the request with error code `MethodNotFound` (e.g. `-32601`).
+
+#### <a href="#cancelRequest" name="cancelRequest" class="anchor"> Cancellation Support (:arrow_right: :arrow_left:)</a>
+
+The base protocol offers support for request cancellation. To cancel a request, a notification message with the following properties is sent:
+
+_Notification_:
+* method: '$/cancelRequest'
+* params: `CancelParams` defined as follows:
+
+```typescript
+interface CancelParams {
+	/**
+	 * The request id to cancel.
+	 */
+	id: number | string;
+}
+```
+
+A request that got canceled still needs to return from the server and send a response back. It can not be left open / hanging. This is in line with the JSON RPC protocol that requires that every request sends a response back. In addition it allows for returning partial results on cancel. If the request returns an error response on cancellation it is advised to set the error code to `ErrorCodes.RequestCancelled`.
+
+## Language Server Protocol
+
+The language server protocol defines a set of JSON-RPC request, response and notification messages which are exchanged using the above base protocol. This section starts describing the basic JSON structures used in the protocol. The document uses TypeScript interfaces to describe these. Based on the basic JSON structures, the actual requests with their responses and the notifications are described.
+
+In general, the language server protocol supports JSON-RPC messages, however the base protocol defined here uses a convention such that the parameters passed to request/notification messages should be of `object` type (if passed at all). However, this does not disallow using `Array` parameter types in custom messages.
+
+The protocol currently assumes that one server serves one tool. There is currently no support in the protocol to share one server between different tools. Such a sharing would require additional protocol e.g. to lock a document to support concurrent editing.
+
+### Basic JSON Structures
+
+#### URI
+
+URI's are transferred as strings. The URI's format is defined in [http://tools.ietf.org/html/rfc3986](http://tools.ietf.org/html/rfc3986)
+
+```
+  foo://example.com:8042/over/there?name=ferret#nose
+  \_/   \______________/\_________/ \_________/ \__/
+   |           |            |            |        |
+scheme     authority       path        query   fragment
+   |   _____________________|__
+  / \ /                        \
+  urn:example:animal:ferret:nose
+```
+
+We also maintain a node module to parse a string into `scheme`, `authority`, `path`, `query`, and `fragment` URI components. The GitHub repository is [https://github.com/Microsoft/vscode-uri](https://github.com/Microsoft/vscode-uri) the npm module is [https://www.npmjs.com/package/vscode-uri](https://www.npmjs.com/package/vscode-uri).
+
+Many of the interfaces contain fields that correspond to the URI of a document. For clarity, the type of such a field is declared as a `DocumentUri`. Over the wire, it will still be transferred as a string, but this guarantees that the contents of that string can be parsed as a valid URI.
+
+```typescript
+type DocumentUri = string;
+```
+
+#### Text Documents
+
+The current protocol is tailored for textual documents whose content can be represented as a string. There is currently no support for binary documents. A position inside a document (see Position definition below) is expressed as a zero-based line and character offset. The offsets are based on a UTF-16 string representation. So a string of the form `a𐐀b` the character offset of the character `a` is 0, the character offset of `𐐀` is 1 and the character offset of b is 3 since `𐐀` is represented using two code units in UTF-16. To ensure that both client and server split the string into the same line representation the protocol specifies the following end-of-line sequences: '\n', '\r\n' and '\r'.
+
+Positions are line end character agnostic. So you can not specify  a position that denotes `\r|\n` or `\n|` where `|` represents the character offset.
+
+```typescript
+export const EOL: string[] = ['\n', '\r\n', '\r'];
+```
+
+#### Position
+
+Position in a text document expressed as zero-based line and zero-based character offset. A position is between two characters like an 'insert' cursor in a editor. Special values like for example `-1` to denote the end of a line are not supported.
+
+```typescript
+interface Position {
+	/**
+	 * Line position in a document (zero-based).
+	 */
+	line: number;
+
+	/**
+	 * Character offset on a line in a document (zero-based). Assuming that the line is
+	 * represented as a string, the `character` value represents the gap between the
+	 * `character` and `character + 1`.
+	 *
+	 * If the character value is greater than the line length it defaults back to the
+	 * line length.
+	 */
+	character: number;
+}
+```
+#### Range
+
+A range in a text document expressed as (zero-based) start and end positions. A range is comparable to a selection in an editor. Therefore the end position is exclusive. If you want to specify a range that contains a line including the line ending character(s) then use an end position denoting the start of the next line. For example:
+```typescript
+{
+    start: { line: 5, character: 23 },
+    end : { line 6, character : 0 }
+}
+```
+
+```typescript
+interface Range {
+	/**
+	 * The range's start position.
+	 */
+	start: Position;
+
+	/**
+	 * The range's end position.
+	 */
+	end: Position;
+}
+```
+
+#### Location
+
+Represents a location inside a resource, such as a line inside a text file.
+```typescript
+interface Location {
+	uri: DocumentUri;
+	range: Range;
+}
+```
+
+#### LocationLink
+
+Represents a link between a source and a target location.
+
+```typescript
+interface LocationLink {
+
+	/**
+	 * Span of the origin of this link.
+	 *
+	 * Used as the underlined span for mouse interaction. Defaults to the word range at
+	 * the mouse position.
+	 */
+	originSelectionRange?: Range;
+
+	/**
+	 * The target resource identifier of this link.
+	 */
+	targetUri: DocumentUri;
+
+	/**
+	 * The full target range of this link. If the target for example is a symbol then target range is the
+	 * range enclosing this symbol not including leading/trailing whitespace but everything else
+	 * like comments. This information is typically used to highlight the range in the editor.
+	 */
+	targetRange: Range;
+
+	/**
+	 * The range that should be selected and revealed when this link is being followed, e.g the name of a function.
+	 * Must be contained by the the `targetRange`. See also `DocumentSymbol#range`
+	 */
+	targetSelectionRange: Range;
+}
+```
+
+#### Diagnostic
+
+Represents a diagnostic, such as a compiler error or warning. Diagnostic objects are only valid in the scope of a resource.
+
+```typescript
+interface Diagnostic {
+	/**
+	 * The range at which the message applies.
+	 */
+	range: Range;
+
+	/**
+	 * The diagnostic's severity. Can be omitted. If omitted it is up to the
+	 * client to interpret diagnostics as error, warning, info or hint.
+	 */
+	severity?: number;
+
+	/**
+	 * The diagnostic's code, which might appear in the user interface.
+	 */
+	code?: number | string;
+
+	/**
+	 * A human-readable string describing the source of this
+	 * diagnostic, e.g. 'typescript' or 'super lint'.
+	 */
+	source?: string;
+
+	/**
+	 * The diagnostic's message.
+	 */
+	message: string;
+
+	/**
+	 * An array of related diagnostic information, e.g. when symbol-names within
+	 * a scope collide all definitions can be marked via this property.
+	 */
+	relatedInformation?: DiagnosticRelatedInformation[];
+}
+```
+
+The protocol currently supports the following diagnostic severities:
+
+```typescript
+namespace DiagnosticSeverity {
+	/**
+	 * Reports an error.
+	 */
+	export const Error = 1;
+	/**
+	 * Reports a warning.
+	 */
+	export const Warning = 2;
+	/**
+	 * Reports an information.
+	 */
+	export const Information = 3;
+	/**
+	 * Reports a hint.
+	 */
+	export const Hint = 4;
+}
+```
+
+```typescript
+/**
+ * Represents a related message and source code location for a diagnostic. This should be
+ * used to point to code locations that cause or related to a diagnostics, e.g when duplicating
+ * a symbol in a scope.
+ */
+export interface DiagnosticRelatedInformation {
+	/**
+	 * The location of this related diagnostic information.
+	 */
+	location: Location;
+
+	/**
+	 * The message of this related diagnostic information.
+	 */
+	message: string;
+}
+```
+
+#### Command
+
+Represents a reference to a command. Provides a title which will be used to represent a command in the UI. Commands are identified by a string identifier. The recommended way to handle commands is to implement their execution on the server side if the client and server provides the corresponding capabilities. Alternatively the tool extension code could handle the command. The protocol currently doesn't specify a set of well-known commands.
+
+```typescript
+interface Command {
+	/**
+	 * Title of the command, like `save`.
+	 */
+	title: string;
+	/**
+	 * The identifier of the actual command handler.
+	 */
+	command: string;
+	/**
+	 * Arguments that the command handler should be
+	 * invoked with.
+	 */
+	arguments?: any[];
+}
+```
+
+#### TextEdit
+
+A textual edit applicable to a text document.
+
+```typescript
+interface TextEdit {
+	/**
+	 * The range of the text document to be manipulated. To insert
+	 * text into a document create a range where start === end.
+	 */
+	range: Range;
+
+	/**
+	 * The string to be inserted. For delete operations use an
+	 * empty string.
+	 */
+	newText: string;
+}
+```
+
+#### TextEdit[]
+
+Complex text manipulations are described with an array of `TextEdit`'s, representing a single change to the document.
+
+All text edits ranges refer to positions in the original document. Text edits ranges must never overlap, that means no part of the original document must be manipulated by more than one edit. However, it is possible that multiple edits have the same start position: multiple inserts, or any number of inserts followed by a single remove or replace edit. If multiple inserts have the same position, the order in the array defines the order in which the inserted strings appear in the resulting text.
+
+#### TextDocumentEdit
+
+Describes textual changes on a single text document. The text document is referred to as a `VersionedTextDocumentIdentifier` to allow clients to check the text document version before an edit is applied. A `TextDocumentEdit` describes all changes on a version Si and after they are applied move the document to version Si+1. So the creator of a `TextDocumentEdit` doesn't need to sort the array or do any kind of ordering. However the edits must be non overlapping.
+
+```typescript
+export interface TextDocumentEdit {
+	/**
+	 * The text document to change.
+	 */
+	textDocument: VersionedTextDocumentIdentifier;
+
+	/**
+	 * The edits to be applied.
+	 */
+	edits: TextEdit[];
+}
+```
+
+### File Resource changes
+
+> New in version 3.13:
+
+File resource changes allow servers to create, rename and delete files and folders via the client. Note that the names talk about files but the operations are supposed to work on files and folders. This is in line with other naming in the Language Server Protocol (see file watchers which can watch files and folders). The corresponding change literals look as follows:
+
+```typescript
+/**
+ * Options to create a file.
+ */
+export interface CreateFileOptions {
+	/**
+	 * Overwrite existing file. Overwrite wins over `ignoreIfExists`
+	 */
+	overwrite?: boolean;
+	/**
+	 * Ignore if exists.
+	 */
+	ignoreIfExists?: boolean;
+}
+
+/**
+ * Create file operation
+ */
+export interface CreateFile {
+	/**
+	 * A create
+	 */
+	kind: 'create';
+	/**
+	 * The resource to create.
+	 */
+	uri: DocumentUri;
+	/**
+	 * Additional options
+	 */
+	options?: CreateFileOptions;
+}
+
+/**
+ * Rename file options
+ */
+export interface RenameFileOptions {
+	/**
+	 * Overwrite target if existing. Overwrite wins over `ignoreIfExists`
+	 */
+	overwrite?: boolean;
+	/**
+	 * Ignores if target exists.
+	 */
+	ignoreIfExists?: boolean;
+}
+
+/**
+ * Rename file operation
+ */
+export interface RenameFile {
+	/**
+	 * A rename
+	 */
+	kind: 'rename';
+	/**
+	 * The old (existing) location.
+	 */
+	oldUri: DocumentUri;
+	/**
+	 * The new location.
+	 */
+	newUri: DocumentUri;
+	/**
+	 * Rename options.
+	 */
+	options?: RenameFileOptions;
+}
+
+/**
+ * Delete file options
+ */
+export interface DeleteFileOptions {
+	/**
+	 * Delete the content recursively if a folder is denoted.
+	 */
+	recursive?: boolean;
+	/**
+	 * Ignore the operation if the file doesn't exist.
+	 */
+	ignoreIfNotExists?: boolean;
+}
+
+/**
+ * Delete file operation
+ */
+export interface DeleteFile {
+	/**
+	 * A delete
+	 */
+	kind: 'delete';
+	/**
+	 * The file to delete.
+	 */
+	uri: DocumentUri;
+	/**
+	 * Delete options.
+	 */
+	options?: DeleteFileOptions;
+}
+```
+
+#### WorkspaceEdit
+
+A workspace edit represents changes to many resources managed in the workspace. The edit should either provide `changes` or `documentChanges`. If the client can handle versioned document edits and if `documentChanges` are present, the latter are preferred over `changes`.
+
+```typescript
+export interface WorkspaceEdit {
+	/**
+	 * Holds changes to existing resources.
+	 */
+	changes?: { [uri: DocumentUri]: TextEdit[]; };
+
+	/**
+	 * Depending on the client capability `workspace.workspaceEdit.resourceOperations` document changes
+	 * are either an array of `TextDocumentEdit`s to express changes to n different text documents
+	 * where each text document edit addresses a specific version of a text document. Or it can contain
+	 * above `TextDocumentEdit`s mixed with create, rename and delete file / folder operations.
+	 *
+	 * Whether a client supports versioned document edits is expressed via
+	 * `workspace.workspaceEdit.documentChanges` client capability.
+	 *
+	 * If a client neither supports `documentChanges` nor `workspace.workspaceEdit.resourceOperations` then
+	 * only plain `TextEdit`s using the `changes` property are supported.
+	 */
+	documentChanges?: (TextDocumentEdit[] | (TextDocumentEdit | CreateFile | RenameFile | DeleteFile)[]);
+}
+```
+
+#### TextDocumentIdentifier
+
+Text documents are identified using a URI. On the protocol level, URIs are passed as strings. The corresponding JSON structure looks like this:
+```typescript
+interface TextDocumentIdentifier {
+	/**
+	 * The text document's URI.
+	 */
+	uri: DocumentUri;
+}
+```
+
+#### TextDocumentItem
+
+An item to transfer a text document from the client to the server.
+
+```typescript
+interface TextDocumentItem {
+	/**
+	 * The text document's URI.
+	 */
+	uri: DocumentUri;
+
+	/**
+	 * The text document's language identifier.
+	 */
+	languageId: string;
+
+	/**
+	 * The version number of this document (it will increase after each
+	 * change, including undo/redo).
+	 */
+	version: number;
+
+	/**
+	 * The content of the opened text document.
+	 */
+	text: string;
+}
+```
+
+Text documents have a language identifier to identify a document on the server side when it handles more than one language to avoid re-interpreting the file extension. If a document refers to one of the programming languages listed below it is recommended that clients use those ids.
+
+Language | Identifier
+-------- | ----------
+ABAP | `abap`
+Windows Bat | `bat`
+BibTeX | `bibtex`
+Clojure | `clojure`
+Coffeescript | `coffeescript`
+C | `c`
+C++ | `cpp`
+C# | `csharp`
+CSS | `css`
+Diff | `diff`
+Dart | `dart`
+Dockerfile | `dockerfile`
+F# | `fsharp`
+Git | `git-commit` and `git-rebase`
+Go | `go`
+Groovy | `groovy`
+Handlebars | `handlebars`
+HTML | `html`
+Ini | `ini`
+Java | `java`
+JavaScript | `javascript`
+JavaScript React | `javascriptreact`
+JSON | `json`
+LaTeX | `latex`
+Less | `less`
+Lua | `lua`
+Makefile | `makefile`
+Markdown | `markdown`
+Objective-C | `objective-c`
+Objective-C++ | `objective-cpp`
+Perl | `perl`
+Perl 6 | `perl6`
+PHP | `php`
+Powershell | `powershell`
+Pug | `jade`
+Python | `python`
+R | `r`
+Razor (cshtml) | `razor`
+Ruby | `ruby`
+Rust | `rust`
+SCSS | `scss` (syntax using curly brackets), `sass` (indented syntax)
+Scala | `scala`
+ShaderLab | `shaderlab`
+Shell Script (Bash) | `shellscript`
+SQL | `sql`
+Swift | `swift`
+TypeScript | `typescript`
+TypeScript React| `typescriptreact`
+TeX | `tex`
+Visual Basic | `vb`
+XML | `xml`
+XSL | `xsl`
+YAML | `yaml`
+{: .table .table-bordered .table-responsive}
+
+#### VersionedTextDocumentIdentifier
+
+An identifier to denote a specific version of a text document.
+
+```typescript
+interface VersionedTextDocumentIdentifier extends TextDocumentIdentifier {
+	/**
+	 * The version number of this document. If a versioned text document identifier
+	 * is sent from the server to the client and the file is not open in the editor
+	 * (the server has not received an open notification before) the server can send
+	 * `null` to indicate that the version is known and the content on disk is the
+	 * truth (as speced with document content ownership).
+	 *
+	 * The version number of a document will increase after each change, including
+	 * undo/redo. The number doesn't need to be consecutive.
+	 */
+	version: number | null;
+}
+```
+
+#### TextDocumentPositionParams
+
+Was `TextDocumentPosition` in 1.0 with inlined parameters.
+
+A parameter literal used in requests to pass a text document and a position inside that document.
+
+```typescript
+interface TextDocumentPositionParams {
+	/**
+	 * The text document.
+	 */
+	textDocument: TextDocumentIdentifier;
+
+	/**
+	 * The position inside the text document.
+	 */
+	position: Position;
+}
+```
+
+#### DocumentFilter
+
+A document filter denotes a document through properties like `language`, `scheme` or `pattern`. An example is a filter that applies to TypeScript files on disk. Another example is a filter the applies to JSON files with name `package.json`:
+```typescript
+{ language: 'typescript', scheme: 'file' }
+{ language: 'json', pattern: '**/package.json' }
+```
+
+```typescript
+export interface DocumentFilter {
+	/**
+	 * A language id, like `typescript`.
+	 */
+	language?: string;
+
+	/**
+	 * A Uri [scheme](#Uri.scheme), like `file` or `untitled`.
+	 */
+	scheme?: string;
+
+	/**
+	 * A glob pattern, like `*.{ts,js}`.
+	 *
+	 * Glob patterns can have the following syntax:
+	 * - `*` to match one or more characters in a path segment
+	 * - `?` to match on one character in a path segment
+	 * - `**` to match any number of path segments, including none
+	 * - `{}` to group conditions (e.g. `**​/*.{ts,js}` matches all TypeScript and JavaScript files)
+	 * - `[]` to declare a range of characters to match in a path segment (e.g., `example.[0-9]` to match on `example.0`, `example.1`, …)
+	 * - `[!...]` to negate a range of characters to match in a path segment (e.g., `example.[!0-9]` to match on `example.a`, `example.b`, but not `example.0`)
+	 */
+	pattern?: string;
+}
+```
+
+A document selector is the combination of one or more document filters.
+
+```typescript
+export type DocumentSelector = DocumentFilter[];
+```
+
+#### MarkupContent
+
+ A `MarkupContent` literal represents a string value which content can be represented in different formats. Currently `plaintext` and `markdown` are supported formats. A `MarkupContent` is usually used in documentation properties of result literals like `CompletionItem` or `SignatureInformation`.
+
+```typescript
+/**
+ * Describes the content type that a client supports in various
+ * result literals like `Hover`, `ParameterInfo` or `CompletionItem`.
+ *
+ * Please note that `MarkupKinds` must not start with a `$`. This kinds
+ * are reserved for internal usage.
+ */
+export namespace MarkupKind {
+	/**
+	 * Plain text is supported as a content format
+	 */
+	export const PlainText: 'plaintext' = 'plaintext';
+
+	/**
+	 * Markdown is supported as a content format
+	 */
+	export const Markdown: 'markdown' = 'markdown';
+}
+export type MarkupKind = 'plaintext' | 'markdown';
+
+/**
+ * A `MarkupContent` literal represents a string value which content is interpreted base on its
+ * kind flag. Currently the protocol supports `plaintext` and `markdown` as markup kinds.
+ *
+ * If the kind is `markdown` then the value can contain fenced code blocks like in GitHub issues.
+ * See https://help.github.com/articles/creating-and-highlighting-code-blocks/#syntax-highlighting
+ *
+ * Here is an example how such a string can be constructed using JavaScript / TypeScript:
+ * ```typescript
+ * let markdown: MarkdownContent = {
+ *  kind: MarkupKind.Markdown,
+ *	value: [
+ *		'# Header',
+ *		'Some text',
+ *		'```typescript',
+ *		'someCode();',
+ *		'```'
+ *	].join('\n')
+ * };
+ * ```
+ *
+ * *Please Note* that clients might sanitize the return markdown. A client could decide to
+ * remove HTML from the markdown to avoid script execution.
+ */
+export interface MarkupContent {
+	/**
+	 * The type of the Markup
+	 */
+	kind: MarkupKind;
+
+	/**
+	 * The content itself
+	 */
+	value: string;
+}
+```
+
+### Actual Protocol
+
+This section documents the actual language server protocol. It uses the following format:
+
+* a header describing the request
+* a _Request_: section describing the format of the request sent. The method is a string identifying the request the params are documented using a TypeScript interface
+* a _Response_: section describing the format of the response. The result item describes the returned data in case of a success. The error.data describes the returned data in case of an error. Please remember that in case of a failure the response already contains an error.code and an error.message field. These fields are only spec'd if the protocol forces the use of certain error codes or messages. In cases where the server can decide on these values freely they aren't listed here.
+* a _Registration Options_ section describing the registration option if the request or notification supports dynamic capability registration.
+
+#### Request, Notification and Response ordering
+
+Responses to requests should be sent in roughly the same order as the requests appear on the server or client side. So for example if a server receives a `textDocument/completion` request and then a `textDocument/signatureHelp` request it will usually first return the response for the `textDocument/completion` and then the response for `textDocument/signatureHelp`.
+
+However, the server may decide to use a parallel execution strategy and may wish to return responses in a different order than the requests were received. The server may do so as long as this reordering doesn't affect the correctness of the responses. For example, reordering the result of `textDocument/completion` and `textDocument/signatureHelp` is allowed, as these each of these requests usually won't affect the output of the other. On the other hand, the server most likely should not reorder `textDocument/definition` and `textDocument/rename` requests, since the executing the latter may affect the result of the former.
+
+#### Server lifetime
+
+The current protocol specification defines that the lifetime of a server is managed by the client (e.g. a tool like VS Code or Emacs). It is up to the client to decide when to start (process-wise) and when to shutdown a server.
+
+#### <a href="#initialize" name="initialize" class="anchor">Initialize Request (:leftwards_arrow_with_hook:)</a>
+
+The initialize request is sent as the first request from the client to the server. If the server receives a request or notification before the `initialize` request it should act as follows:
+
+* For a request the response should be an error with `code: -32002`. The message can be picked by the server.
+* Notifications should be dropped, except for the exit notification. This will allow the exit of a server without an initialize request.
+
+Until the server has responded to the `initialize` request with an `InitializeResult`, the client must not send any additional requests or notifications to the server. In addition the server is not allowed to send any requests or notifications to the client until it has responded with an `InitializeResult`, with the exception that during the `initialize` request the server is allowed to send the notifications `window/showMessage`, `window/logMessage` and `telemetry/event` as well as the `window/showMessageRequest` request to the client.
+
+The `initialize` request may only be sent once.
+
+_Request_:
+* method: 'initialize'
+* params: `InitializeParams` defined as follows:
+
+```typescript
+interface InitializeParams {
+	/**
+	 * The process Id of the parent process that started
+	 * the server. Is null if the process has not been started by another process.
+	 * If the parent process is not alive then the server should exit (see exit notification) its process.
+	 */
+	processId: number | null;
+
+	/**
+	 * The rootPath of the workspace. Is null
+	 * if no folder is open.
+	 *
+	 * @deprecated in favour of rootUri.
+	 */
+	rootPath?: string | null;
+
+	/**
+	 * The rootUri of the workspace. Is null if no
+	 * folder is open. If both `rootPath` and `rootUri` are set
+	 * `rootUri` wins.
+	 */
+	rootUri: DocumentUri | null;
+
+	/**
+	 * User provided initialization options.
+	 */
+	initializationOptions?: any;
+
+	/**
+	 * The capabilities provided by the client (editor or tool)
+	 */
+	capabilities: ClientCapabilities;
+
+	/**
+	 * The initial trace setting. If omitted trace is disabled ('off').
+	 */
+	trace?: 'off' | 'messages' | 'verbose';
+
+	/**
+	 * The workspace folders configured in the client when the server starts.
+	 * This property is only available if the client supports workspace folders.
+	 * It can be `null` if the client supports workspace folders but none are
+	 * configured.
+	 *
+	 * Since 3.6.0
+	 */
+	workspaceFolders?: WorkspaceFolder[] | null;
+}
+```
+Where `ClientCapabilities`, `TextDocumentClientCapabilities` and `WorkspaceClientCapabilities` are defined as follows:
+
+##### `WorkspaceClientCapabilities` define capabilities the editor / tool provides on the workspace:
+
+> New in version 3.13: `ResourceOperationKind` and `FailureHandlingKind` and the client capability `workspace.workspaceEdit.resourceOperations` as well as `workspace.workspaceEdit.failureHandling`.
+
+```typescript
+
+/**
+ * The kind of resource operations supported by the client.
+ */
+export type ResourceOperationKind = 'create' | 'rename' | 'delete';
+
+export namespace ResourceOperationKind {
+
+	/**
+	 * Supports creating new files and folders.
+	 */
+	export const Create: ResourceOperationKind = 'create';
+
+	/**
+	 * Supports renaming existing files and folders.
+	 */
+	export const Rename: ResourceOperationKind = 'rename';
+
+	/**
+	 * Supports deleting existing files and folders.
+	 */
+	export const Delete: ResourceOperationKind = 'delete';
+}
+
+export type FailureHandlingKind = 'abort' | 'transactional' | 'undo' | 'textOnlyTransactional';
+
+export namespace FailureHandlingKind {
+
+	/**
+	 * Applying the workspace change is simply aborted if one of the changes provided
+	 * fails. All operations executed before the failing operation stay executed.
+	 */
+	export const Abort: FailureHandlingKind = 'abort';
+
+	/**
+	 * All operations are executed transactionally. That means they either all
+	 * succeed or no changes at all are applied to the workspace.
+	 */
+	export const Transactional: FailureHandlingKind = 'transactional';
+
+
+	/**
+	 * If the workspace edit contains only textual file changes they are executed transactionally.
+	 * If resource changes (create, rename or delete file) are part of the change the failure
+	 * handling strategy is abort.
+	 */
+	export const TextOnlyTransactional: FailureHandlingKind = 'textOnlyTransactional';
+
+	/**
+	 * The client tries to undo the operations already executed. But there is no
+	 * guarantee that this succeeds.
+	 */
+	export const Undo: FailureHandlingKind = 'undo';
+}
+
+/**
+ * Workspace specific client capabilities.
+ */
+export interface WorkspaceClientCapabilities {
+	/**
+	 * The client supports applying batch edits to the workspace by supporting
+	 * the request 'workspace/applyEdit'
+	 */
+	applyEdit?: boolean;
+
+	/**
+	 * Capabilities specific to `WorkspaceEdit`s
+	 */
+	workspaceEdit?: {
+		/**
+		 * The client supports versioned document changes in `WorkspaceEdit`s
+		 */
+		documentChanges?: boolean;
+
+		/**
+		 * The resource operations the client supports. Clients should at least
+		 * support 'create', 'rename' and 'delete' files and folders.
+		 */
+		resourceOperations?: ResourceOperationKind[];
+
+		/**
+		 * The failure handling strategy of a client if applying the workspace edit
+		 * fails.
+		 */
+		failureHandling?: FailureHandlingKind;
+	};
+
+	/**
+	 * Capabilities specific to the `workspace/didChangeConfiguration` notification.
+	 */
+	didChangeConfiguration?: {
+		/**
+		 * Did change configuration notification supports dynamic registration.
+		 */
+		dynamicRegistration?: boolean;
+	};
+
+	/**
+	 * Capabilities specific to the `workspace/didChangeWatchedFiles` notification.
+	 */
+	didChangeWatchedFiles?: {
+		/**
+		 * Did change watched files notification supports dynamic registration. Please note
+		 * that the current protocol doesn't support static configuration for file changes
+		 * from the server side.
+		 */
+		dynamicRegistration?: boolean;
+	};
+
+	/**
+	 * Capabilities specific to the `workspace/symbol` request.
+	 */
+	symbol?: {
+		/**
+		 * Symbol request supports dynamic registration.
+		 */
+		dynamicRegistration?: boolean;
+
+		/**
+		 * Specific capabilities for the `SymbolKind` in the `workspace/symbol` request.
+		 */
+		symbolKind?: {
+			/**
+			 * The symbol kind values the client supports. When this
+			 * property exists the client also guarantees that it will
+			 * handle values outside its set gracefully and falls back
+			 * to a default value when unknown.
+			 *
+			 * If this property is not present the client only supports
+			 * the symbol kinds from `File` to `Array` as defined in
+			 * the initial version of the protocol.
+			 */
+			valueSet?: SymbolKind[];
+		}
+	};
+
+	/**
+	 * Capabilities specific to the `workspace/executeCommand` request.
+	 */
+	executeCommand?: {
+		/**
+		 * Execute command supports dynamic registration.
+		 */
+		dynamicRegistration?: boolean;
+	};
+
+	/**
+	 * The client has support for workspace folders.
+	 *
+	 * Since 3.6.0
+	 */
+	workspaceFolders?: boolean;
+
+	/**
+	 * The client supports `workspace/configuration` requests.
+	 *
+	 * Since 3.6.0
+	 */
+	configuration?: boolean;
+}
+```
+
+##### `TextDocumentClientCapabilities` define capabilities the editor / tool provides on text documents.
+
+```typescript
+/**
+ * Text document specific client capabilities.
+ */
+export interface TextDocumentClientCapabilities {
+
+	synchronization?: {
+		/**
+		 * Whether text document synchronization supports dynamic registration.
+		 */
+		dynamicRegistration?: boolean;
+
+		/**
+		 * The client supports sending will save notifications.
+		 */
+		willSave?: boolean;
+
+		/**
+		 * The client supports sending a will save request and
+		 * waits for a response providing text edits which will
+		 * be applied to the document before it is saved.
+		 */
+		willSaveWaitUntil?: boolean;
+
+		/**
+		 * The client supports did save notifications.
+		 */
+		didSave?: boolean;
+	}
+
+	/**
+	 * Capabilities specific to the `textDocument/completion`
+	 */
+	completion?: {
+		/**
+		 * Whether completion supports dynamic registration.
+		 */
+		dynamicRegistration?: boolean;
+
+		/**
+		 * The client supports the following `CompletionItem` specific
+		 * capabilities.
+		 */
+		completionItem?: {
+			/**
+			 * The client supports snippets as insert text.
+			 *
+			 * A snippet can define tab stops and placeholders with `$1`, `$2`
+			 * and `${3:foo}`. `$0` defines the final tab stop, it defaults to
+			 * the end of the snippet. Placeholders with equal identifiers are linked,
+			 * that is typing in one will update others too.
+			 */
+			snippetSupport?: boolean;
+
+			/**
+			 * The client supports commit characters on a completion item.
+			 */
+			commitCharactersSupport?: boolean
+
+			/**
+			 * The client supports the following content formats for the documentation
+			 * property. The order describes the preferred format of the client.
+			 */
+			documentationFormat?: MarkupKind[];
+
+			/**
+			 * The client supports the deprecated property on a completion item.
+			 */
+			deprecatedSupport?: boolean;
+
+			/**
+			 * The client supports the preselect property on a completion item.
+			 */
+			preselectSupport?: boolean;
+		}
+
+		completionItemKind?: {
+			/**
+			 * The completion item kind values the client supports. When this
+			 * property exists the client also guarantees that it will
+			 * handle values outside its set gracefully and falls back
+			 * to a default value when unknown.
+			 *
+			 * If this property is not present the client only supports
+			 * the completion items kinds from `Text` to `Reference` as defined in
+			 * the initial version of the protocol.
+			 */
+			valueSet?: CompletionItemKind[];
+		},
+
+		/**
+		 * The client supports to send additional context information for a
+		 * `textDocument/completion` request.
+		 */
+		contextSupport?: boolean;
+	};
+
+	/**
+	 * Capabilities specific to the `textDocument/hover`
+	 */
+	hover?: {
+		/**
+		 * Whether hover supports dynamic registration.
+		 */
+		dynamicRegistration?: boolean;
+
+		/**
+		 * The client supports the follow content formats for the content
+		 * property. The order describes the preferred format of the client.
+		 */
+		contentFormat?: MarkupKind[];
+	};
+
+	/**
+	 * Capabilities specific to the `textDocument/signatureHelp`
+	 */
+	signatureHelp?: {
+		/**
+		 * Whether signature help supports dynamic registration.
+		 */
+		dynamicRegistration?: boolean;
+
+		/**
+		 * The client supports the following `SignatureInformation`
+		 * specific properties.
+		 */
+		signatureInformation?: {
+			/**
+			 * The client supports the follow content formats for the documentation
+			 * property. The order describes the preferred format of the client.
+			 */
+			documentationFormat?: MarkupKind[];
+
+			/**
+			 * Client capabilities specific to parameter information.
+			 */
+			parameterInformation?: {
+				/**
+				 * The client supports processing label offsets instead of a
+				 * simple label string.
+				 *
+				 * Since 3.14.0
+				 */
+				labelOffsetSupport?: boolean;
+			}
+		};
+	};
+
+	/**
+	 * Capabilities specific to the `textDocument/references`
+	 */
+	references?: {
+		/**
+		 * Whether references supports dynamic registration.
+		 */
+		dynamicRegistration?: boolean;
+	};
+
+	/**
+	 * Capabilities specific to the `textDocument/documentHighlight`
+	 */
+	documentHighlight?: {
+		/**
+		 * Whether document highlight supports dynamic registration.
+		 */
+		dynamicRegistration?: boolean;
+	};
+
+	/**
+	 * Capabilities specific to the `textDocument/documentSymbol`
+	 */
+	documentSymbol?: {
+		/**
+		 * Whether document symbol supports dynamic registration.
+		 */
+		dynamicRegistration?: boolean;
+
+		/**
+		 * Specific capabilities for the `SymbolKind`.
+		 */
+		symbolKind?: {
+			/**
+			 * The symbol kind values the client supports. When this
+			 * property exists the client also guarantees that it will
+			 * handle values outside its set gracefully and falls back
+			 * to a default value when unknown.
+			 *
+			 * If this property is not present the client only supports
+			 * the symbol kinds from `File` to `Array` as defined in
+			 * the initial version of the protocol.
+			 */
+			valueSet?: SymbolKind[];
+		}
+
+		/**
+		 * The client supports hierarchical document symbols.
+		 */
+		hierarchicalDocumentSymbolSupport?: boolean;
+	};
+
+	/**
+	 * Capabilities specific to the `textDocument/formatting`
+	 */
+	formatting?: {
+		/**
+		 * Whether formatting supports dynamic registration.
+		 */
+		dynamicRegistration?: boolean;
+	};
+
+	/**
+	 * Capabilities specific to the `textDocument/rangeFormatting`
+	 */
+	rangeFormatting?: {
+		/**
+		 * Whether range formatting supports dynamic registration.
+		 */
+		dynamicRegistration?: boolean;
+	};
+
+	/**
+	 * Capabilities specific to the `textDocument/onTypeFormatting`
+	 */
+	onTypeFormatting?: {
+		/**
+		 * Whether on type formatting supports dynamic registration.
+		 */
+		dynamicRegistration?: boolean;
+	};
+
+	/**
+		* Capabilities specific to the `textDocument/declaration`
+		*/
+	declaration?: {
+		/**
+		 * Whether declaration supports dynamic registration. If this is set to `true`
+		 * the client supports the new `(TextDocumentRegistrationOptions & StaticRegistrationOptions)`
+		 * return value for the corresponding server capability as well.
+		 */
+		dynamicRegistration?: boolean;
+
+		/**
+		 * The client supports additional metadata in the form of declaration links.
+		 *
+		 * Since 3.14.0
+		 */
+		linkSupport?: boolean;
+	};
+
+	/**
+	 * Capabilities specific to the `textDocument/definition`.
+	 *
+	 * Since 3.14.0
+	 */
+	definition?: {
+		/**
+		 * Whether definition supports dynamic registration.
+		 */
+		dynamicRegistration?: boolean;
+
+		/**
+		 * The client supports additional metadata in the form of definition links.
+		 */
+		linkSupport?: boolean;
+	};
+
+	/**
+	 * Capabilities specific to the `textDocument/typeDefinition`
+	 *
+	 * Since 3.6.0
+	 */
+	typeDefinition?: {
+		/**
+		 * Whether typeDefinition supports dynamic registration. If this is set to `true`
+		 * the client supports the new `(TextDocumentRegistrationOptions & StaticRegistrationOptions)`
+		 * return value for the corresponding server capability as well.
+		 */
+		dynamicRegistration?: boolean;
+
+		/**
+		 * The client supports additional metadata in the form of definition links.
+		 *
+		 * Since 3.14.0
+		 */
+		linkSupport?: boolean;
+	};
+
+	/**
+	 * Capabilities specific to the `textDocument/implementation`.
+	 *
+	 * Since 3.6.0
+	 */
+	implementation?: {
+		/**
+		 * Whether implementation supports dynamic registration. If this is set to `true`
+		 * the client supports the new `(TextDocumentRegistrationOptions & StaticRegistrationOptions)`
+		 * return value for the corresponding server capability as well.
+		 */
+		dynamicRegistration?: boolean;
+
+		/**
+		 * The client supports additional metadata in the form of definition links.
+		 *
+		 * Since 3.14.0
+		 */
+		linkSupport?: boolean;
+	};
+
+	/**
+	 * Capabilities specific to the `textDocument/codeAction`
+	 */
+	codeAction?: {
+		/**
+		 * Whether code action supports dynamic registration.
+		 */
+		dynamicRegistration?: boolean;
+		/**
+		 * The client support code action literals as a valid
+		 * response of the `textDocument/codeAction` request.
+		 *
+		 * Since 3.8.0
+		 */
+		codeActionLiteralSupport?: {
+			/**
+			 * The code action kind is support with the following value
+			 * set.
+			 */
+			codeActionKind: {
+
+				/**
+				 * The code action kind values the client supports. When this
+				 * property exists the client also guarantees that it will
+				 * handle values outside its set gracefully and falls back
+				 * to a default value when unknown.
+				 */
+				valueSet: CodeActionKind[];
+			};
+		};
+	};
+
+	/**
+	 * Capabilities specific to the `textDocument/codeLens`
+	 */
+	codeLens?: {
+		/**
+		 * Whether code lens supports dynamic registration.
+		 */
+		dynamicRegistration?: boolean;
+	};
+
+	/**
+	 * Capabilities specific to the `textDocument/documentLink`
+	 */
+	documentLink?: {
+		/**
+		 * Whether document link supports dynamic registration.
+		 */
+		dynamicRegistration?: boolean;
+	};
+
+	/**
+	 * Capabilities specific to the `textDocument/documentColor` and the
+	 * `textDocument/colorPresentation` request.
+	 *
+	 * Since 3.6.0
+	 */
+	colorProvider?: {
+		/**
+		 * Whether colorProvider supports dynamic registration. If this is set to `true`
+		 * the client supports the new `(ColorProviderOptions & TextDocumentRegistrationOptions & StaticRegistrationOptions)`
+		 * return value for the corresponding server capability as well.
+		 */
+		dynamicRegistration?: boolean;
+	}
+
+	/**
+	 * Capabilities specific to the `textDocument/rename`
+	 */
+	rename?: {
+		/**
+		 * Whether rename supports dynamic registration.
+		 */
+		dynamicRegistration?: boolean;
+		/**
+		 * The client supports testing for validity of rename operations
+		 * before execution.
+		 */
+		prepareSupport?: boolean;
+	};
+
+	/**
+	 * Capabilities specific to `textDocument/publishDiagnostics`.
+	 */
+	publishDiagnostics?: {
+		/**
+		 * Whether the clients accepts diagnostics with related information.
+		 */
+		relatedInformation?: boolean;
+	};
+	/**
+	 * Capabilities specific to `textDocument/foldingRange` requests.
+	 *
+	 * Since 3.10.0
+	 */
+	foldingRange?: {
+		/**
+		 * Whether implementation supports dynamic registration for folding range providers. If this is set to `true`
+		 * the client supports the new `(FoldingRangeProviderOptions & TextDocumentRegistrationOptions & StaticRegistrationOptions)`
+		 * return value for the corresponding server capability as well.
+		 */
+		dynamicRegistration?: boolean;
+		/**
+		 * The maximum number of folding ranges that the client prefers to receive per document. The value serves as a
+		 * hint, servers are free to follow the limit.
+		 */
+		rangeLimit?: number;
+		/**
+		 * If set, the client signals that it only supports folding complete lines. If set, client will
+		 * ignore specified `startCharacter` and `endCharacter` properties in a FoldingRange.
+		 */
+		lineFoldingOnly?: boolean;
+	};
+}
+```
+
+`ClientCapabilities` now define capabilities for dynamic registration, workspace and text document features the client supports. The `experimental` can be used to pass experimental capabilities under development. For future compatibility a `ClientCapabilities` object literal can have more properties set than currently defined. Servers receiving a `ClientCapabilities` object literal with unknown properties should ignore these properties. A missing property should be interpreted as an absence of the capability. If a missing property normally defines sub properties, all missing sub properties should be interpreted as an absence of the corresponding capability.
+
+Client capabilities got introduced with version 3.0 of the protocol. They therefore only describe capabilities that got introduced in 3.x or later. Capabilities that existed in the 2.x version of the protocol are still mandatory for clients. Clients cannot opt out of providing them. So even if a client omits the `ClientCapabilities.textDocument.synchronization` it is still required that the client provides text document synchronization (e.g. open, changed and close notifications).
+
+```typescript
+interface ClientCapabilities {
+	/**
+	 * Workspace specific client capabilities.
+	 */
+	workspace?: WorkspaceClientCapabilities;
+
+	/**
+	 * Text document specific client capabilities.
+	 */
+	textDocument?: TextDocumentClientCapabilities;
+
+	/**
+	 * Experimental client capabilities.
+	 */
+	experimental?: any;
+}
+```
+
+_Response_:
+* result: `InitializeResult` defined as follows:
+
+```typescript
+interface InitializeResult {
+	/**
+	 * The capabilities the language server provides.
+	 */
+	capabilities: ServerCapabilities;
+}
+```
+* error.code:
+
+```typescript
+/**
+ * Known error codes for an `InitializeError`;
+ */
+export namespace InitializeError {
+	/**
+	 * If the protocol version provided by the client can't be handled by the server.
+	 * @deprecated This initialize error got replaced by client capabilities. There is
+	 * no version handshake in version 3.0x
+	 */
+	export const unknownProtocolVersion: number = 1;
+}
+```
+
+* error.data:
+
+```typescript
+interface InitializeError {
+	/**
+	 * Indicates whether the client execute the following retry logic:
+	 * (1) show the message provided by the ResponseError to the user
+	 * (2) user selects retry or cancel
+	 * (3) if user selected retry the initialize method is sent again.
+	 */
+	retry: boolean;
+}
+```
+
+The server can signal the following capabilities:
+
+```typescript
+/**
+ * Defines how the host (editor) should sync document changes to the language server.
+ */
+export namespace TextDocumentSyncKind {
+	/**
+	 * Documents should not be synced at all.
+	 */
+	export const None = 0;
+
+	/**
+	 * Documents are synced by always sending the full content
+	 * of the document.
+	 */
+	export const Full = 1;
+
+	/**
+	 * Documents are synced by sending the full content on open.
+	 * After that only incremental updates to the document are
+	 * send.
+	 */
+	export const Incremental = 2;
+}
+
+/**
+ * Completion options.
+ */
+export interface CompletionOptions {
+	/**
+	 * The server provides support to resolve additional
+	 * information for a completion item.
+	 */
+	resolveProvider?: boolean;
+
+	/**
+	 * The characters that trigger completion automatically.
+	 */
+	triggerCharacters?: string[];
+}
+/**
+ * Signature help options.
+ */
+export interface SignatureHelpOptions {
+	/**
+	 * The characters that trigger signature help
+	 * automatically.
+	 */
+	triggerCharacters?: string[];
+}
+
+/**
+ * Code Action options.
+ */
+export interface CodeActionOptions {
+	/**
+	 * CodeActionKinds that this server may return.
+	 *
+	 * The list of kinds may be generic, such as `CodeActionKind.Refactor`, or the server
+	 * may list out every specific kind they provide.
+	 */
+	codeActionKinds?: CodeActionKind[];
+}
+
+/**
+ * Code Lens options.
+ */
+export interface CodeLensOptions {
+	/**
+	 * Code lens has a resolve provider as well.
+	 */
+	resolveProvider?: boolean;
+}
+
+/**
+ * Format document on type options.
+ */
+export interface DocumentOnTypeFormattingOptions {
+	/**
+	 * A character on which formatting should be triggered, like `}`.
+	 */
+	firstTriggerCharacter: string;
+
+	/**
+	 * More trigger characters.
+	 */
+	moreTriggerCharacter?: string[];
+}
+
+/**
+ * Rename options
+ */
+export interface RenameOptions {
+	/**
+	 * Renames should be checked and tested before being executed.
+	 */
+	prepareProvider?: boolean;
+}
+
+/**
+ * Document link options.
+ */
+export interface DocumentLinkOptions {
+	/**
+	 * Document links have a resolve provider as well.
+	 */
+	resolveProvider?: boolean;
+}
+
+/**
+ * Execute command options.
+ */
+export interface ExecuteCommandOptions {
+	/**
+	 * The commands to be executed on the server
+	 */
+	commands: string[]
+}
+
+/**
+ * Save options.
+ */
+export interface SaveOptions {
+	/**
+	 * The client is supposed to include the content on save.
+	 */
+	includeText?: boolean;
+}
+
+/**
+ * Color provider options.
+ */
+export interface ColorProviderOptions {
+}
+
+/**
+ * Folding range provider options.
+ */
+export interface FoldingRangeProviderOptions {
+}
+
+export interface TextDocumentSyncOptions {
+	/**
+	 * Open and close notifications are sent to the server. If omitted open close notification should not
+	 * be sent.
+	 */
+	openClose?: boolean;
+	/**
+	 * Change notifications are sent to the server. See TextDocumentSyncKind.None, TextDocumentSyncKind.Full
+	 * and TextDocumentSyncKind.Incremental. If omitted it defaults to TextDocumentSyncKind.None.
+	 */
+	change?: number;
+	/**
+	 * If present will save notifications are sent to the server. If omitted the notification should not be
+	 * sent.
+	 */
+	willSave?: boolean;
+	/**
+	 * If present will save wait until requests are sent to the server. If omitted the request should not be
+	 * sent.
+	 */
+	willSaveWaitUntil?: boolean;
+	/**
+	 * If present save notifications are sent to the server. If omitted the notification should not be
+	 * sent.
+	 */
+	save?: SaveOptions;
+}
+
+/**
+ * Static registration options to be returned in the initialize request.
+ */
+interface StaticRegistrationOptions {
+	/**
+	 * The id used to register the request. The id can be used to deregister
+	 * the request again. See also Registration#id.
+	 */
+	id?: string;
+}
+
+interface ServerCapabilities {
+	/**
+	 * Defines how text documents are synced. Is either a detailed structure defining each notification or
+	 * for backwards compatibility the TextDocumentSyncKind number. If omitted it defaults to `TextDocumentSyncKind.None`.
+	 */
+	textDocumentSync?: TextDocumentSyncOptions | number;
+	/**
+	 * The server provides hover support.
+	 */
+	hoverProvider?: boolean;
+	/**
+	 * The server provides completion support.
+	 */
+	completionProvider?: CompletionOptions;
+	/**
+	 * The server provides signature help support.
+	 */
+	signatureHelpProvider?: SignatureHelpOptions;
+	/**
+	 * The server provides goto definition support.
+	 */
+	definitionProvider?: boolean;
+	/**
+	 * The server provides Goto Type Definition support.
+	 *
+	 * Since 3.6.0
+	 */
+	typeDefinitionProvider?: boolean | (TextDocumentRegistrationOptions & StaticRegistrationOptions);
+	/**
+	 * The server provides Goto Implementation support.
+	 *
+	 * Since 3.6.0
+	 */
+	implementationProvider?: boolean | (TextDocumentRegistrationOptions & StaticRegistrationOptions);
+	/**
+	 * The server provides find references support.
+	 */
+	referencesProvider?: boolean;
+	/**
+	 * The server provides document highlight support.
+	 */
+	documentHighlightProvider?: boolean;
+	/**
+	 * The server provides document symbol support.
+	 */
+	documentSymbolProvider?: boolean;
+	/**
+	 * The server provides workspace symbol support.
+	 */
+	workspaceSymbolProvider?: boolean;
+	/**
+	 * The server provides code actions. The `CodeActionOptions` return type is only
+	 * valid if the client signals code action literal support via the property
+	 * `textDocument.codeAction.codeActionLiteralSupport`.
+	 */
+	codeActionProvider?: boolean | CodeActionOptions;
+	/**
+	 * The server provides code lens.
+	 */
+	codeLensProvider?: CodeLensOptions;
+	/**
+	 * The server provides document formatting.
+	 */
+	documentFormattingProvider?: boolean;
+	/**
+	 * The server provides document range formatting.
+	 */
+	documentRangeFormattingProvider?: boolean;
+	/**
+	 * The server provides document formatting on typing.
+	 */
+	documentOnTypeFormattingProvider?: DocumentOnTypeFormattingOptions;
+	/**
+	 * The server provides rename support. RenameOptions may only be
+	 * specified if the client states that it supports
+	 * `prepareSupport` in its initial `initialize` request.
+	 */
+	renameProvider?: boolean | RenameOptions;
+	/**
+	 * The server provides document link support.
+	 */
+	documentLinkProvider?: DocumentLinkOptions;
+	/**
+	 * The server provides color provider support.
+	 *
+	 * Since 3.6.0
+	 */
+	colorProvider?: boolean | ColorProviderOptions | (ColorProviderOptions & TextDocumentRegistrationOptions & StaticRegistrationOptions);
+	/**
+	 * The server provides folding provider support.
+	 *
+	 * Since 3.10.0
+	 */
+	foldingRangeProvider?: boolean | FoldingRangeProviderOptions | (FoldingRangeProviderOptions & TextDocumentRegistrationOptions & StaticRegistrationOptions);
+	/**
+	 * The server provides go to declaration support.
+	 *
+	 * Since 3.14.0
+	 */
+	declarationProvider?: boolean | (TextDocumentRegistrationOptions & StaticRegistrationOptions);
+	/**
+	 * The server provides execute command support.
+	 */
+	executeCommandProvider?: ExecuteCommandOptions;
+	/**
+	 * Workspace specific server capabilities
+	 */
+	workspace?: {
+		/**
+		 * The server supports workspace folder.
+		 *
+		 * Since 3.6.0
+		 */
+		workspaceFolders?: {
+			/**
+			* The server has support for workspace folders
+			*/
+			supported?: boolean;
+			/**
+			* Whether the server wants to receive workspace folder
+			* change notifications.
+			*
+			* If a strings is provided the string is treated as a ID
+			* under which the notification is registered on the client
+			* side. The ID can be used to unregister for these events
+			* using the `client/unregisterCapability` request.
+			*/
+			changeNotifications?: string | boolean;
+		}
+	}
+	/**
+	 * Experimental server capabilities.
+	 */
+	experimental?: any;
+}
+```
+
+#### <a href="#initialized" name="initialized" class="anchor">Initialized Notification (:arrow_right:)</a>
+
+The initialized notification is sent from the client to the server after the client received the result of the `initialize` request but before the client is sending any other request or notification to the server. The server can use the `initialized` notification for example to dynamically register capabilities. The `initialized` notification may only be sent once.
+
+_Notification_:
+* method: 'initialized'
+* params: `InitializedParams` defined as follows:
+
+```typescript
+interface InitializedParams {
+}
+```
+
+#### <a href="#shutdown" name="shutdown" class="anchor">Shutdown Request (:leftwards_arrow_with_hook:)</a>
+
+The shutdown request is sent from the client to the server. It asks the server to shut down, but to not exit (otherwise the response might not be delivered correctly to the client). There is a separate exit notification that asks the server to exit. Clients must not send any notifications other than `exit` or requests to a server to which they have sent a shutdown requests. If a server receives requests after a shutdown request those requests should be errored with `InvalidRequest`.
+
+_Request_:
+* method: 'shutdown'
+* params: void
+
+_Response_:
+* result: null
+* error: code and message set in case an exception happens during shutdown request.
+
+#### <a href="#exit" name="exit" class="anchor">Exit Notification (:arrow_right:)</a>
+
+A notification to ask the server to exit its process.
+The server should exit with `success` code 0 if the shutdown request has been received before; otherwise with `error` code 1.
+
+_Notification_:
+* method: 'exit'
+* params: void
+
+#### <a href="#window_showMessage" name="window_showMessage" class="anchor">ShowMessage Notification (:arrow_left:)</a>
+
+The show message notification is sent from a server to a client to ask the client to display a particular message in the user interface.
+
+_Notification_:
+* method: 'window/showMessage'
+* params: `ShowMessageParams` defined as follows:
+
+```typescript
+interface ShowMessageParams {
+	/**
+	 * The message type. See {@link MessageType}.
+	 */
+	type: number;
+
+	/**
+	 * The actual message.
+	 */
+	message: string;
+}
+```
+
+Where the type is defined as follows:
+
+```typescript
+export namespace MessageType {
+	/**
+	 * An error message.
+	 */
+	export const Error = 1;
+	/**
+	 * A warning message.
+	 */
+	export const Warning = 2;
+	/**
+	 * An information message.
+	 */
+	export const Info = 3;
+	/**
+	 * A log message.
+	 */
+	export const Log = 4;
+}
+```
+
+#### <a href="#window_showMessageRequest" name="window_showMessageRequest" class="anchor">ShowMessage Request (:arrow_right_hook:)</a>
+
+The show message request is sent from a server to a client to ask the client to display a particular message in the user interface. In addition to the show message notification the request allows to pass actions and to wait for an answer from the client.
+
+_Request_:
+* method: 'window/showMessageRequest'
+* params: `ShowMessageRequestParams` defined as follows:
+
+_Response_:
+* result: the selected `MessageActionItem` \| `null` if none got selected.
+* error: code and message set in case an exception happens during showing a message.
+
+```typescript
+interface ShowMessageRequestParams {
+	/**
+	 * The message type. See {@link MessageType}
+	 */
+	type: number;
+
+	/**
+	 * The actual message
+	 */
+	message: string;
+
+	/**
+	 * The message action items to present.
+	 */
+	actions?: MessageActionItem[];
+}
+```
+
+Where the `MessageActionItem` is defined as follows:
+
+```typescript
+interface MessageActionItem {
+	/**
+	 * A short title like 'Retry', 'Open Log' etc.
+	 */
+	title: string;
+}
+```
+
+#### <a href="#window_logMessage" name="window_logMessage" class="anchor">LogMessage Notification (:arrow_left:)</a>
+
+The log message notification is sent from the server to the client to ask the client to log a particular message.
+
+_Notification_:
+* method: 'window/logMessage'
+* params: `LogMessageParams` defined as follows:
+
+```typescript
+interface LogMessageParams {
+	/**
+	 * The message type. See {@link MessageType}
+	 */
+	type: number;
+
+	/**
+	 * The actual message
+	 */
+	message: string;
+}
+```
+
+Where type is defined as above.
+
+#### <a href="#telemetry_event" name="telemetry_event" class="anchor">Telemetry Notification (:arrow_left:)</a>
+
+The telemetry notification is sent from the server to the client to ask the client to log a telemetry event.
+
+_Notification_:
+* method: 'telemetry/event'
+* params: 'any'
+
+#### <a href="#client_registerCapability" name="client_registerCapability" class="anchor">Register Capability (:arrow_right_hook:)</a>
+
+The `client/registerCapability` request is sent from the server to the client to register for a new capability on the client side. Not all clients need to support dynamic capability registration. A client opts in via the `dynamicRegistration` property on the specific client capabilities. A client can even provide dynamic registration for capability A but not for capability B (see `TextDocumentClientCapabilities` as an example).
+
+_Request_:
+* method: 'client/registerCapability'
+* params: `RegistrationParams`
+
+Where `RegistrationParams` are defined as follows:
+
+```typescript
+/**
+ * General parameters to register for a capability.
+ */
+export interface Registration {
+	/**
+	 * The id used to register the request. The id can be used to deregister
+	 * the request again.
+	 */
+	id: string;
+
+	/**
+	 * The method / capability to register for.
+	 */
+	method: string;
+
+	/**
+	 * Options necessary for the registration.
+	 */
+	registerOptions?: any;
+}
+
+export interface RegistrationParams {
+	registrations: Registration[];
+}
+```
+
+Since most of the registration options require to specify a document selector there is a base interface that can be used.
+
+```typescript
+export interface TextDocumentRegistrationOptions {
+	/**
+	 * A document selector to identify the scope of the registration. If set to null
+	 * the document selector provided on the client side will be used.
+	 */
+	documentSelector: DocumentSelector | null;
+}
+```
+
+An example JSON RPC message to register dynamically for the `textDocument/willSaveWaitUntil` feature on the client side is as follows (only details shown):
+
+```json
+{
+	"method": "client/registerCapability",
+	"params": {
+		"registrations": [
+			{
+				"id": "79eee87c-c409-4664-8102-e03263673f6f",
+				"method": "textDocument/willSaveWaitUntil",
+				"registerOptions": {
+					"documentSelector": [
+						{ "language": "javascript" }
+					]
+				}
+			}
+		]
+	}
+}
+```
+
+This message is sent from the server to the client and after the client has successfully executed the request further `textDocument/willSaveWaitUntil` requests for JavaScript text documents are sent from the client to the server.
+
+_Response_:
+* result: void.
+* error: code and message set in case an exception happens during the request.
+
+#### <a href="#client_unregisterCapability" name="client_unregisterCapability" class="anchor">Unregister Capability (:arrow_right_hook:)</a>
+
+The `client/unregisterCapability` request is sent from the server to the client to unregister a previously registered capability.
+
+_Request_:
+* method: 'client/unregisterCapability'
+* params: `UnregistrationParams`
+
+Where `UnregistrationParams` are defined as follows:
+
+```typescript
+/**
+ * General parameters to unregister a capability.
+ */
+export interface Unregistration {
+	/**
+	 * The id used to unregister the request or notification. Usually an id
+	 * provided during the register request.
+	 */
+	id: string;
+
+	/**
+	 * The method / capability to unregister for.
+	 */
+	method: string;
+}
+
+export interface UnregistrationParams {
+	unregisterations: Unregistration[];
+}
+```
+
+An example JSON RPC message to unregister the above registered `textDocument/willSaveWaitUntil` feature looks like this:
+
+```json
+{
+	"method": "client/unregisterCapability",
+	"params": {
+		"unregisterations": [
+			{
+				"id": "79eee87c-c409-4664-8102-e03263673f6f",
+				"method": "textDocument/willSaveWaitUntil"
+			}
+		]
+	}
+}
+```
+_Response_:
+* result: void.
+* error: code and message set in case an exception happens during the request.
+
+##### <a href="#workspace_workspaceFolders" name="workspace_workspaceFolders" class="anchor">Workspace folders request (:arrow_right_hook:)</a>
+
+> *Since version 3.6.0*
+
+Many tools support more than one root folder per workspace. Examples for this are VS Code's multi-root support, Atom's project folder support or Sublime's project support. If a client workspace consists of multiple roots then a server typically needs to know about this. The protocol up to now assumes one root folder which is announced to the server by the `rootUri` property of the `InitializeParams`. If the client supports workspace folders and announces them via the corresponding `workspaceFolders` client capability, the `InitializeParams` contain an additional property `workspaceFolders` with the configured workspace folders when the server starts.
+
+The `workspace/workspaceFolders` request is sent from the server to the client to fetch the current open list of workspace folders. Returns `null` in the response if only a single file is open in the tool. Returns an empty array if a workspace is open but no folders are configured.
+
+_Request_:
+
+* method: 'workspace/workspaceFolders'
+* params: none
+
+_Response_:
+
+* result: `WorkspaceFolder[] | null` defined as follows:
+
+```typescript
+export interface WorkspaceFolder {
+	/**
+	 * The associated URI for this workspace folder.
+	 */
+	uri: DocumentUri;
+
+	/**
+	 * The name of the workspace folder. Used to refer to this
+	 * workspace folder in the user interface.
+	 */
+	name: string;
+}
+```
+* error: code and message set in case an exception happens during the 'workspace/workspaceFolders' request
+
+##### <a href="#workspace_didChangeWorkspaceFolders" name="workspace_didChangeWorkspaceFolders" class="anchor">DidChangeWorkspaceFolders Notification (:arrow_right:)</a>
+
+> *Since version 3.6.0*
+
+The `workspace/didChangeWorkspaceFolders` notification is sent from the client to the server to inform the server about workspace folder configuration changes. The notification is sent by default if both _ServerCapabilities/workspace/workspaceFolders_ and _ClientCapabilities/workspace/workspaceFolders_ are true; or if the server has registered itself to receive this notification. To register for the `workspace/didChangeWorkspaceFolders` send a `client/registerCapability` request from the server to the client. The registration parameter must have a `registrations` item of the following form, where `id` is a unique id used to unregister the capability (the example uses a UUID):
+```ts
+{
+	id: "28c6150c-bd7b-11e7-abc4-cec278b6b50a",
+	method: "workspace/didChangeWorkspaceFolders"
+}
+```
+
+_Notification_:
+
+* method: 'workspace/didChangeWorkspaceFolders'
+* params: `DidChangeWorkspaceFoldersParams` defined as follows:
+
+```typescript
+export interface DidChangeWorkspaceFoldersParams {
+	/**
+	 * The actual workspace folder change event.
+	 */
+	event: WorkspaceFoldersChangeEvent;
+}
+
+/**
+ * The workspace folder change event.
+ */
+export interface WorkspaceFoldersChangeEvent {
+	/**
+	 * The array of added workspace folders
+	 */
+	added: WorkspaceFolder[];
+
+	/**
+	 * The array of the removed workspace folders
+	 */
+	removed: WorkspaceFolder[];
+}
+```
+
+#### <a href="#workspace_didChangeConfiguration" name="workspace_didChangeConfiguration" class="anchor">DidChangeConfiguration Notification (:arrow_right:)</a>
+
+A notification sent from the client to the server to signal the change of configuration settings.
+
+_Notification_:
+* method: 'workspace/didChangeConfiguration',
+* params: `DidChangeConfigurationParams` defined as follows:
+
+```typescript
+interface DidChangeConfigurationParams {
+	/**
+	 * The actual changed settings
+	 */
+	settings: any;
+}
+```
+
+#### <a href="#workspace_configuration" name="workspace_configuration" class="anchor">Configuration Request (:arrow_right_hook:)</a>
+
+> *Since version 3.6.0*
+
+The `workspace/configuration` request is sent from the server to the client to fetch configuration settings from the client. The request can fetch several configuration settings in one roundtrip. The order of the returned configuration settings correspond to the order of the passed `ConfigurationItems` (e.g. the first item in the response is the result for the first configuration item in the params).
+
+A `ConfigurationItem` consists of the configuration section to ask for and an additional scope URI. The configuration section ask for is defined by the server and doesn't necessarily need to correspond to the configuration store used be the client. So a server might ask for a configuration `cpp.formatterOptions` but the client stores the configuration in a XML store layout differently. It is up to the client to do the necessary conversion. If a scope URI is provided the client should return the setting scoped to the provided resource. If the client for example uses [EditorConfig](http://editorconfig.org/) to manage its settings the configuration should be returned for the passed resource URI. If the client can't provide a configuration setting for a given scope then `null` need to be present in the returned array.
+
+_Request_:
+
+* method: 'workspace/configuration'
+* params: `ConfigurationParams` defined as follows
+
+```typescript
+export interface ConfigurationParams {
+	items: ConfigurationItem[];
+}
+
+export interface ConfigurationItem {
+	/**
+	 * The scope to get the configuration section for.
+	 */
+	scopeUri?: DocumentUri;
+
+	/**
+	 * The configuration section asked for.
+	 */
+	section?: string;
+}
+```
+
+_Response_:
+* result: any[]
+* error: code and message set in case an exception happens during the 'workspace/configuration' request
+
+#### <a href="#workspace_didChangeWatchedFiles" name="workspace_didChangeWatchedFiles" class="anchor">DidChangeWatchedFiles Notification (:arrow_right:)</a>
+
+The watched files notification is sent from the client to the server when the client detects changes to files watched by the language client. It is recommended that servers register for these file events using the registration mechanism. In former implementations clients pushed file events without the server actively asking for it.
+
+Servers are allowed to run their own file watching mechanism and not rely on clients to provide file events. However this is not recommended due to the following reasons:
+
+- to our experience getting file watching on disk right is challenging, especially if it needs to be supported across multiple OSes.
+- file watching is not for free especially if the implementation uses some sort of polling and keeps a file tree in memory to compare time stamps (as for example some node modules do)
+- a client usually starts more than one server. If every server runs its own file watching it can become a CPU or memory problem.
+- in general there are more server than client implementations. So this problem is better solved on the client side.
+
+
+_Notification_:
+* method: 'workspace/didChangeWatchedFiles'
+* params: `DidChangeWatchedFilesParams` defined as follows:
+
+```typescript
+interface DidChangeWatchedFilesParams {
+	/**
+	 * The actual file events.
+	 */
+	changes: FileEvent[];
+}
+```
+
+Where FileEvents are described as follows:
+
+```typescript
+/**
+ * An event describing a file change.
+ */
+interface FileEvent {
+	/**
+	 * The file's URI.
+	 */
+	uri: DocumentUri;
+	/**
+	 * The change type.
+	 */
+	type: number;
+}
+
+/**
+ * The file event type.
+ */
+export namespace FileChangeType {
+	/**
+	 * The file got created.
+	 */
+	export const Created = 1;
+	/**
+	 * The file got changed.
+	 */
+	export const Changed = 2;
+	/**
+	 * The file got deleted.
+	 */
+	export const Deleted = 3;
+}
+```
+
+_Registration Options_: `DidChangeWatchedFilesRegistrationOptions` defined as follows
+
+```typescript
+/**
+ * Describe options to be used when registering for file system change events.
+ */
+export interface DidChangeWatchedFilesRegistrationOptions {
+	/**
+	 * The watchers to register.
+	 */
+	watchers: FileSystemWatcher[];
+}
+
+export interface FileSystemWatcher {
+	/**
+	 * The  glob pattern to watch.
+	 *
+	 * Glob patterns can have the following syntax:
+	 * - `*` to match one or more characters in a path segment
+	 * - `?` to match on one character in a path segment
+	 * - `**` to match any number of path segments, including none
+	 * - `{}` to group conditions (e.g. `**​/*.{ts,js}` matches all TypeScript and JavaScript files)
+	 * - `[]` to declare a range of characters to match in a path segment (e.g., `example.[0-9]` to match on `example.0`, `example.1`, …)
+	 * - `[!...]` to negate a range of characters to match in a path segment (e.g., `example.[!0-9]` to match on `example.a`, `example.b`, but not `example.0`)
+	 */
+	globPattern: string;
+
+	/**
+	 * The kind of events of interest. If omitted it defaults
+	 * to WatchKind.Create | WatchKind.Change | WatchKind.Delete
+	 * which is 7.
+	 */
+	kind?: number;
+}
+
+export namespace WatchKind {
+	/**
+	 * Interested in create events.
+	 */
+	export const Create = 1;
+
+	/**
+	 * Interested in change events
+	 */
+	export const Change = 2;
+
+	/**
+	 * Interested in delete events
+	 */
+	export const Delete = 4;
+}
+```
+
+#### <a href="#workspace_symbol" name="workspace_symbol" class="anchor">Workspace Symbols Request (:leftwards_arrow_with_hook:)</a>
+
+The workspace symbol request is sent from the client to the server to list project-wide symbols matching the query string.
+
+_Request_:
+* method: 'workspace/symbol'
+* params: `WorkspaceSymbolParams` defined as follows:
+
+```typescript
+/**
+ * The parameters of a Workspace Symbol Request.
+ */
+interface WorkspaceSymbolParams {
+	/**
+	 * A non-empty query string
+	 */
+	query: string;
+}
+```
+
+_Response_:
+* result: `SymbolInformation[]` \| `null` as defined above.
+* error: code and message set in case an exception happens during the workspace symbol request.
+
+_Registration Options_: void
+
+
+#### <a href="#workspace_executeCommand" name="workspace_executeCommand" class="anchor">Execute a command (:leftwards_arrow_with_hook:)</a>
+
+The `workspace/executeCommand` request is sent from the client to the server to trigger command execution on the server. In most cases
+the server creates a `WorkspaceEdit` structure and applies the changes to the workspace using the request `workspace/applyEdit` which is
+sent from the server to the client.
+
+_Request:_
+* method: 'workspace/executeCommand'
+* params: `ExecuteCommandParams` defined as follows:
+
+```typescript
+export interface ExecuteCommandParams {
+
+	/**
+	 * The identifier of the actual command handler.
+	 */
+	command: string;
+	/**
+	 * Arguments that the command should be invoked with.
+	 */
+	arguments?: any[];
+}
+```
+
+The arguments are typically specified when a command is returned from the server to the client. Example requests that return a command are `textDocument/codeAction` or `textDocument/codeLens`.
+
+_Response_:
+* result: `any` \| `null`
+* error: code and message set in case an exception happens during the request.
+
+_Registration Options_: `ExecuteCommandRegistrationOptions` defined as follows:
+
+```typescript
+/**
+ * Execute command registration options.
+ */
+export interface ExecuteCommandRegistrationOptions {
+	/**
+	 * The commands to be executed on the server
+	 */
+	commands: string[]
+}
+```
+
+
+#### <a href="#workspace_applyEdit" name="workspace_applyEdit" class="anchor">Applies a WorkspaceEdit (:arrow_right_hook:)</a>
+
+The `workspace/applyEdit` request is sent from the server to the client to modify resource on the client side.
+
+_Request_:
+* method: 'workspace/applyEdit'
+* params: `ApplyWorkspaceEditParams` defined as follows:
+
+```typescript
+export interface ApplyWorkspaceEditParams {
+	/**
+	 * An optional label of the workspace edit. This label is
+	 * presented in the user interface for example on an undo
+	 * stack to undo the workspace edit.
+	 */
+	label?: string;
+
+	/**
+	 * The edits to apply.
+	 */
+	edit: WorkspaceEdit;
+}
+```
+
+_Response_:
+* result: `ApplyWorkspaceEditResponse` defined as follows:
+
+```typescript
+export interface ApplyWorkspaceEditResponse {
+	/**
+	 * Indicates whether the edit was applied or not.
+	 */
+	applied: boolean;
+
+	/**
+	 * An optional textual description for why the edit was not applied.
+	 * This may be used may be used by the server for diagnostic
+	 * logging or to provide a suitable error for a request that
+	 * triggered the edit.
+	 */
+	failureReason?: string;
+}
+```
+* error: code and message set in case an exception happens during the request.
+
+
+#### <a href="#textDocument_didOpen" name="textDocument_didOpen" class="anchor">DidOpenTextDocument Notification (:arrow_right:)</a>
+
+The document open notification is sent from the client to the server to signal newly opened text documents. The document's truth is now managed by the client and the server must not try to read the document's truth using the document's Uri. Open in this sense means it is managed by the client. It doesn't necessarily mean that its content is presented in an editor. An open notification must not be sent more than once without a corresponding close notification send before. This means open and close notification must be balanced and the max open count for a particular textDocument is one. Note that a server's ability to fulfill requests is independent of whether a text document is open or closed.
+
+The `DidOpenTextDocumentParams` contain the language id the document is associated with. If the language Id of a document changes, the client needs to send a `textDocument/didClose` to the server followed by a `textDocument/didOpen` with the new language id if the server handles the new language id as well.
+
+_Notification_:
+* method: 'textDocument/didOpen'
+* params: `DidOpenTextDocumentParams` defined as follows:
+
+```typescript
+interface DidOpenTextDocumentParams {
+	/**
+	 * The document that was opened.
+	 */
+	textDocument: TextDocumentItem;
+}
+```
+
+_Registration Options_: `TextDocumentRegistrationOptions`
+
+
+#### <a href="#textDocument_didChange" name="textDocument_didChange" class="anchor">DidChangeTextDocument Notification (:arrow_right:)</a>
+
+The document change notification is sent from the client to the server to signal changes to a text document. In 2.0 the shape of the params has changed to include proper version numbers and language ids.
+
+_Notification_:
+* method: 'textDocument/didChange'
+* params: `DidChangeTextDocumentParams` defined as follows:
+
+```typescript
+interface DidChangeTextDocumentParams {
+	/**
+	 * The document that did change. The version number points
+	 * to the version after all provided content changes have
+	 * been applied.
+	 */
+	textDocument: VersionedTextDocumentIdentifier;
+
+	/**
+	 * The actual content changes. The content changes describe single state changes
+	 * to the document. So if there are two content changes c1 and c2 for a document
+	 * in state S then c1 move the document to S' and c2 to S''.
+	 */
+	contentChanges: TextDocumentContentChangeEvent[];
+}
+
+/**
+ * An event describing a change to a text document. If range and rangeLength are omitted
+ * the new text is considered to be the full content of the document.
+ */
+interface TextDocumentContentChangeEvent {
+	/**
+	 * The range of the document that changed.
+	 */
+	range?: Range;
+
+	/**
+	 * The length of the range that got replaced.
+	 */
+	rangeLength?: number;
+
+	/**
+	 * The new text of the range/document.
+	 */
+	text: string;
+}
+```
+
+_Registration Options_: `TextDocumentChangeRegistrationOptions` defined as follows:
+
+```typescript
+/**
+ * Describe options to be used when registering for text document change events.
+ */
+export interface TextDocumentChangeRegistrationOptions extends TextDocumentRegistrationOptions {
+	/**
+	 * How documents are synced to the server. See TextDocumentSyncKind.Full
+	 * and TextDocumentSyncKind.Incremental.
+	 */
+	syncKind: number;
+}
+```
+
+
+#### <a href="#textDocument_willSave" name="textDocument_willSave" class="anchor">WillSaveTextDocument Notification (:arrow_right:)</a>
+
+The document will save notification is sent from the client to the server before the document is actually saved.
+
+_Notification_:
+* method: 'textDocument/willSave'
+* params: `WillSaveTextDocumentParams` defined as follows:
+
+```typescript
+/**
+ * The parameters send in a will save text document notification.
+ */
+export interface WillSaveTextDocumentParams {
+	/**
+	 * The document that will be saved.
+	 */
+	textDocument: TextDocumentIdentifier;
+
+	/**
+	 * The 'TextDocumentSaveReason'.
+	 */
+	reason: number;
+}
+
+/**
+ * Represents reasons why a text document is saved.
+ */
+export namespace TextDocumentSaveReason {
+
+	/**
+	 * Manually triggered, e.g. by the user pressing save, by starting debugging,
+	 * or by an API call.
+	 */
+	export const Manual = 1;
+
+	/**
+	 * Automatic after a delay.
+	 */
+	export const AfterDelay = 2;
+
+	/**
+	 * When the editor lost focus.
+	 */
+	export const FocusOut = 3;
+}
+```
+
+_Registration Options_: `TextDocumentRegistrationOptions`
+
+
+#### <a href="#textDocument_willSaveWaitUntil" name="textDocument_willSaveWaitUntil" class="anchor">WillSaveWaitUntilTextDocument Request (:leftwards_arrow_with_hook:)</a>
+
+The document will save request is sent from the client to the server before the document is actually saved. The request can return an array of TextEdits which will be applied to the text document before it is saved. Please note that clients might drop results if computing the text edits took too long or if a server constantly fails on this request. This is done to keep the save fast and reliable.
+
+_Request_:
+* method: 'textDocument/willSaveWaitUntil'
+* params: `WillSaveTextDocumentParams`
+
+_Response_:
+* result:`TextEdit[]` \| `null`
+* error: code and message set in case an exception happens during the `willSaveWaitUntil` request.
+
+_Registration Options_: `TextDocumentRegistrationOptions`
+
+#### <a href="#textDocument_didSave" name="textDocument_didSave" class="anchor">DidSaveTextDocument Notification (:arrow_right:)</a>
+
+The document save notification is sent from the client to the server when the document was saved in the client.
+
+* method: 'textDocument/didSave'
+* params: `DidSaveTextDocumentParams` defined as follows:
+
+```typescript
+interface DidSaveTextDocumentParams {
+	/**
+	 * The document that was saved.
+	 */
+	textDocument: TextDocumentIdentifier;
+
+	/**
+	 * Optional the content when saved. Depends on the includeText value
+	 * when the save notification was requested.
+	 */
+	text?: string;
+}
+```
+
+_Registration Options_: `TextDocumentSaveRegistrationOptions` defined as follows:
+
+```typescript
+export interface TextDocumentSaveRegistrationOptions extends TextDocumentRegistrationOptions {
+	/**
+	 * The client is supposed to include the content on save.
+	 */
+	includeText?: boolean;
+}
+```
+
+#### <a href="#textDocument_didClose" name="textDocument_didClose" class="anchor">DidCloseTextDocument Notification (:arrow_right:)</a>
+
+The document close notification is sent from the client to the server when the document got closed in the client. The document's truth now exists where the document's Uri points to (e.g. if the document's Uri is a file Uri the truth now exists on disk). As with the open notification the close notification is about managing the document's content. Receiving a close notification doesn't mean that the document was open in an editor before. A close notification requires a previous open notification to be sent. Note that a server's ability to fulfill requests is independent of whether a text document is open or closed.
+
+_Notification_:
+* method: 'textDocument/didClose'
+* params: `DidCloseTextDocumentParams` defined as follows:
+
+```typescript
+interface DidCloseTextDocumentParams {
+	/**
+	 * The document that was closed.
+	 */
+	textDocument: TextDocumentIdentifier;
+}
+```
+
+_Registration Options_: `TextDocumentRegistrationOptions`
+
+
+#### <a href="#textDocument_publishDiagnostics" name="textDocument_publishDiagnostics" class="anchor">PublishDiagnostics Notification (:arrow_left:)</a>
+
+Diagnostics notification are sent from the server to the client to signal results of validation runs.
+
+Diagnostics are "owned" by the server so it is the server's responsibility to clear them if necessary. The following rule is used for VS Code servers that generate diagnostics:
+
+* if a language is single file only (for example HTML) then diagnostics are cleared by the server when the file is closed.
+* if a language has a project system (for example C#) diagnostics are not cleared when a file closes. When a project is opened all diagnostics for all files are recomputed (or read from a cache).
+
+When a file changes it is the server's responsibility to re-compute diagnostics and push them to the client. If the computed set is empty it has to push the empty array to clear former diagnostics. Newly pushed diagnostics always replace previously pushed diagnostics. There is no merging that happens on the client side.
+
+_Notification_:
+* method: 'textDocument/publishDiagnostics'
+* params: `PublishDiagnosticsParams` defined as follows:
+
+```typescript
+interface PublishDiagnosticsParams {
+	/**
+	 * The URI for which diagnostic information is reported.
+	 */
+	uri: DocumentUri;
+
+	/**
+	 * An array of diagnostic information items.
+	 */
+	diagnostics: Diagnostic[];
+}
+```
+
+#### <a href="#textDocument_completion" name="textDocument_completion" class="anchor">Completion Request (:leftwards_arrow_with_hook:)</a>
+
+The Completion request is sent from the client to the server to compute completion items at a given cursor position. Completion items are presented in the [IntelliSense](https://code.visualstudio.com/docs/editor/editingevolved#_intellisense) user interface. If computing full completion items is expensive, servers can additionally provide a handler for the completion item resolve request ('completionItem/resolve'). This request is sent when a completion item is selected in the user interface. A typical use case is for example: the 'textDocument/completion' request doesn't fill in the `documentation` property for returned completion items since it is expensive to compute. When the item is selected in the user interface then a 'completionItem/resolve' request is sent with the selected completion item as a parameter. The returned completion item should have the documentation property filled in. The request can delay the computation of the `detail` and `documentation` properties. However, properties that are needed for the initial sorting and filtering, like `sortText`, `filterText`, `insertText`, and `textEdit` must be provided in the `textDocument/completion` response and must not be changed during resolve.
+
+_Request_:
+* method: 'textDocument/completion'
+* params: `CompletionParams` defined as follows:
+
+```typescript
+export interface CompletionParams extends TextDocumentPositionParams {
+
+	/**
+	 * The completion context. This is only available if the client specifies
+	 * to send this using `ClientCapabilities.textDocument.completion.contextSupport === true`
+	 */
+	context?: CompletionContext;
+}
+
+/**
+ * How a completion was triggered
+ */
+export namespace CompletionTriggerKind {
+	/**
+	 * Completion was triggered by typing an identifier (24x7 code
+	 * complete), manual invocation (e.g Ctrl+Space) or via API.
+	 */
+	export const Invoked: 1 = 1;
+
+	/**
+	 * Completion was triggered by a trigger character specified by
+	 * the `triggerCharacters` properties of the `CompletionRegistrationOptions`.
+	 */
+	export const TriggerCharacter: 2 = 2;
+
+	/**
+	 * Completion was re-triggered as the current completion list is incomplete.
+	 */
+	export const TriggerForIncompleteCompletions: 3 = 3;
+}
+export type CompletionTriggerKind = 1 | 2 | 3;
+
+
+/**
+ * Contains additional information about the context in which a completion request is triggered.
+ */
+export interface CompletionContext {
+	/**
+	 * How the completion was triggered.
+	 */
+	triggerKind: CompletionTriggerKind;
+
+	/**
+	 * The trigger character (a single character) that has trigger code complete.
+	 * Is undefined if `triggerKind !== CompletionTriggerKind.TriggerCharacter`
+	 */
+	triggerCharacter?: string;
+}
+```
+
+_Response_:
+* result: `CompletionItem[]` \| `CompletionList` \| `null`. If a `CompletionItem[]` is provided it is interpreted to be complete. So it is the same as `{ isIncomplete: false, items }`
+
+```typescript
+/**
+ * Represents a collection of [completion items](#CompletionItem) to be presented
+ * in the editor.
+ */
+interface CompletionList {
+	/**
+	 * This list it not complete. Further typing should result in recomputing
+	 * this list.
+	 */
+	isIncomplete: boolean;
+
+	/**
+	 * The completion items.
+	 */
+	items: CompletionItem[];
+}
+
+/**
+ * Defines whether the insert text in a completion item should be interpreted as
+ * plain text or a snippet.
+ */
+namespace InsertTextFormat {
+	/**
+	 * The primary text to be inserted is treated as a plain string.
+	 */
+	export const PlainText = 1;
+
+	/**
+	 * The primary text to be inserted is treated as a snippet.
+	 *
+	 * A snippet can define tab stops and placeholders with `$1`, `$2`
+	 * and `${3:foo}`. `$0` defines the final tab stop, it defaults to
+	 * the end of the snippet. Placeholders with equal identifiers are linked,
+	 * that is typing in one will update others too.
+	 */
+	export const Snippet = 2;
+}
+
+type InsertTextFormat = 1 | 2;
+
+interface CompletionItem {
+	/**
+	 * The label of this completion item. By default
+	 * also the text that is inserted when selecting
+	 * this completion.
+	 */
+	label: string;
+
+	/**
+	 * The kind of this completion item. Based of the kind
+	 * an icon is chosen by the editor. The standardized set
+	 * of available values is defined in `CompletionItemKind`.
+	 */
+	kind?: number;
+
+	/**
+	 * A human-readable string with additional information
+	 * about this item, like type or symbol information.
+	 */
+	detail?: string;
+
+	/**
+	 * A human-readable string that represents a doc-comment.
+	 */
+	documentation?: string | MarkupContent;
+
+	/**
+	 * Indicates if this item is deprecated.
+	 */
+	deprecated?: boolean;
+
+	/**
+	 * Select this item when showing.
+	 *
+	 * *Note* that only one completion item can be selected and that the
+	 * tool / client decides which item that is. The rule is that the *first*
+	 * item of those that match best is selected.
+	 */
+	preselect?: boolean;
+
+	/**
+	 * A string that should be used when comparing this item
+	 * with other items. When `falsy` the label is used.
+	 */
+	sortText?: string;
+
+	/**
+	 * A string that should be used when filtering a set of
+	 * completion items. When `falsy` the label is used.
+	 */
+	filterText?: string;
+
+	/**
+	 * A string that should be inserted into a document when selecting
+	 * this completion. When `falsy` the label is used.
+	 *
+	 * The `insertText` is subject to interpretation by the client side.
+	 * Some tools might not take the string literally. For example
+	 * VS Code when code complete is requested in this example `con<cursor position>`
+	 * and a completion item with an `insertText` of `console` is provided it
+	 * will only insert `sole`. Therefore it is recommended to use `textEdit` instead
+	 * since it avoids additional client side interpretation.
+	 */
+	insertText?: string;
+
+	/**
+	 * The format of the insert text. The format applies to both the `insertText` property
+	 * and the `newText` property of a provided `textEdit`. If ommitted defaults to
+	 * `InsertTextFormat.PlainText`.
+	 */
+	insertTextFormat?: InsertTextFormat;
+
+	/**
+	 * An edit which is applied to a document when selecting this completion. When an edit is provided the value of
+	 * `insertText` is ignored.
+	 *
+	 * *Note:* The range of the edit must be a single line range and it must contain the position at which completion
+	 * has been requested.
+	 */
+	textEdit?: TextEdit;
+
+	/**
+	 * An optional array of additional text edits that are applied when
+	 * selecting this completion. Edits must not overlap (including the same insert position)
+	 * with the main edit nor with themselves.
+	 *
+	 * Additional text edits should be used to change text unrelated to the current cursor position
+	 * (for example adding an import statement at the top of the file if the completion item will
+	 * insert an unqualified type).
+	 */
+	additionalTextEdits?: TextEdit[];
+
+	/**
+	 * An optional set of characters that when pressed while this completion is active will accept it first and
+	 * then type that character. *Note* that all commit characters should have `length=1` and that superfluous
+	 * characters will be ignored.
+	 */
+	commitCharacters?: string[];
+
+	/**
+	 * An optional command that is executed *after* inserting this completion. *Note* that
+	 * additional modifications to the current document should be described with the
+	 * additionalTextEdits-property.
+	 */
+	command?: Command;
+
+	/**
+	 * A data entry field that is preserved on a completion item between
+	 * a completion and a completion resolve request.
+	 */
+	data?: any
+}
+
+/**
+ * The kind of a completion entry.
+ */
+namespace CompletionItemKind {
+	export const Text = 1;
+	export const Method = 2;
+	export const Function = 3;
+	export const Constructor = 4;
+	export const Field = 5;
+	export const Variable = 6;
+	export const Class = 7;
+	export const Interface = 8;
+	export const Module = 9;
+	export const Property = 10;
+	export const Unit = 11;
+	export const Value = 12;
+	export const Enum = 13;
+	export const Keyword = 14;
+	export const Snippet = 15;
+	export const Color = 16;
+	export const File = 17;
+	export const Reference = 18;
+	export const Folder = 19;
+	export const EnumMember = 20;
+	export const Constant = 21;
+	export const Struct = 22;
+	export const Event = 23;
+	export const Operator = 24;
+	export const TypeParameter = 25;
+}
+```
+* error: code and message set in case an exception happens during the completion request.
+
+_Registration Options_: `CompletionRegistrationOptions` options defined as follows:
+
+```typescript
+export interface CompletionRegistrationOptions extends TextDocumentRegistrationOptions {
+	/**
+	 * Most tools trigger completion request automatically without explicitly requesting
+	 * it using a keyboard shortcut (e.g. Ctrl+Space). Typically they do so when the user
+	 * starts to type an identifier. For example if the user types `c` in a JavaScript file
+	 * code complete will automatically pop up present `console` besides others as a
+	 * completion item. Characters that make up identifiers don't need to be listed here.
+	 *
+	 * If code complete should automatically be trigger on characters not being valid inside
+	 * an identifier (for example `.` in JavaScript) list them in `triggerCharacters`.
+	 */
+	triggerCharacters?: string[];
+
+	/**
+	 * The list of all possible characters that commit a completion. This field can be used
+	 * if clients don't support individual commmit characters per completion item. See
+	 * `ClientCapabilities.textDocument.completion.completionItem.commitCharactersSupport`.
+	 *
+	 * If a server provides both `allCommitCharacters` and commit characters on an individual
+	 * completion item the ones on the completion item win.
+	 *
+     * Since 3.2.0
+	 */
+	allCommitCharacters?: string[];
+
+	/**
+	 * The server provides support to resolve additional
+	 * information for a completion item.
+	 */
+	resolveProvider?: boolean;
+}
+```
+
+Completion items support snippets (see `InsertTextFormat.Snippet`). The snippet format is as follows:
+
+##### Snippet Syntax
+
+The `body` of a snippet can use special constructs to control cursors and the text being inserted. The following are supported features and their syntaxes:
+
+##### Tab stops
+
+With tab stops, you can make the editor cursor move inside a snippet. Use `$1`, `$2` to specify cursor locations. The number is the order in which tab stops will be visited, whereas `$0` denotes the final cursor position. Multiple tab stops are linked and updated in sync.
+
+##### Placeholders
+
+Placeholders are tab stops with values, like `${1:foo}`. The placeholder text will be inserted and selected such that it can be easily changed. Placeholders can be nested, like `${1:another ${2:placeholder}}`.
+
+##### Choice
+
+Placeholders can have choices as values. The syntax is a comma separated enumeration of values, enclosed with the pipe-character, for example `${1|one,two,three|}`. When the snippet is inserted and the placeholder selected, choices will prompt the user to pick one of the values.
+
+##### Variables
+
+With `$name` or `${name:default}` you can insert the value of a variable. When a variable isn’t set, its *default* or the empty string is inserted. When a variable is unknown (that is, its name isn’t defined) the name of the variable is inserted and it is transformed into a placeholder.
+
+The following variables can be used:
+
+* `TM_SELECTED_TEXT` The currently selected text or the empty string
+* `TM_CURRENT_LINE` The contents of the current line
+* `TM_CURRENT_WORD` The contents of the word under cursor or the empty string
+* `TM_LINE_INDEX` The zero-index based line number
+* `TM_LINE_NUMBER` The one-index based line number
+* `TM_FILENAME` The filename of the current document
+* `TM_FILENAME_BASE` The filename of the current document without its extensions
+* `TM_DIRECTORY` The directory of the current document
+* `TM_FILEPATH` The full file path of the current document
+
+##### Variable Transforms
+
+Transformations allow you to modify the value of a variable before it is inserted. The definition of a transformation consists of three parts:
+
+1. A regular expression that is matched against the value of a variable, or the empty string when the variable cannot be resolved.
+2. A "format string" that allows to reference matching groups from the regular expression. The format string allows for conditional inserts and simple modifications.
+3. Options that are passed to the regular expression.
+
+The following example inserts the name of the current file without its ending, so from `foo.txt` it makes `foo`.
+
+```
+${TM_FILENAME/(.*)\..+$/$1/}
+  |           |         | |
+  |           |         | |-> no options
+  |           |         |
+  |           |         |-> references the contents of the first
+  |           |             capture group
+  |           |
+  |           |-> regex to capture everything before
+  |               the final `.suffix`
+  |
+  |-> resolves to the filename
+```
+
+##### Grammar
+
+Below is the EBNF ([extended Backus-Naur form](https://en.wikipedia.org/wiki/Extended_Backus-Naur_form)) for snippets. With `\` (backslash), you can escape `$`, `}` and `\`. Within choice elements, the backslash also escapes comma and pipe characters.
+
+```
+any         ::= tabstop | placeholder | choice | variable | text
+tabstop     ::= '$' int | '${' int '}'
+placeholder ::= '${' int ':' any '}'
+choice      ::= '${' int '|' text (',' text)* '|}'
+variable    ::= '$' var | '${' var }'
+                | '${' var ':' any '}'
+                | '${' var '/' regex '/' (format | text)+ '/' options '}'
+format      ::= '$' int | '${' int '}'
+                | '${' int ':' '/upcase' | '/downcase' | '/capitalize' '}'
+                | '${' int ':+' if '}'
+                | '${' int ':?' if ':' else '}'
+                | '${' int ':-' else '}' | '${' int ':' else '}'
+regex       ::= JavaScript Regular Expression value (ctor-string)
+options     ::= JavaScript Regular Expression option (ctor-options)
+var         ::= [_a-zA-Z] [_a-zA-Z0-9]*
+int         ::= [0-9]+
+text        ::= .*
+```
+
+#### <a href="#completionItem_resolve" name="completionItem_resolve" class="anchor">Completion Item Resolve Request (:leftwards_arrow_with_hook:)</a>
+
+The request is sent from the client to the server to resolve additional information for a given completion item.
+
+_Request_:
+* method: 'completionItem/resolve'
+* params: `CompletionItem`
+
+_Response_:
+* result: `CompletionItem`
+* error: code and message set in case an exception happens during the completion resolve request.
+
+#### <a href="#textDocument_hover" name="textDocument_hover" class="anchor">Hover Request (:leftwards_arrow_with_hook:)</a>
+
+The hover request is sent from the client to the server to request hover information at a given text document position.
+
+_Request_:
+* method: 'textDocument/hover'
+* params: [`TextDocumentPositionParams`](#textdocumentpositionparams)
+
+_Response_:
+* result: `Hover` \| `null` defined as follows:
+
+```typescript
+/**
+ * The result of a hover request.
+ */
+interface Hover {
+	/**
+	 * The hover's content
+	 */
+	contents: MarkedString | MarkedString[] | MarkupContent;
+
+	/**
+	 * An optional range is a range inside a text document
+	 * that is used to visualize a hover, e.g. by changing the background color.
+	 */
+	range?: Range;
+}
+```
+
+Where `MarkedString` is defined as follows:
+
+```typescript
+/**
+ * MarkedString can be used to render human readable text. It is either a markdown string
+ * or a code-block that provides a language and a code snippet. The language identifier
+ * is semantically equal to the optional language identifier in fenced code blocks in GitHub
+ * issues. See https://help.github.com/articles/creating-and-highlighting-code-blocks/#syntax-highlighting
+ *
+ * The pair of a language and a value is an equivalent to markdown:
+ * ```${language}
+ * ${value}
+ * ```
+ *
+ * Note that markdown strings will be sanitized - that means html will be escaped.
+* @deprecated use MarkupContent instead.
+*/
+type MarkedString = string | { language: string; value: string };
+```
+
+* error: code and message set in case an exception happens during the hover request.
+
+_Registration Options_: `TextDocumentRegistrationOptions`
+
+#### <a href="#textDocument_signatureHelp" name="textDocument_signatureHelp" class="anchor">Signature Help Request (:leftwards_arrow_with_hook:)</a>
+
+The signature help request is sent from the client to the server to request signature information at a given cursor position.
+
+_Request_:
+* method: 'textDocument/signatureHelp'
+* params: [`TextDocumentPositionParams`](#textdocumentpositionparams)
+
+_Response_:
+* result: `SignatureHelp` \| `null` defined as follows:
+
+```typescript
+/**
+ * Signature help represents the signature of something
+ * callable. There can be multiple signature but only one
+ * active and only one active parameter.
+ */
+interface SignatureHelp {
+	/**
+	 * One or more signatures.
+	 */
+	signatures: SignatureInformation[];
+
+	/**
+	 * The active signature. If omitted or the value lies outside the
+	 * range of `signatures` the value defaults to zero or is ignored if
+	 * `signatures.length === 0`. Whenever possible implementors should
+	 * make an active decision about the active signature and shouldn't
+	 * rely on a default value.
+	 * In future version of the protocol this property might become
+	 * mandatory to better express this.
+	 */
+	activeSignature?: number;
+
+	/**
+	 * The active parameter of the active signature. If omitted or the value
+	 * lies outside the range of `signatures[activeSignature].parameters`
+	 * defaults to 0 if the active signature has parameters. If
+	 * the active signature has no parameters it is ignored.
+	 * In future version of the protocol this property might become
+	 * mandatory to better express the active parameter if the
+	 * active signature does have any.
+	 */
+	activeParameter?: number;
+}
+
+/**
+ * Represents the signature of something callable. A signature
+ * can have a label, like a function-name, a doc-comment, and
+ * a set of parameters.
+ */
+interface SignatureInformation {
+	/**
+	 * The label of this signature. Will be shown in
+	 * the UI.
+	 */
+	label: string;
+
+	/**
+	 * The human-readable doc-comment of this signature. Will be shown
+	 * in the UI but can be omitted.
+	 */
+	documentation?: string | MarkupContent;
+
+	/**
+	 * The parameters of this signature.
+	 */
+	parameters?: ParameterInformation[];
+}
+
+/**
+ * Represents a parameter of a callable-signature. A parameter can
+ * have a label and a doc-comment.
+ */
+interface ParameterInformation {
+
+	/**
+	 * The label of this parameter information.
+	 *
+	 * Either a string or an inclusive start and exclusive end offsets within its containing
+	 * signature label. (see SignatureInformation.label). The offsets are based on a UTF-16
+	 * string representation as `Position` and `Range` does.
+	 *
+	 * *Note*: a label of type string should be a substring of its containing signature label.
+	 * Its intended use case is to highlight the parameter label part in the `SignatureInformation.label`.
+	 */
+	label: string | [number, number];
+
+	/**
+	 * The human-readable doc-comment of this parameter. Will be shown
+	 * in the UI but can be omitted.
+	 */
+	documentation?: string | MarkupContent;
+}
+```
+
+* error: code and message set in case an exception happens during the signature help request.
+
+_Registration Options_: `SignatureHelpRegistrationOptions` defined as follows:
+
+```typescript
+export interface SignatureHelpRegistrationOptions extends TextDocumentRegistrationOptions {
+	/**
+	 * The characters that trigger signature help
+	 * automatically.
+	 */
+	triggerCharacters?: string[];
+}
+```
+#### <a href="#textDocument_declaration" name="textDocument_declaration" class="anchor">Goto Declaration Request (:leftwards_arrow_with_hook:)</a>
+
+> *Since version 3.14.0*
+
+The go to declaration request is sent from the client to the server to resolve the declaration location of a symbol at a given text document position.
+
+The result type [`LocationLink`](#locationlink)[] got introduce with version 3.14.0 and depends in the corresponding client capability `clientCapabilities.textDocument.declaration.linkSupport`.
+
+_Request_:
+* method: 'textDocument/declaration'
+* params: [`TextDocumentPositionParams`](#textdocumentpositionparams)
+
+_Response_:
+* result: [`Location`](#location) \| [`Location`](#location)[] \| [`LocationLink`](#locationlink)[] \|`null`
+* error: code and message set in case an exception happens during the declaration request.
+
+_Registration Options_: `TextDocumentRegistrationOptions`
+
+#### <a href="#textDocument_definition" name="textDocument_definition" class="anchor">Goto Definition Request (:leftwards_arrow_with_hook:)</a>
+
+> *Since version 3.14.0*
+
+The go to definition request is sent from the client to the server to resolve the definition location of a symbol at a given text document position.
+`
+The result type [`LocationLink`](#locationlink)[] got introduce with version 3.14.0 and depends in the corresponding client capability `clientCapabilities.textDocument.definition.linkSupport`.
+
+_Request_:
+* method: 'textDocument/definition'
+* params: [`TextDocumentPositionParams`](#textdocumentpositionparams)
+
+_Response_:
+* result: [`Location`](#location) \| [`Location`](#location)[] \| [`LocationLink`](#locationlink)[] \| `null`
+* error: code and message set in case an exception happens during the definition request.
+
+_Registration Options_: `TextDocumentRegistrationOptions`
+
+#### <a href="#textDocument_typeDefinition" name="textDocument_typeDefinition" class="anchor">Goto Type Definition Request (:leftwards_arrow_with_hook:)</a>
+
+> *Since version 3.6.0*
+
+The go to type definition request is sent from the client to the server to resolve the type definition location of a symbol at a given text document position.
+
+The result type [`LocationLink`](#locationlink)[] got introduce with version 3.14.0 and depends in the corresponding client capability `clientCapabilities.textDocument.typeDefinition.linkSupport`.
+
+_Request_:
+* method: 'textDocument/typeDefinition'
+* params: [`TextDocumentPositionParams`](#textdocumentpositionparams)
+
+_Response_:
+* result: [`Location`](#location) \| [`Location`](#location)[] \| [`LocationLink`](#locationlink)[] \| `null`
+* error: code and message set in case an exception happens during the definition request.
+
+_Registration Options_: `TextDocumentRegistrationOptions`
+
+#### <a href="#textDocument_implementation" name="textDocument_implementation" class="anchor">Goto Implementation Request (:leftwards_arrow_with_hook:)</a>
+
+> *Since version 3.6.0*
+
+The go to implementation request is sent from the client to the server to resolve the implementation location of a symbol at a given text document position.
+
+The result type [`LocationLink`](#locationlink)[] got introduce with version 3.14.0 and depends in the corresponding client capability `clientCapabilities.implementation.typeDefinition.linkSupport`.
+
+_Request_:
+* method: 'textDocument/implementation'
+* params: [`TextDocumentPositionParams`](#textdocumentpositionparams)
+
+_Response_:
+* result: [`Location`](#location) \| [`Location`](#location)[] \| [`LocationLink`](#locationlink)[] \| `null`
+* error: code and message set in case an exception happens during the definition request.
+
+_Registration Options_: `TextDocumentRegistrationOptions`
+
+#### <a href="#textDocument_references" name="textDocument_references" class="anchor">Find References Request (:leftwards_arrow_with_hook:)</a>
+
+The references request is sent from the client to the server to resolve project-wide references for the symbol denoted by the given text document position.
+
+_Request_:
+* method: 'textDocument/references'
+* params: `ReferenceParams` defined as follows:
+
+```typescript
+interface ReferenceParams extends TextDocumentPositionParams {
+	context: ReferenceContext
+}
+
+interface ReferenceContext {
+	/**
+	 * Include the declaration of the current symbol.
+	 */
+	includeDeclaration: boolean;
+}
+```
+_Response_:
+* result: [`Location`](#location)[] \| `null`
+* error: code and message set in case an exception happens during the reference request.
+
+_Registration Options_: `TextDocumentRegistrationOptions`
+
+#### <a href="#textDocument_documentHighlight" name="textDocument_documentHighlight" class="anchor">Document Highlights Request (:leftwards_arrow_with_hook:)</a>
+
+The document highlight request is sent from the client to the server to resolve a document highlights for a given text document position.
+For programming languages this usually highlights all references to the symbol scoped to this file. However we kept 'textDocument/documentHighlight'
+and 'textDocument/references' separate requests since the first one is allowed to be more fuzzy. Symbol matches usually have a `DocumentHighlightKind`
+of `Read` or `Write` whereas fuzzy or textual matches use `Text`as the kind.
+
+_Request_:
+* method: 'textDocument/documentHighlight'
+* params: [`TextDocumentPositionParams`](#textdocumentpositionparams)
+
+_Response_:
+* result: `DocumentHighlight[]` \| `null` defined as follows:
+
+```typescript
+/**
+ * A document highlight is a range inside a text document which deserves
+ * special attention. Usually a document highlight is visualized by changing
+ * the background color of its range.
+ *
+ */
+interface DocumentHighlight {
+	/**
+	 * The range this highlight applies to.
+	 */
+	range: Range;
+
+	/**
+	 * The highlight kind, default is DocumentHighlightKind.Text.
+	 */
+	kind?: number;
+}
+
+/**
+ * A document highlight kind.
+ */
+export namespace DocumentHighlightKind {
+	/**
+	 * A textual occurrence.
+	 */
+	export const Text = 1;
+
+	/**
+	 * Read-access of a symbol, like reading a variable.
+	 */
+	export const Read = 2;
+
+	/**
+	 * Write-access of a symbol, like writing to a variable.
+	 */
+	export const Write = 3;
+}
+```
+
+* error: code and message set in case an exception happens during the document highlight request.
+
+_Registration Options_: `TextDocumentRegistrationOptions`
+
+#### <a href="#textDocument_documentSymbol" name="textDocument_documentSymbol" class="anchor">Document Symbols Request (:leftwards_arrow_with_hook:)</a>
+
+The document symbol request is sent from the client to the server. The returned result is either
+
+- `SymbolInformation[]` which is a flat list of all symbols found in a given text document. Then neither the symbol's location range nor the symbol's container name should be used to infer a hierarchy.
+- `DocumentSymbol[]` which is a hierarchy of symbols found in a given text document.
+
+_Request_:
+* method: 'textDocument/documentSymbol'
+* params: `DocumentSymbolParams` defined as follows:
+
+```typescript
+interface DocumentSymbolParams {
+	/**
+	 * The text document.
+	 */
+	textDocument: TextDocumentIdentifier;
+}
+```
+
+_Response_:
+* result: `DocumentSymbol[]` \| `SymbolInformation[]` \| `null` defined as follows:
+
+```typescript
+/**
+ * A symbol kind.
+ */
+export namespace SymbolKind {
+	export const File = 1;
+	export const Module = 2;
+	export const Namespace = 3;
+	export const Package = 4;
+	export const Class = 5;
+	export const Method = 6;
+	export const Property = 7;
+	export const Field = 8;
+	export const Constructor = 9;
+	export const Enum = 10;
+	export const Interface = 11;
+	export const Function = 12;
+	export const Variable = 13;
+	export const Constant = 14;
+	export const String = 15;
+	export const Number = 16;
+	export const Boolean = 17;
+	export const Array = 18;
+	export const Object = 19;
+	export const Key = 20;
+	export const Null = 21;
+	export const EnumMember = 22;
+	export const Struct = 23;
+	export const Event = 24;
+	export const Operator = 25;
+	export const TypeParameter = 26;
+}
+
+/**
+ * Represents programming constructs like variables, classes, interfaces etc. that appear in a document. Document symbols can be
+ * hierarchical and they have two ranges: one that encloses its definition and one that points to its most interesting range,
+ * e.g. the range of an identifier.
+ */
+export class DocumentSymbol {
+
+	/**
+	 * The name of this symbol. Will be displayed in the user interface and therefore must not be
+	 * an empty string or a string only consisting of white spaces.
+	 */
+	name: string;
+
+	/**
+	 * More detail for this symbol, e.g the signature of a function.
+	 */
+	detail?: string;
+
+	/**
+	 * The kind of this symbol.
+	 */
+	kind: SymbolKind;
+
+	/**
+	 * Indicates if this symbol is deprecated.
+	 */
+	deprecated?: boolean;
+
+	/**
+	 * The range enclosing this symbol not including leading/trailing whitespace but everything else
+	 * like comments. This information is typically used to determine if the clients cursor is
+	 * inside the symbol to reveal in the symbol in the UI.
+	 */
+	range: Range;
+
+	/**
+	 * The range that should be selected and revealed when this symbol is being picked, e.g the name of a function.
+	 * Must be contained by the `range`.
+	 */
+	selectionRange: Range;
+
+	/**
+	 * Children of this symbol, e.g. properties of a class.
+	 */
+	children?: DocumentSymbol[];
+}
+
+/**
+ * Represents information about programming constructs like variables, classes,
+ * interfaces etc.
+ */
+interface SymbolInformation {
+	/**
+	 * The name of this symbol.
+	 */
+	name: string;
+
+	/**
+	 * The kind of this symbol.
+	 */
+	kind: number;
+
+	/**
+	 * Indicates if this symbol is deprecated.
+	 */
+	deprecated?: boolean;
+
+	/**
+	 * The location of this symbol. The location's range is used by a tool
+	 * to reveal the location in the editor. If the symbol is selected in the
+	 * tool the range's start information is used to position the cursor. So
+	 * the range usually spans more then the actual symbol's name and does
+	 * normally include things like visibility modifiers.
+	 *
+	 * The range doesn't have to denote a node range in the sense of a abstract
+	 * syntax tree. It can therefore not be used to re-construct a hierarchy of
+	 * the symbols.
+	 */
+	location: Location;
+
+	/**
+	 * The name of the symbol containing this symbol. This information is for
+	 * user interface purposes (e.g. to render a qualifier in the user interface
+	 * if necessary). It can't be used to re-infer a hierarchy for the document
+	 * symbols.
+	 */
+	containerName?: string;
+}
+
+```
+
+* error: code and message set in case an exception happens during the document symbol request.
+
+_Registration Options_: `TextDocumentRegistrationOptions`
+
+#### <a href="#textDocument_codeAction" name="textDocument_codeAction" class="anchor">Code Action Request (:leftwards_arrow_with_hook:)</a>
+
+The code action request is sent from the client to the server to compute commands for a given text document and range. These commands are typically code fixes to either fix problems or to beautify/refactor code. The result of a `textDocument/codeAction` request is an array of `Command` literals which are typically presented in the user interface. To ensure that a server is useful in many clients the commands specified in a code actions should be handled by the server and not by the client (see `workspace/executeCommand` and `ServerCapabilities.executeCommandProvider`). If the client supports providing edits with a code action then the mode should be used.
+
+When the command is selected the server should be contacted again (via the `workspace/executeCommand`) request to execute the command.
+
+> *Since version 3.8.0:* support for CodeAction literals to enable the following scenarios:
+
+- the ability to directly return a workspace edit from the code action request. This avoids having another server roundtrip to execute an actual code action. However server providers should be aware that if the code action is expensive to compute or the edits are huge it might still be beneficial if the result is simply a command and the actual edit is only computed when needed.
+- the ability to group code actions using a kind. Clients are allowed to ignore that information. However it allows them to better group code action for example into corresponding menus (e.g. all refactor code actions into a refactor menu).
+
+Clients need to announce their support for code action literals and code action kinds via the corresponding client capability `textDocument.codeAction.codeActionLiteralSupport`.
+
+_Request_:
+* method: 'textDocument/codeAction'
+* params: `CodeActionParams` defined as follows:
+
+```typescript
+/**
+ * Params for the CodeActionRequest
+ */
+interface CodeActionParams {
+	/**
+	 * The document in which the command was invoked.
+	 */
+	textDocument: TextDocumentIdentifier;
+
+	/**
+	 * The range for which the command was invoked.
+	 */
+	range: Range;
+
+	/**
+	 * Context carrying additional information.
+	 */
+	context: CodeActionContext;
+}
+
+/**
+ * The kind of a code action.
+ *
+ * Kinds are a hierarchical list of identifiers separated by `.`, e.g. `"refactor.extract.function"`.
+ *
+ * The set of kinds is open and client needs to announce the kinds it supports to the server during
+ * initialization.
+ */
+export type CodeActionKind = string;
+
+/**
+ * A set of predefined code action kinds
+ */
+export namespace CodeActionKind {
+
+	/**
+	 * Empty kind.
+	 */
+	export const Empty: CodeActionKind = '';
+
+	/**
+	 * Base kind for quickfix actions: 'quickfix'
+	 */
+	export const QuickFix: CodeActionKind = 'quickfix';
+
+	/**
+	 * Base kind for refactoring actions: 'refactor'
+	 */
+	export const Refactor: CodeActionKind = 'refactor';
+
+	/**
+	 * Base kind for refactoring extraction actions: 'refactor.extract'
+	 *
+	 * Example extract actions:
+	 *
+	 * - Extract method
+	 * - Extract function
+	 * - Extract variable
+	 * - Extract interface from class
+	 * - ...
+	 */
+	export const RefactorExtract: CodeActionKind = 'refactor.extract';
+
+	/**
+	 * Base kind for refactoring inline actions: 'refactor.inline'
+	 *
+	 * Example inline actions:
+	 *
+	 * - Inline function
+	 * - Inline variable
+	 * - Inline constant
+	 * - ...
+	 */
+	export const RefactorInline: CodeActionKind = 'refactor.inline';
+
+	/**
+	 * Base kind for refactoring rewrite actions: 'refactor.rewrite'
+	 *
+	 * Example rewrite actions:
+	 *
+	 * - Convert JavaScript function to class
+	 * - Add or remove parameter
+	 * - Encapsulate field
+	 * - Make method static
+	 * - Move method to base class
+	 * - ...
+	 */
+	export const RefactorRewrite: CodeActionKind = 'refactor.rewrite';
+
+	/**
+	 * Base kind for source actions: `source`
+	 *
+	 * Source code actions apply to the entire file.
+	 */
+	export const Source: CodeActionKind = 'source';
+
+	/**
+	 * Base kind for an organize imports source action: `source.organizeImports`
+	 */
+	export const SourceOrganizeImports: CodeActionKind = 'source.organizeImports';
+}
+
+/**
+ * Contains additional diagnostic information about the context in which
+ * a code action is run.
+ */
+interface CodeActionContext {
+	/**
+	 * An array of diagnostics.
+	 */
+	diagnostics: Diagnostic[];
+
+	/**
+	 * Requested kind of actions to return.
+	 *
+	 * Actions not of this kind are filtered out by the client before being shown. So servers
+	 * can omit computing them.
+	 */
+	only?: CodeActionKind[];
+}
+```
+
+_Response_:
+* result: `(Command | CodeAction)[]` \| `null` where `CodeAction` is defined as follows:
+
+```typescript
+/**
+ * A code action represents a change that can be performed in code, e.g. to fix a problem or
+ * to refactor code.
+ *
+ * A CodeAction must set either `edit` and/or a `command`. If both are supplied, the `edit` is applied first, then the `command` is executed.
+ */
+export interface CodeAction {
+
+	/**
+	 * A short, human-readable, title for this code action.
+	 */
+	title: string;
+
+	/**
+	 * The kind of the code action.
+	 *
+	 * Used to filter code actions.
+	 */
+	kind?: CodeActionKind;
+
+	/**
+	 * The diagnostics that this code action resolves.
+	 */
+	diagnostics?: Diagnostic[];
+
+	/**
+	 * The workspace edit this code action performs.
+	 */
+	edit?: WorkspaceEdit;
+
+	/**
+	 * A command this code action executes. If a code action
+	 * provides an edit and a command, first the edit is
+	 * executed and then the command.
+	 */
+	command?: Command;
+}
+```
+
+* error: code and message set in case an exception happens during the code action request.
+
+_Registration Options_: `CodeActionRegistrationOptions`  defined as follows:
+
+```typescript
+export interface CodeActionRegistrationOptions extends TextDocumentRegistrationOptions, CodeActionOptions {
+}
+```
+
+
+#### <a href="#textDocument_codeLens" name="textDocument_codeLens" class="anchor">Code Lens Request (:leftwards_arrow_with_hook:)</a>
+
+The code lens request is sent from the client to the server to compute code lenses for a given text document.
+
+_Request_:
+* method: 'textDocument/codeLens'
+* params: `CodeLensParams` defined as follows:
+
+```typescript
+interface CodeLensParams {
+	/**
+	 * The document to request code lens for.
+	 */
+	textDocument: TextDocumentIdentifier;
+}
+```
+
+_Response_:
+* result: `CodeLens[]` \| `null` defined as follows:
+
+```typescript
+/**
+ * A code lens represents a command that should be shown along with
+ * source text, like the number of references, a way to run tests, etc.
+ *
+ * A code lens is _unresolved_ when no command is associated to it. For performance
+ * reasons the creation of a code lens and resolving should be done in two stages.
+ */
+interface CodeLens {
+	/**
+	 * The range in which this code lens is valid. Should only span a single line.
+	 */
+	range: Range;
+
+	/**
+	 * The command this code lens represents.
+	 */
+	command?: Command;
+
+	/**
+	 * A data entry field that is preserved on a code lens item between
+	 * a code lens and a code lens resolve request.
+	 */
+	data?: any
+}
+```
+* error: code and message set in case an exception happens during the code lens request.
+
+_Registration Options_: `CodeLensRegistrationOptions` defined as follows:
+
+```typescript
+export interface CodeLensRegistrationOptions extends TextDocumentRegistrationOptions {
+	/**
+	 * Code lens has a resolve provider as well.
+	 */
+	resolveProvider?: boolean;
+}
+```
+
+#### <a href="#codeLens_resolve" name="codeLens_resolve" class="anchor">Code Lens Resolve Request (:leftwards_arrow_with_hook:)</a>
+
+The code lens resolve request is sent from the client to the server to resolve the command for a given code lens item.
+
+_Request_:
+* method: 'codeLens/resolve'
+* params: `CodeLens`
+
+_Response_:
+* result: `CodeLens`
+* error: code and message set in case an exception happens during the code lens resolve request.
+
+#### <a href="#textDocument_documentLink" name="textDocument_documentLink" class="anchor">Document Link Request (:leftwards_arrow_with_hook:)</a>
+
+The document links request is sent from the client to the server to request the location of links in a document.
+
+_Request_:
+* method: 'textDocument/documentLink'
+* params: `DocumentLinkParams`, defined as follows:
+
+```typescript
+interface DocumentLinkParams {
+	/**
+	 * The document to provide document links for.
+	 */
+	textDocument: TextDocumentIdentifier;
+}
+```
+
+_Response_:
+* result: An array of `DocumentLink` \| `null`.
+
+```typescript
+/**
+ * A document link is a range in a text document that links to an internal or external resource, like another
+ * text document or a web site.
+ */
+interface DocumentLink {
+	/**
+	 * The range this link applies to.
+	 */
+	range: Range;
+	/**
+	 * The uri this link points to. If missing a resolve request is sent later.
+	 */
+	target?: DocumentUri;
+	/**
+	 * A data entry field that is preserved on a document link between a
+	 * DocumentLinkRequest and a DocumentLinkResolveRequest.
+	 */
+	data?: any;
+}
+```
+* error: code and message set in case an exception happens during the document link request.
+
+_Registration Options_: `DocumentLinkRegistrationOptions` defined as follows:
+
+```typescript
+export interface DocumentLinkRegistrationOptions extends TextDocumentRegistrationOptions {
+	/**
+	 * Document links have a resolve provider as well.
+	 */
+	resolveProvider?: boolean;
+}
+```
+
+#### <a href="#documentLink_resolve" name="documentLink_resolve" class="anchor">Document Link Resolve Request (:leftwards_arrow_with_hook:)</a>
+
+The document link resolve request is sent from the client to the server to resolve the target of a given document link.
+
+_Request_:
+* method: 'documentLink/resolve'
+* params: `DocumentLink`
+
+_Response_:
+* result: `DocumentLink`
+* error: code and message set in case an exception happens during the document link resolve request.
+
+#### <a href="#textDocument_documentColor" name="textDocument_documentColor" class="anchor">Document Color Request (:leftwards_arrow_with_hook:)</a>
+
+> *Since version 3.6.0*
+
+The document color request is sent from the client to the server to list all color references found in a given text document. Along with the range, a color value in RGB is returned.
+
+Clients can use the result to decorate color references in an editor. For example:
+- Color boxes showing the actual color next to the reference
+- Show a color picker when a color reference is edited
+
+_Request_:
+
+* method: 'textDocument/documentColor'
+* params: `DocumentColorParams` defined as follows
+
+```ts
+interface DocumentColorParams {
+	/**
+	 * The text document.
+	 */
+	textDocument: TextDocumentIdentifier;
+}
+```
+
+_Response_:
+* result: `ColorInformation[]` defined as follows:
+
+```typescript
+interface ColorInformation {
+	/**
+	 * The range in the document where this color appears.
+	 */
+	range: Range;
+
+	/**
+	 * The actual color value for this color range.
+	 */
+	color: Color;
+}
+
+/**
+ * Represents a color in RGBA space.
+ */
+interface Color {
+
+	/**
+	 * The red component of this color in the range [0-1].
+	 */
+	readonly red: number;
+
+	/**
+	 * The green component of this color in the range [0-1].
+	 */
+	readonly green: number;
+
+	/**
+	 * The blue component of this color in the range [0-1].
+	 */
+	readonly blue: number;
+
+	/**
+	 * The alpha component of this color in the range [0-1].
+	 */
+	readonly alpha: number;
+}
+```
+* error: code and message set in case an exception happens during the 'textDocument/documentColor' request
+
+#### <a href="#textDocument_colorPresentation" name="textDocument_colorPresentation" class="anchor">Color Presentation Request (:leftwards_arrow_with_hook:)</a>
+
+> *Since version 3.6.0*
+
+The color presentation request is sent from the client to the server to obtain a list of presentations for a color value at a given location. Clients can use the result to
+- modify a color reference.
+- show in a color picker and let users pick one of the presentations
+
+
+_Request_:
+
+* method: 'textDocument/colorPresentation'
+* params: `ColorPresentationParams` defined as follows
+
+```typescript
+interface ColorPresentationParams {
+	/**
+	 * The text document.
+	 */
+	textDocument: TextDocumentIdentifier;
+
+	/**
+	 * The color information to request presentations for.
+	 */
+	color: Color;
+
+	/**
+	 * The range where the color would be inserted. Serves as a context.
+	 */
+	range: Range;
+}
+```
+
+_Response_:
+* result: `ColorPresentation[]` defined as follows:
+
+```typescript
+interface ColorPresentation {
+	/**
+	 * The label of this color presentation. It will be shown on the color
+	 * picker header. By default this is also the text that is inserted when selecting
+	 * this color presentation.
+	 */
+	label: string;
+	/**
+	 * An [edit](#TextEdit) which is applied to a document when selecting
+	 * this presentation for the color.  When `falsy` the [label](#ColorPresentation.label)
+	 * is used.
+	 */
+	textEdit?: TextEdit;
+	/**
+	 * An optional array of additional [text edits](#TextEdit) that are applied when
+	 * selecting this color presentation. Edits must not overlap with the main [edit](#ColorPresentation.textEdit) nor with themselves.
+	 */
+	additionalTextEdits?: TextEdit[];
+}
+```
+
+* error: code and message set in case an exception happens during the 'textDocument/colorPresentation' request
+
+#### <a href="#textDocument_formatting" name="textDocument_formatting" class="anchor">Document Formatting Request  (:leftwards_arrow_with_hook:)</a>
+
+The document formatting request is sent from the client to the server to format a whole document.
+
+_Request_:
+* method: 'textDocument/formatting'
+* params: `DocumentFormattingParams` defined as follows
+
+```typescript
+interface DocumentFormattingParams {
+	/**
+	 * The document to format.
+	 */
+	textDocument: TextDocumentIdentifier;
+
+	/**
+	 * The format options.
+	 */
+	options: FormattingOptions;
+}
+
+/**
+ * Value-object describing what options formatting should use.
+ */
+interface FormattingOptions {
+	/**
+	 * Size of a tab in spaces.
+	 */
+	tabSize: number;
+
+	/**
+	 * Prefer spaces over tabs.
+	 */
+	insertSpaces: boolean;
+
+	/**
+	 * Signature for further properties.
+	 */
+	[key: string]: boolean | number | string;
+}
+```
+
+_Response_:
+* result: [`TextEdit[]`](#textedit) \| `null` describing the modification to the document to be formatted.
+* error: code and message set in case an exception happens during the formatting request.
+
+_Registration Options_: `TextDocumentRegistrationOptions`
+
+#### <a href="#textDocument_rangeFormatting" name="textDocument_rangeFormatting" class="anchor">Document Range Formatting Request (:leftwards_arrow_with_hook:)</a>
+
+The document range formatting request is sent from the client to the server to format a given range in a document.
+
+_Request_:
+* method: 'textDocument/rangeFormatting',
+* params: `DocumentRangeFormattingParams` defined as follows:
+
+```typescript
+interface DocumentRangeFormattingParams {
+	/**
+	 * The document to format.
+	 */
+	textDocument: TextDocumentIdentifier;
+
+	/**
+	 * The range to format
+	 */
+	range: Range;
+
+	/**
+	 * The format options
+	 */
+	options: FormattingOptions;
+}
+```
+
+_Response_:
+* result: [`TextEdit[]`](#textedit) \| `null` describing the modification to the document to be formatted.
+* error: code and message set in case an exception happens during the range formatting request.
+
+_Registration Options_: `TextDocumentRegistrationOptions`
+
+#### <a href="#textDocument_onTypeFormatting" name="textDocument_onTypeFormatting" class="anchor">Document on Type Formatting Request (:leftwards_arrow_with_hook:)</a>
+
+The document on type formatting request is sent from the client to the server to format parts of the document during typing.
+
+_Request_:
+* method: 'textDocument/onTypeFormatting'
+* params: `DocumentOnTypeFormattingParams` defined as follows:
+
+```typescript
+interface DocumentOnTypeFormattingParams {
+	/**
+	 * The document to format.
+	 */
+	textDocument: TextDocumentIdentifier;
+
+	/**
+	 * The position at which this request was sent.
+	 */
+	position: Position;
+
+	/**
+	 * The character that has been typed.
+	 */
+	ch: string;
+
+	/**
+	 * The format options.
+	 */
+	options: FormattingOptions;
+}
+```
+
+_Response_:
+* result: [`TextEdit[]`](#textedit) \| `null` describing the modification to the document.
+* error: code and message set in case an exception happens during the range formatting request.
+
+_Registration Options_: `DocumentOnTypeFormattingRegistrationOptions` defined as follows:
+
+```typescript
+export interface DocumentOnTypeFormattingRegistrationOptions extends TextDocumentRegistrationOptions {
+	/**
+	 * A character on which formatting should be triggered, like `}`.
+	 */
+	firstTriggerCharacter: string;
+	/**
+	 * More trigger characters.
+	 */
+	moreTriggerCharacter?: string[]
+}
+```
+#### <a href="#textDocument_rename" name="textDocument_rename" class="anchor">Rename Request (:leftwards_arrow_with_hook:)</a>
+
+The rename request is sent from the client to the server to perform a workspace-wide rename of a symbol.
+
+_Request_:
+* method: 'textDocument/rename'
+* params: `RenameParams` defined as follows
+
+```typescript
+interface RenameParams {
+	/**
+	 * The document to rename.
+	 */
+	textDocument: TextDocumentIdentifier;
+
+	/**
+	 * The position at which this request was sent.
+	 */
+	position: Position;
+
+	/**
+	 * The new name of the symbol. If the given name is not valid the
+	 * request must return a [ResponseError](#ResponseError) with an
+	 * appropriate message set.
+	 */
+	newName: string;
+}
+```
+
+_Response_:
+* result: [`WorkspaceEdit`](#workspaceedit) \| `null` describing the modification to the workspace.
+* error: code and message set in case an exception happens during the rename request.
+
+_Registration Options_: `RenameRegistrationOptions` defined as follows:
+
+```typescript
+export interface RenameRegistrationOptions extends TextDocumentRegistrationOptions {
+	/**
+	 * Renames should be checked and tested for validity before being executed.
+	 */
+	prepareProvider?: boolean;
+}
+```
+
+#### <a href="#textDocument_prepareRename" name="textDocument_prepareRename" class="anchor">Prepare Rename Request (:leftwards_arrow_with_hook:)</a>
+
+> *Since version 3.12.0*
+
+The prepare rename request is sent from the client to the server to setup and test the validity of a rename operation at a given location.
+
+_Request_:
+* method: 'textDocument/prepareRename'
+* params: [`TextDocumentPositionParams`](#textdocumentpositionparams)
+
+_Response_:
+* result: [`Range`](#range) \| `{ range: Range, placeholder: string }` \| `null` describing the range of the string to rename and optionally a placeholder text of the string content to be renamed. If `null` is returned then it is deemed that a 'textDocument/rename' request is not valid at the given position.
+* error: code and message set in case an exception happens during the prepare rename request.
+
+#### <a href="#textDocument_foldingRange" name="textDocument_foldingRange" class="anchor">Folding Range Request (:leftwards_arrow_with_hook:)</a>
+
+> *Since version 3.10.0*
+
+The folding range request is sent from the client to the server to return all folding ranges found in a given text document.
+
+_Request_:
+
+* method: 'textDocument/foldingRange'
+* params: `FoldingRangeParams` defined as follows
+
+```typescript
+export interface FoldingRangeParams {
+	/**
+	 * The text document.
+	 */
+	textDocument: TextDocumentIdentifier;
+}
+
+```
+
+_Response_:
+* result: `FoldingRange[] | null` defined as follows:
+
+```typescript
+/**
+ * Enum of known range kinds
+ */
+export enum FoldingRangeKind {
+	/**
+	 * Folding range for a comment
+	 */
+	Comment = 'comment',
+	/**
+	 * Folding range for a imports or includes
+	 */
+	Imports = 'imports',
+	/**
+	 * Folding range for a region (e.g. `#region`)
+	 */
+	Region = 'region'
+}
+
+/**
+ * Represents a folding range.
+ */
+export interface FoldingRange {
+
+	/**
+	 * The zero-based line number from where the folded range starts.
+	 */
+	startLine: number;
+
+	/**
+	 * The zero-based character offset from where the folded range starts. If not defined, defaults to the length of the start line.
+	 */
+	startCharacter?: number;
+
+	/**
+	 * The zero-based line number where the folded range ends.
+	 */
+	endLine: number;
+
+	/**
+	 * The zero-based character offset before the folded range ends. If not defined, defaults to the length of the end line.
+	 */
+	endCharacter?: number;
+
+	/**
+	 * Describes the kind of the folding range such as `comment' or 'region'. The kind
+	 * is used to categorize folding ranges and used by commands like 'Fold all comments'. See
+	 * [FoldingRangeKind](#FoldingRangeKind) for an enumeration of standardized kinds.
+	 */
+	kind?: string;
+}
+```
+
+* error: code and message set in case an exception happens during the 'textDocument/foldingRange' request
+
+_Registration Options_: `TextDocumentRegistrationOptions`
+
+
+### Implementation considerations
+
+Language servers usually run in a separate process and client communicate with them in an asynchronous fashion. Additionally clients usually allow users to interact with the source code even if request results are pending. We recommend the following implementation pattern to avoid that clients apply outdated response results:
+
+- if a client sends a request to the server and the client state changes in a way that the result will be invalid it should cancel the server request and ignore the result. If necessary it can resend the request to receive an up to date result.
+- if a server detects a state change that invalidates the result of a request in execution the server can error these requests with `ContentModified`. If clients receive a `ContentModified` error, it generally should not show it in the UI for the end-user. Clients can resend the request if appropriate.
+- if servers end up in an inconsistent state they should log this to the client using the `window/logMessage` request. If they can't recover from this the best they can do right now is to exit themselves. We are considering an [extension to the protocol](https://github.com/Microsoft/language-server-protocol/issues/646) that allows servers to request a restart on the client side.
+- if a client notices that a server exists unexpectedly it should try to restart the server. However clients should be careful to not restart a crashing server endlessly. VS Code for example doesn't restart a server if it crashes 5 times in the last 180 seconds.
+
+### <a href="#changeLog" name="changeLog" class="anchor">Change Log</a>
+
+#### <a href="#version_3_14_0" name="version_3_14_0" class="anchor">3.14.0 (12/13/2018)</a>
+
+* Add support for signature label offsets.
+* Add support for location links.
+* Add support for `textDocument/declaration` request.
+
+#### <a href="#version_3_13_0" name="version_3_13_0" class="anchor">3.13.0 (9/11/2018)</a>
+
+* Add support for file and folder operations (create, rename, move) to workspace edits.
+
+#### <a href="#version_3_12_0" name="version_3_12_0" class="anchor">3.12.0 (8/23/2018)</a>
+
+* Add support for `textDocument/prepareRename` request.
+
+#### <a href="#version_3_11_0" name="version_3_11_0" class="anchor">3.11.0 (8/21/2018)</a>
+
+* Add support for CodeActionOptions to allow a server to provide a list of code action it supports.
+
+#### <a href="#version_3_10_0" name="version_3_10_0" class="anchor">3.10.0 (7/23/2018)</a>
+
+* Add support for hierarchical document symbols as a valid response to a `textDocument/documentSymbol` request.
+* Add support for folding ranges as a valid response to a `textDocument/foldingRange` request.
+
+#### <a href="#version_3_9_0" name="version_3_9_0" class="anchor">3.9.0 (7/10/2018)</a>
+
+* Add support for `preselect` property in `CompletionItem`
+
+#### <a href="#version_3_8_0" name="version_3_8_0" class="anchor">3.8.0 (6/11/2018)</a>
+
+* Added support for CodeAction literals to the `textDocument/codeAction` request.
+* ColorServerCapabilities.colorProvider can also be a boolean
+* Corrected ColorPresentationParams.colorInfo to color (as in the `d.ts` and in implementations)
+
+#### <a href="#version_3_7_0" name="version_3_7_0" class="anchor">3.7.0 (4/5/2018)</a>
+
+* Added support for related information to Diagnostics.
+
+#### <a href="#version_3_6_0" name="version_3_6_0" class="anchor">3.6.0 (2/22/2018)</a>
+
+Merge the proposed protocol for workspace folders, configuration, go to type definition, go to implementation and document color provider into the main branch of the specification. For details see:
+
+* [Get Workspace Folders](https://microsoft.github.io/language-server-protocol/specification#workspace_workspaceFolders)
+* [DidChangeWorkspaceFolders Notification](https://microsoft.github.io/language-server-protocol/specification#workspace_didChangeWorkspaceFolders)
+* [Get Configuration](https://microsoft.github.io/language-server-protocol/specification#workspace_configuration)
+* [Go to Type Definition](https://microsoft.github.io/language-server-protocol/specification#textDocument_typeDefinition)
+* [Go to Implementation](https://microsoft.github.io/language-server-protocol/specification#textDocument_implementation)
+* [Document Color](https://microsoft.github.io/language-server-protocol/specification#textDocument_documentColor)
+* [Color Presentation](https://microsoft.github.io/language-server-protocol/specification#textDocument_colorPresentation)
+
+In addition we enhanced the `CompletionTriggerKind` with a new value `TriggerForIncompleteCompletions: 3 = 3` to signal the a completion request got trigger since the last result was incomplete.
+
+#### <a href="#version_3_5_0" name="version_3_5_0" class="anchor">3.5.0</a>
+
+Decided to skip this version to bring the protocol version number in sync the with npm module vscode-languageserver-protocol.
+
+#### <a href="#version_3_4_0" name="version_3_4_0" class="anchor">3.4.0 (11/27/2017)</a>
+
+* [extensible completion item and symbol kinds](https://github.com/Microsoft/language-server-protocol/issues/129)
+
+#### <a href="version_3_3_0" name="version_3_3_0" class="anchor">3.3.0 (11/24/2017)</a>
+
+* Added support for `CompletionContext`
+* Added support for `MarkupContent`
+* Removed old New and Updated markers.
+
+#### <a href="version_3_2_0" name="version_3_2_0" class="anchor">3.2.0 (09/26/2017)</a>
+
+* Added optional `commitCharacters` property to the `CompletionItem`
+
+#### <a href="version_3_1_0" name="version_3_1_0" class="anchor">3.1.0 (02/28/2017)</a>
+
+* Make the `WorkspaceEdit` changes backwards compatible.
+* Updated the specification to correctly describe the breaking changes from 2.x to 3.x around `WorkspaceEdit`and `TextDocumentEdit`.
+
+#### <a href="#version_3_0_0" name="version_3_0_0" class="anchor">3.0 Version</a>
+
+- add support for client feature flags to support that servers can adapt to different client capabilities. An example is the new `textDocument/willSaveWaitUntil` request which not all clients might be able to support. If the feature is disabled in the client capabilities sent on the initialize request, the server can't rely on receiving the request.
+- add support to experiment with new features. The new `ClientCapabilities.experimental` section together with feature flags allow servers to provide experimental feature without the need of ALL clients to adopt them immediately.
+- servers can more dynamically react to client features. Capabilities can now be registered and unregistered after the initialize request using the new `client/registerCapability` and `client/unregisterCapability`. This for example allows servers to react to settings or configuration changes without a restart.
+- add support for `textDocument/willSave` notification and `textDocument/willSaveWaitUntil` request.
+- add support for `textDocument/documentLink` request.
+- add a `rootUri` property to the initializeParams in favor of the `rootPath` property.

--- a/doc/specification-3-14.md.commit
+++ b/doc/specification-3-14.md.commit
@@ -1,0 +1,8 @@
+Repo: https://github.com/microsoft/language-server-protocol.git
+Branch: gh-pages
+
+commit 9255683f91f4403e5f3a43557b065251a7a597a1 (HEAD -> gh-pages, origin/gh-pages)
+Merge: 0be4cb6 12daf34
+Author: Dirk Bäumer <dirkb@microsoft.com>
+Date:   Wed Nov 6 12:01:55 2019 +0100
+

--- a/scripts/reorder.awk
+++ b/scripts/reorder.awk
@@ -1,0 +1,115 @@
+# This AWK script extracts typescripts comments from lsp-messages.ads
+# and reorders them in an order that corresponds to LSP specification.
+# Use the following command to run the script:
+#
+#sed -n -e '/^   --```typescript/,/^   --```/p' \
+# ../source/protocol/lsp-messages.ads | awk -f reorder.awk
+BEGIN{Span_Index=0}
+/--```typescript/{Line_Index=0}
+!/--```/{ARR[Span_Index][Line_Index++]=$0}
+/--```$/{Span_Index++;Line_Index=0}
+END{
+    M=0
+    Map[M++]=0
+    Map[M++]=1
+    Map[M++]=2
+    Map[M++]=3
+    Map[M++]=4
+    Map[M++]=5
+    Map[M++]=6
+    Map[M++]=7
+    Map[M++]=8
+    Map[M++]=9
+    Map[M++]=10
+    Map[M++]=13
+    Map[M++]=11
+    Map[M++]=12
+    Map[M++]=14
+    Map[M++]=15
+    Map[M++]=18
+    Map[M++]=19
+    Map[M++]=20
+    Map[M++]=16
+    Map[M++]=21
+    Map[M++]=17
+    Map[M++]=22
+    Map[M++]=23
+    Map[M++]=24
+    Map[M++]=25
+    Map[M++]=27
+    Map[M++]=31
+    Map[M++]=26
+    Map[M++]=28
+    Map[M++]=29
+    Map[M++]=33
+    Map[M++]=35
+    Map[M++]=36
+    Map[M++]=32
+    Map[M++]=34
+    Map[M++]=38
+    Map[M++]=37
+    Map[M++]=39
+    Map[M++]=40
+    Map[M++]=41
+    Map[M++]=51
+    Map[M++]=42
+    Map[M++]=52
+    Map[M++]=30
+    Map[M++]=85
+    Map[M++]=53
+
+    Map[M++]=86
+    Map[M++]=60
+    Map[M++]=59
+    Map[M++]=87
+    Map[M++]=70
+    Map[M++]=80
+    Map[M++]=50
+    Map[M++]=81
+    Map[M++]=82
+    Map[M++]=54
+    Map[M++]=55
+    Map[M++]=43
+    Map[M++]=56
+    Map[M++]=57
+    Map[M++]=44
+    Map[M++]=58
+    Map[M++]=61
+    Map[M++]=88
+    Map[M++]=62
+    Map[M++]=45
+    Map[M++]=64
+    Map[M++]=63
+    Map[M++]=65
+    Map[M++]=46
+    Map[M++]=66
+    Map[M++]=67
+    Map[M++]=68
+    Map[M++]=69
+    Map[M++]=71
+    Map[M++]=89
+    Map[M++]=90
+    Map[M++]=72
+    Map[M++]=73
+    Map[M++]=47
+    Map[M++]=74
+    Map[M++]=75
+    Map[M++]=48
+    Map[M++]=91
+    Map[M++]=92
+    Map[M++]=93
+    Map[M++]=76
+    Map[M++]=77
+    Map[M++]=78
+    Map[M++]=49
+    Map[M++]=79
+    Map[M++]=94
+    Map[M++]=95
+    Map[M++]=96
+    
+    for(J in Map) {
+        print "   --```typescript"#, J, Map[J]
+        for (K in ARR[Map[J]]) print ARR[Map[J]][K]
+        print "   --```"
+    }
+}

--- a/source/ada/lsp-ada_driver.adb
+++ b/source/ada/lsp-ada_driver.adb
@@ -155,6 +155,7 @@ begin
       Server.Run
         (Error_Decorator'Unchecked_Access,
          Handler'Unchecked_Access,
+         Server       => Handler'Unchecked_Access,
          On_Error     => On_Uncaught_Exception'Unrestricted_Access,
          Server_Trace => Server_Trace,
          In_Trace     => In_Trace,

--- a/source/ada/lsp-ada_handlers.adb
+++ b/source/ada/lsp-ada_handlers.adb
@@ -1526,6 +1526,12 @@ package body LSP.Ada_Handlers is
          procedure Process_Comments
            (Node : Ada_Node;
             Uri  : LSP.Messages.DocumentUri);
+         --  Iterate over all comments and include them in the responce when
+         --  they contain a remaned word
+
+         -----------------------
+         --  Process_Comments --
+         -----------------------
 
          procedure Process_Comments
            (Node : Ada_Node;
@@ -1542,7 +1548,7 @@ package body LSP.Ada_Handlers is
          begin
             while Token /= No_Token loop
                if Kind (Data (Token)) = Ada_Comment
-                 and then Contain (Token, Name, Span)
+                 and then Contains (Token, Name, Span)
                then
                   declare
                      C : constant LSP.Messages.TextEdit :=

--- a/source/ada/lsp-ada_handlers.adb
+++ b/source/ada/lsp-ada_handlers.adb
@@ -492,7 +492,9 @@ package body LSP.Ada_Handlers is
       Response.result.capabilities.typeDefinitionProvider := True;
       Response.result.capabilities.referencesProvider := True;
       Response.result.capabilities.documentSymbolProvider := True;
-      Response.result.capabilities.renameProvider := True;
+      Response.result.capabilities.renameProvider :=
+        (Is_Set => True,
+         Value  => (prepareProvider => (Is_Set => False)));
       Response.result.capabilities.textDocumentSync :=
         (Is_Set => True, Is_Number => True, Value => LSP.Messages.Full);
       Response.result.capabilities.completionProvider :=

--- a/source/ada/lsp-ada_handlers.adb
+++ b/source/ada/lsp-ada_handlers.adb
@@ -16,6 +16,7 @@
 ------------------------------------------------------------------------------
 
 with Ada.Characters.Handling; use Ada.Characters.Handling;
+with Ada.Strings.Wide_Wide_Unbounded;
 with Ada.Strings.UTF_Encoding;
 with Ada.Strings.UTF_Encoding.Wide_Wide_Strings;
 with Ada.Strings.Unbounded; use Ada.Strings.Unbounded;
@@ -1521,6 +1522,43 @@ package body LSP.Ada_Handlers is
          Definition : Defining_Name;
          Imprecise  : Boolean;
          Empty      : LSP.Messages.TextEdit_Vector;
+
+         procedure Process_Comments
+           (Node : Ada_Node;
+            Uri  : LSP.Messages.DocumentUri);
+
+         procedure Process_Comments
+           (Node : Ada_Node;
+            Uri  : LSP.Messages.DocumentUri)
+         is
+            use Libadalang.Common;
+
+            Token : Token_Reference := First_Token (Node.Unit);
+            Name  : constant Wide_Wide_String :=
+              Ada.Strings.Wide_Wide_Unbounded.To_Wide_Wide_String
+                (Get_Last_Name (Name_Node));
+            Span  : LSP.Messages.Span;
+
+         begin
+            while Token /= No_Token loop
+               if Kind (Data (Token)) = Ada_Comment
+                 and then Contain (Token, Name, Span)
+               then
+                  declare
+                     C : constant LSP.Messages.TextEdit :=
+                       (span    => Span,
+                        newText => Value.newName);
+                  begin
+                     if not Response.result.changes (Uri).Contains (C) then
+                        Response.result.changes (Uri).Append (C);
+                     end if;
+                  end;
+               end if;
+
+               Token := Next (Token);
+            end loop;
+         end Process_Comments;
+
       begin
          if Name_Node = No_Name then
             return;
@@ -1567,6 +1605,11 @@ package body LSP.Ada_Handlers is
                      --  We haven't touched this document yet, create an empty
                      --  change list
                      Response.result.changes.Insert (Location.uri, Empty);
+
+                     --  Process comments if it is needed
+                     if Self.Refactoring.Renaming.In_Comments then
+                        Process_Comments (Node.As_Ada_Node, Location.uri);
+                     end if;
                   end if;
 
                   --  When iterating over all contexts (and therefore all
@@ -1611,6 +1654,7 @@ package body LSP.Ada_Handlers is
       defaultCharset    : constant String := "defaultCharset";
       enableDiagnostics : constant String := "enableDiagnostics";
       enableIndexing    : constant String := "enableIndexing";
+      renameInComments  : constant String := "renameInComments";
 
       Ada       : constant LSP.Types.LSP_Any := Value.settings.Get ("ada");
       File      : LSP.Types.LSP_String;
@@ -1650,6 +1694,11 @@ package body LSP.Ada_Handlers is
          --  indexing in the parameters to this request.
          if Ada.Has_Field (enableIndexing) then
             Self.Indexing_Enabled := Ada.Get (enableIndexing);
+         end if;
+
+         if Ada.Has_Field (renameInComments) then
+            Self.Refactoring.Renaming.In_Comments :=
+              Ada.Get (renameInComments);
          end if;
       end if;
 

--- a/source/ada/lsp-ada_handlers.adb
+++ b/source/ada/lsp-ada_handlers.adb
@@ -1606,6 +1606,7 @@ package body LSP.Ada_Handlers is
       scenarioVariables : constant String := "scenarioVariables";
       defaultCharset    : constant String := "defaultCharset";
       enableDiagnostics : constant String := "enableDiagnostics";
+      enableIndexing    : constant String := "enableIndexing";
 
       Ada       : constant LSP.Types.LSP_Any := Value.settings.Get ("ada");
       File      : LSP.Types.LSP_String;
@@ -1639,6 +1640,12 @@ package body LSP.Ada_Handlers is
          --  deactivating of diagnostics via a setting here.
          if Ada.Has_Field (enableDiagnostics) then
             Self.Diagnostics_Enabled := Ada.Get (enableDiagnostics);
+         end if;
+
+         --  Similarly to diagnostics, we support selectively activating
+         --  indexing in the parameters to this request.
+         if Ada.Has_Field (enableIndexing) then
+            Self.Indexing_Enabled := Ada.Get (enableIndexing);
          end if;
       end if;
 
@@ -1872,11 +1879,10 @@ package body LSP.Ada_Handlers is
       Last_Percent    : Natural := 0;
       Current_Percent : Natural := 0;
    begin
-      --  Prevent work if another request is pending
-      --  if Self.Server.Look_Ahead_Message /= null then
-      --     Self.Indexing_Was_Paused := True;
-      --     return;
-      --  end if;
+      --  Prevent work if the indexing has been explicitly disabled
+      if not Self.Indexing_Enabled then
+         return;
+      end if;
 
       --  Collect the contexts and their sources: we do this so that we are
       --  able to produce a progress bar covering the total number of files.

--- a/source/ada/lsp-ada_handlers.adb
+++ b/source/ada/lsp-ada_handlers.adb
@@ -1136,7 +1136,7 @@ package body LSP.Ada_Handlers is
       --  Append the associated basic declaration's text to the response.
       --  We set the language for highlighting.
       if Decl_Text /= Empty_LSP_String then
-         Response.result.contents.Append
+         Response.result.contents.Vector.Append
            (LSP.Messages.MarkedString'
               (Is_String => False,
                value     => Decl_Text,
@@ -1155,7 +1155,7 @@ package body LSP.Ada_Handlers is
               (Integer (Decl.Sloc_Range.Start_Column), Min_Width => 1)
             & ")");
 
-         Response.result.contents.Append
+         Response.result.contents.Vector.Append
            (LSP.Messages.MarkedString'
               (Is_String => True,
                value     => Location_Text));
@@ -1169,7 +1169,7 @@ package body LSP.Ada_Handlers is
                    (Decl).Doc.To_String));
 
          if Comments_Text /= Empty_LSP_String then
-            Response.result.contents.Append
+            Response.result.contents.Vector.Append
               (LSP.Messages.MarkedString'
                  (Is_String => True,
                   value     => Comments_Text));

--- a/source/ada/lsp-ada_handlers.adb
+++ b/source/ada/lsp-ada_handlers.adb
@@ -489,7 +489,9 @@ package body LSP.Ada_Handlers is
       Root     : LSP.Types.LSP_String;
    begin
       Response.result.capabilities.definitionProvider := True;
-      Response.result.capabilities.typeDefinitionProvider := True;
+      Response.result.capabilities.typeDefinitionProvider :=
+        (Is_Set => True,
+         Value => (Is_Boolean => True, Bool => True));
       Response.result.capabilities.referencesProvider := True;
       Response.result.capabilities.documentSymbolProvider := True;
       Response.result.capabilities.renameProvider :=

--- a/source/ada/lsp-ada_handlers.ads
+++ b/source/ada/lsp-ada_handlers.ads
@@ -78,6 +78,10 @@ private
       Token_Id : Integer := 0;
       --  An ever-increasing number used to generate unique progress tokens
 
+      Indexing_Enabled  : Boolean := True;
+      --  Whether to index sources in the background. This should be True
+      --  for normal use, and can be disabled for debug or testing purposes.
+
       Indexing_Required : Boolean := False;
       --  Set to True if an indexing operation had been paused in order to
       --  process requests.

--- a/source/ada/lsp-ada_handlers.ads
+++ b/source/ada/lsp-ada_handlers.ads
@@ -54,6 +54,16 @@ private
    package Context_Lists is new Ada.Containers.Doubly_Linked_Lists
      (Context_Access);
 
+   --  Options for refactoring/renaming
+   type Renaming_Options is record
+      In_Comments : Boolean := False;
+   end record;
+
+   --  Options for refactoring
+   type Refactoring_Options is record
+      Renaming : Renaming_Options;
+   end record;
+
    type Message_Handler
      (Server  : access LSP.Servers.Server;
       Trace   : GNATCOLL.Traces.Trace_Handle)
@@ -104,6 +114,9 @@ private
       --
       --      * Indexing_Required is set to False when Index_Files has
       --        completed
+
+      Refactoring : Refactoring_Options;
+      --  Configuration options for refactoring
    end record;
 
    overriding procedure Before_Work

--- a/source/ada/lsp-lal_utils.adb
+++ b/source/ada/lsp-lal_utils.adb
@@ -32,11 +32,11 @@ package body LSP.Lal_Utils is
    --  Return the declaration of the subprogram or task that contains Ref.
    --  Return No_Defining_Name if this fails.
 
-   -------------
-   -- Contain --
-   -------------
+   --------------
+   -- Contains --
+   --------------
 
-   function Contain
+   function Contains
      (Token   : Token_Reference;
       Pattern : Wide_Wide_String;
       Span    : out LSP.Messages.Span)
@@ -65,7 +65,7 @@ package body LSP.Lal_Utils is
                   last  => (Line, Start + T'Length - 1));
          return True;
       end;
-   end Contain;
+   end Contains;
 
    ----------------------
    -- Get_Node_As_Name --
@@ -101,8 +101,7 @@ package body LSP.Lal_Utils is
    -- Get_Last_Name --
    -------------------
 
-   function Get_Last_Name
-     (Name_Node : Name)
+   function Get_Last_Name (Name_Node : Name)
       return Langkit_Support.Text.Unbounded_Text_Type
    is
       Names : constant Unbounded_Text_Type_Array :=

--- a/source/ada/lsp-lal_utils.ads
+++ b/source/ada/lsp-lal_utils.ads
@@ -44,8 +44,7 @@ package LSP.Lal_Utils is
    --  Imprecise is set to True if LAL's imprecise fallback mechanism has been
    --  used to compute the cross reference.
 
-   function Get_Last_Name
-     (Name_Node : Name)
+   function Get_Last_Name (Name_Node : Name)
       return Langkit_Support.Text.Unbounded_Text_Type;
    --  Return the last name, for example if name is A.B.C then return C
 
@@ -98,7 +97,7 @@ package LSP.Lal_Utils is
    --  Imprecise_Results is set to True if we don't know whether the results
    --  are precise.
 
-   function Contain
+   function Contains
      (Token   : Libadalang.Common.Token_Reference;
       Pattern : Wide_Wide_String;
       Span    : out LSP.Messages.Span)

--- a/source/ada/lsp-lal_utils.ads
+++ b/source/ada/lsp-lal_utils.ads
@@ -24,8 +24,11 @@ with GNATCOLL.VFS;
 with GNATCOLL.Traces;
 
 with LSP.Ada_Contexts;
+with LSP.Messages;
 
-with Libadalang.Analysis; use Libadalang.Analysis;
+with Libadalang.Analysis;  use Libadalang.Analysis;
+with Libadalang.Common;
+with Langkit_Support.Text;
 
 package LSP.Lal_Utils is
 
@@ -40,6 +43,11 @@ package LSP.Lal_Utils is
    --  Return the definition node (canonical part) of the given name.
    --  Imprecise is set to True if LAL's imprecise fallback mechanism has been
    --  used to compute the cross reference.
+
+   function Get_Last_Name
+     (Name_Node : Name)
+      return Langkit_Support.Text.Unbounded_Text_Type;
+   --  Return the last name, for example if name is A.B.C then return C
 
    function Find_Next_Part
      (Definition : Defining_Name;
@@ -89,5 +97,12 @@ package LSP.Lal_Utils is
    --  these calls are listed, ordered by the name of these subprograms.
    --  Imprecise_Results is set to True if we don't know whether the results
    --  are precise.
+
+   function Contain
+     (Token   : Libadalang.Common.Token_Reference;
+      Pattern : Wide_Wide_String;
+      Span    : out LSP.Messages.Span)
+      return Boolean;
+   --  Return True if the Token text contains Pattern and set position in Span
 
 end LSP.Lal_Utils;

--- a/source/client/lsp-clients.adb
+++ b/source/client/lsp-clients.adb
@@ -967,11 +967,12 @@ package body LSP.Clients is
    procedure Workspace_Apply_Edit
      (Self    : in out Client'Class;
       Request : LSP.Types.LSP_Number_Or_String;
-      Applied : Boolean)
+      Failure : LSP.Types.Optional_String)
    is
       Message : LSP.Messages.Client_Responses.ApplyWorkspaceEdit_Response :=
         (Is_Error => False,
-         result => (applied => Applied),
+         result => (applied => not Failure.Is_Set,
+                    failureReason => Failure),
          error => (Is_Set => False),
          others => <>);
    begin

--- a/source/client/lsp-clients.ads
+++ b/source/client/lsp-clients.ads
@@ -156,7 +156,7 @@ package LSP.Clients is
    procedure Workspace_Apply_Edit
      (Self    : in out Client'Class;
       Request : LSP.Types.LSP_Number_Or_String;
-      Applied : Boolean);
+      Failure : LSP.Types.Optional_String);
 
    function Allocate_Request_Id
      (Self : in out Client'Class) return LSP.Types.LSP_Number_Or_String;

--- a/source/protocol/lsp-generic_sets.adb
+++ b/source/protocol/lsp-generic_sets.adb
@@ -1,0 +1,117 @@
+------------------------------------------------------------------------------
+--                         Language Server Protocol                         --
+--                                                                          --
+--                     Copyright (C) 2018-2019, AdaCore                     --
+--                                                                          --
+-- This is free software;  you can redistribute it  and/or modify it  under --
+-- terms of the  GNU General Public License as published  by the Free Soft- --
+-- ware  Foundation;  either version 3,  or (at your option) any later ver- --
+-- sion.  This software is distributed in the hope  that it will be useful, --
+-- but WITHOUT ANY WARRANTY;  without even the implied warranty of MERCHAN- --
+-- TABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public --
+-- License for  more details.  You should have  received  a copy of the GNU --
+-- General  Public  License  distributed  with  this  software;   see  file --
+-- COPYING3.  If not, go to http://www.gnu.org/licenses for a complete copy --
+-- of the license.                                                          --
+------------------------------------------------------------------------------
+
+with GNATCOLL.JSON;
+
+with LSP.JSON_Streams;
+
+package body LSP.Generic_Sets is
+
+   --------------
+   -- Contains --
+   --------------
+
+   function Contains (Self : Set; Value : Element) return Boolean is
+   begin
+      return Self (Value);
+   end Contains;
+
+   -----------
+   -- Empty --
+   -----------
+
+   function Empty return Set is
+   begin
+      return (Element => False);
+   end Empty;
+
+   -------------
+   -- Include --
+   -------------
+
+   procedure Include (Self : in out Set; Value : Element) is
+   begin
+      Self (Value) := True;
+   end Include;
+
+   --------------
+   -- Read_Set --
+   --------------
+
+   procedure Read_Set
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out Set)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+   begin
+      V := (others => False);
+      JS.Start_Array;
+      while not JS.End_Of_Array loop
+         declare
+            Key : Element;
+         begin
+            Element'Read (S, Key);
+            V (Key) := True;
+         end;
+      end loop;
+      JS.End_Array;
+   end Read_Set;
+
+   ------------
+   -- Remove --
+   ------------
+
+   procedure Remove (Self : in out Set; Value : Element) is
+   begin
+      Self (Value) := True;
+   end Remove;
+
+   ------------
+   -- To_Set --
+   ------------
+
+   function To_Set (From, To : Element) return Set is
+      Result : Set := Empty;
+   begin
+      Result (From .. To) := (others => True);
+      return Result;
+   end To_Set;
+
+   ---------------
+   -- Write_Set --
+   ---------------
+
+   procedure Write_Set
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : Set)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+   begin
+      JS.Start_Array;
+
+      for K in V'Range loop
+         if V (K) then
+            Element'Write (S, K);
+         end if;
+      end loop;
+
+      JS.End_Array;
+   end Write_Set;
+
+end LSP.Generic_Sets;

--- a/source/protocol/lsp-generic_sets.ads
+++ b/source/protocol/lsp-generic_sets.ads
@@ -1,0 +1,64 @@
+------------------------------------------------------------------------------
+--                         Language Server Protocol                         --
+--                                                                          --
+--                     Copyright (C) 2018-2019, AdaCore                     --
+--                                                                          --
+-- This is free software;  you can redistribute it  and/or modify it  under --
+-- terms of the  GNU General Public License as published  by the Free Soft- --
+-- ware  Foundation;  either version 3,  or (at your option) any later ver- --
+-- sion.  This software is distributed in the hope  that it will be useful, --
+-- but WITHOUT ANY WARRANTY;  without even the implied warranty of MERCHAN- --
+-- TABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public --
+-- License for  more details.  You should have  received  a copy of the GNU --
+-- General  Public  License  distributed  with  this  software;   see  file --
+-- COPYING3.  If not, go to http://www.gnu.org/licenses for a complete copy --
+-- of the license.                                                          --
+------------------------------------------------------------------------------
+
+--  This package provides generic set to implement Language Server Protocol.
+
+with Ada.Streams;
+
+generic
+   type Element is (<>);
+
+package LSP.Generic_Sets is
+
+   type Set is private;
+
+   function Empty return Set
+     with Inline;
+   --  Return an empty set
+
+   function To_Set (From, To : Element) return Set
+     with Inline;
+   --  Return a set which values in range From .. To
+
+   function Contains (Self : Set; Value : Element) return Boolean
+     with Inline;
+   --  Check if Value is in the set
+
+   procedure Include (Self : in out Set; Value : Element)
+     with Inline;
+   --  Append Value to the set
+
+   procedure Remove (Self : in out Set; Value : Element)
+     with Inline;
+   --  Remove Value to the set
+
+private
+
+   type Set is array (Element) of Boolean;
+
+   procedure Read_Set
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out Set);
+
+   procedure Write_Set
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : Set);
+
+   for Set'Read use Read_Set;
+   for Set'Write use Write_Set;
+
+end LSP.Generic_Sets;

--- a/source/protocol/lsp-generic_vectors.adb
+++ b/source/protocol/lsp-generic_vectors.adb
@@ -1,0 +1,74 @@
+------------------------------------------------------------------------------
+--                         Language Server Protocol                         --
+--                                                                          --
+--                     Copyright (C) 2018-2019, AdaCore                     --
+--                                                                          --
+-- This is free software;  you can redistribute it  and/or modify it  under --
+-- terms of the  GNU General Public License as published  by the Free Soft- --
+-- ware  Foundation;  either version 3,  or (at your option) any later ver- --
+-- sion.  This software is distributed in the hope  that it will be useful, --
+-- but WITHOUT ANY WARRANTY;  without even the implied warranty of MERCHAN- --
+-- TABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public --
+-- License for  more details.  You should have  received  a copy of the GNU --
+-- General  Public  License  distributed  with  this  software;   see  file --
+-- COPYING3.  If not, go to http://www.gnu.org/licenses for a complete copy --
+-- of the license.                                                          --
+------------------------------------------------------------------------------
+
+with GNATCOLL.JSON;
+
+with LSP.JSON_Streams;
+
+package body LSP.Generic_Vectors is
+
+   -----------------
+   -- Read_Vector --
+   -----------------
+
+   procedure Read_Vector
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out Vector)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+   begin
+      V.Clear;
+      JS.Start_Array;
+
+      while not JS.End_Of_Array loop
+         declare
+            Item : Element;
+         begin
+            Element'Read (S, Item);
+            V.Append (Item);
+         end;
+      end loop;
+
+      JS.End_Array;
+   end Read_Vector;
+
+   ------------------
+   -- Write_Vector --
+   ------------------
+
+   procedure Write_Vector
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : Vector)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+   begin
+      if V.Is_Empty then
+         JS.Write (GNATCOLL.JSON.Create (GNATCOLL.JSON.Empty_Array));
+      else
+         JS.Start_Array;
+
+         for Item of V loop
+            Element'Write (S, Item);
+         end loop;
+
+         JS.End_Array;
+      end if;
+   end Write_Vector;
+
+end LSP.Generic_Vectors;

--- a/source/protocol/lsp-generic_vectors.adb
+++ b/source/protocol/lsp-generic_vectors.adb
@@ -58,17 +58,13 @@ package body LSP.Generic_Vectors is
       JS : LSP.JSON_Streams.JSON_Stream'Class renames
         LSP.JSON_Streams.JSON_Stream'Class (S.all);
    begin
-      if V.Is_Empty then
-         JS.Write (GNATCOLL.JSON.Create (GNATCOLL.JSON.Empty_Array));
-      else
-         JS.Start_Array;
+      JS.Start_Array;
 
-         for Item of V loop
-            Element'Write (S, Item);
-         end loop;
+      for Item of V loop
+         Element'Write (S, Item);
+      end loop;
 
-         JS.End_Array;
-      end if;
+      JS.End_Array;
    end Write_Vector;
 
 end LSP.Generic_Vectors;

--- a/source/protocol/lsp-generic_vectors.ads
+++ b/source/protocol/lsp-generic_vectors.ads
@@ -1,0 +1,43 @@
+------------------------------------------------------------------------------
+--                         Language Server Protocol                         --
+--                                                                          --
+--                     Copyright (C) 2018-2019, AdaCore                     --
+--                                                                          --
+-- This is free software;  you can redistribute it  and/or modify it  under --
+-- terms of the  GNU General Public License as published  by the Free Soft- --
+-- ware  Foundation;  either version 3,  or (at your option) any later ver- --
+-- sion.  This software is distributed in the hope  that it will be useful, --
+-- but WITHOUT ANY WARRANTY;  without even the implied warranty of MERCHAN- --
+-- TABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public --
+-- License for  more details.  You should have  received  a copy of the GNU --
+-- General  Public  License  distributed  with  this  software;   see  file --
+-- COPYING3.  If not, go to http://www.gnu.org/licenses for a complete copy --
+-- of the license.                                                          --
+------------------------------------------------------------------------------
+
+--  This package provides generic vector to implement Language Server Protocol.
+
+with Ada.Containers.Vectors;
+with Ada.Streams;
+
+generic
+   type Element is private;
+
+package LSP.Generic_Vectors is
+
+   package Element_Vectors is new Ada.Containers.Vectors (Positive, Element);
+
+   type Vector is new Element_Vectors.Vector with null record;
+
+   procedure Read_Vector
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out Vector);
+
+   procedure Write_Vector
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : Vector);
+
+   for Vector'Read use Read_Vector;
+   for Vector'Write use Write_Vector;
+
+end LSP.Generic_Vectors;

--- a/source/protocol/lsp-json_streams.adb
+++ b/source/protocol/lsp-json_streams.adb
@@ -107,7 +107,7 @@ package body LSP.JSON_Streams is
    ---------
 
    procedure Pop (Self : not null access JSON_Stream'Class) is
-      Modified : constant Boolean := Self.Current.Modified;
+      Modified : constant Boolean := Self.Writable;
       Value    : constant GNATCOLL.JSON.JSON_Value
         := (case Self.Current.Kind is
                when Array_State => GNATCOLL.JSON.Create
@@ -139,11 +139,10 @@ package body LSP.JSON_Streams is
       case Kind is
          when Array_State =>
             Self.Current :=
-             (Array_State, False, GNATCOLL.JSON.Empty_Array, 1);
+             (Array_State, GNATCOLL.JSON.Empty_Array, 1);
          when Object_State =>
             Self.Current :=
              (Kind           => Object_State,
-              Modified       => False,
               Current_Object => GNATCOLL.JSON.Create_Object,
               Key            => <>);
       end case;
@@ -158,7 +157,7 @@ package body LSP.JSON_Streams is
      Data : GNATCOLL.JSON.JSON_Array) is
    begin
       Self.Stack.Append (Self.Current);
-      Self.Current := (Array_State, False, Data, 1);
+      Self.Current := (Array_State, Data, 1);
    end Push;
 
    ----------
@@ -172,7 +171,6 @@ package body LSP.JSON_Streams is
       Self.Stack.Append (Self.Current);
       Self.Current :=
        (Kind           => Object_State,
-        Modified       => False,
         Current_Object => Data,
         Key            => <>);
    end Push;
@@ -219,8 +217,8 @@ package body LSP.JSON_Streams is
      (Self : not null access JSON_Stream'Class;
       Data : GNATCOLL.JSON.JSON_Array) is
    begin
-
-      Self.Current := (Array_State, False, Data, 1);
+      Self.Writable := False;  --  Read-only stream
+      Self.Current := (Array_State, Data, 1);
    end Set_JSON_Document;
 
    -----------------
@@ -337,8 +335,6 @@ package body LSP.JSON_Streams is
                To_UTF_8_String (Self.Current.Key),
                Value);
       end case;
-
-      Self.Current.Modified := True;
    end Update;
 
    -----------

--- a/source/protocol/lsp-json_streams.ads
+++ b/source/protocol/lsp-json_streams.ads
@@ -91,8 +91,6 @@ private
    type State_Kinds is (Array_State, Object_State);
 
    type State (Kind : State_Kinds := Array_State) is record
-      Modified : Boolean := False;
-
       case Kind is
          when Array_State =>
             Current_Array : GNATCOLL.JSON.JSON_Array;
@@ -107,8 +105,9 @@ private
    package State_Vectors is new Ada.Containers.Vectors (Positive, State);
 
    type JSON_Stream is new Ada.Streams.Root_Stream_Type with record
-      Current : State;
-      Stack   : State_Vectors.Vector;
+      Writable : Boolean := True;  --  True means stream to write
+      Current  : State;
+      Stack    : State_Vectors.Vector;
    end record;
 
    overriding procedure Read

--- a/source/protocol/lsp-messages.adb
+++ b/source/protocol/lsp-messages.adb
@@ -314,6 +314,23 @@ package body LSP.Messages is
       JS.End_Object;
    end Read_CodeActionContext;
 
+   ----------------------------
+   -- Read_CodeActionOptions --
+   ----------------------------
+
+   procedure Read_CodeActionOptions
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out CodeActionOptions)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+   begin
+      JS.Start_Object;
+      JS.Key ("codeActionKinds");
+      Optional_CodeActionKindSet'Read (S, V.codeActionKinds);
+      JS.End_Object;
+   end Read_CodeActionOptions;
+
    -------------------------
    -- Read_CodeActionKind --
    -------------------------
@@ -1644,8 +1661,8 @@ package body LSP.Messages is
         (JS, +"documentSymbolProvider", V.documentSymbolProvider);
       Read_Optional_Boolean
         (JS, +"workspaceSymbolProvider", V.workspaceSymbolProvider);
-      Read_Optional_Boolean
-        (JS, +"codeActionProvider", V.codeActionProvider);
+      JS.Key ("codeActionProvider");
+      Optional_CodeActionOptions'Read (S, V.codeActionProvider);
       Read_Optional_Boolean
         (JS, +"documentFormattingProvider", V.documentFormattingProvider);
       Read_Optional_Boolean
@@ -2433,6 +2450,23 @@ package body LSP.Messages is
       Diagnostic_Vector'Write (S, V.diagnostics);
       JS.End_Object;
    end Write_CodeActionContext;
+
+   -----------------------------
+   -- Write_CodeActionOptions --
+   -----------------------------
+
+   procedure Write_CodeActionOptions
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : CodeActionOptions)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+   begin
+      JS.Start_Object;
+      JS.Key ("codeActionKinds");
+      Optional_CodeActionKindSet'Write (S, V.codeActionKinds);
+      JS.End_Object;
+   end Write_CodeActionOptions;
 
    --------------------------
    -- Write_CodeActionKind --
@@ -3815,7 +3849,8 @@ package body LSP.Messages is
         (JS, +"documentSymbolProvider", V.documentSymbolProvider);
       Write_Optional_Boolean
         (JS, +"workspaceSymbolProvider", V.workspaceSymbolProvider);
-      Write_Optional_Boolean (JS, +"codeActionProvider", V.codeActionProvider);
+      JS.Key ("codeActionProvider");
+      Optional_CodeActionOptions'Write (S, V.codeActionProvider);
       Write_Optional_Boolean
         (JS, +"documentFormattingProvider", V.documentFormattingProvider);
       Write_Optional_Boolean

--- a/source/protocol/lsp-messages.adb
+++ b/source/protocol/lsp-messages.adb
@@ -522,7 +522,8 @@ package body LSP.Messages is
       JS.Key ("kind");
       Optional_CompletionItemKind'Read (S, V.kind);
       Read_Optional_String (JS, +"detail", V.detail);
-      Read_Optional_String (JS, +"documentation", V.documentation);
+      JS.Key ("documentation");
+      Optional_String_Or_MarkupContent'Read (S, V.documentation);
       Read_Optional_String (JS, +"sortText", V.sortText);
       Read_Optional_String (JS, +"filterText", V.filterText);
       Read_Optional_String (JS, +"insertText", V.insertText);
@@ -1376,7 +1377,8 @@ package body LSP.Messages is
    begin
       JS.Start_Object;
       Read_String (JS, +"label", V.label);
-      Read_Optional_String (JS, +"documentation", V.documentation);
+      JS.Key ("documentation");
+      Optional_String_Or_MarkupContent'Read (S, V.documentation);
       JS.End_Object;
    end Read_ParameterInformation;
 
@@ -1775,7 +1777,8 @@ package body LSP.Messages is
    begin
       JS.Start_Object;
       Read_String (JS, +"label", V.label);
-      Read_Optional_String (JS, +"documentation", V.documentation);
+      JS.Key ("documentation");
+      Optional_String_Or_MarkupContent'Read (S, V.documentation);
       JS.Key ("parameters");
       ParameterInformation_Vector'Read (S, V.parameters);
       JS.End_Object;
@@ -1918,6 +1921,27 @@ package body LSP.Messages is
       DocumentSelector'Read (S, V.documentSelector);
       JS.End_Object;
    end Read_StaticRegistrationOptions;
+
+   ----------------------------------
+   -- Read_String_Or_MarkupContent --
+   ----------------------------------
+
+   procedure Read_String_Or_MarkupContent
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out String_Or_MarkupContent)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+      Value : constant GNATCOLL.JSON.JSON_Value := JS.Read;
+   begin
+      if Value.Kind in GNATCOLL.JSON.JSON_String_Type then
+         V := (Is_String => True,
+               String    => To_LSP_String (Unbounded_String'(Value.Get)));
+      else
+         V := (Is_String => False, Content => <>);
+         MarkupContent'Read (S, V.Content);
+      end if;
+   end Read_String_Or_MarkupContent;
 
    ------------------------
    -- Read_String_Vector --
@@ -2769,7 +2793,8 @@ package body LSP.Messages is
       JS.Key ("kind");
       Optional_CompletionItemKind'Write (S, V.kind);
       Write_Optional_String (JS, +"detail", V.detail);
-      Write_Optional_String (JS, +"documentation", V.documentation);
+      JS.Key ("documentation");
+      Optional_String_Or_MarkupContent'Write (S, V.documentation);
       Write_Optional_String (JS, +"sortText", V.sortText);
       Write_Optional_String (JS, +"filterText", V.filterText);
       Write_Optional_String (JS, +"insertText", V.insertText);
@@ -3657,7 +3682,8 @@ package body LSP.Messages is
    begin
       JS.Start_Object;
       Write_String (JS, +"label", V.label);
-      Write_Optional_String (JS, +"documentation", V.documentation);
+      JS.Key ("documentation");
+      Optional_String_Or_MarkupContent'Write (S, V.documentation);
       JS.End_Object;
    end Write_ParameterInformation;
 
@@ -4112,7 +4138,8 @@ package body LSP.Messages is
    begin
       JS.Start_Object;
       Write_String (JS, +"label", V.label);
-      Write_Optional_String (JS, +"documentation", V.documentation);
+      JS.Key ("documentation");
+      Optional_String_Or_MarkupContent'Write (S, V.documentation);
       JS.Key ("parameters");
       ParameterInformation_Vector'Write (S, V.parameters);
       JS.End_Object;
@@ -4174,6 +4201,26 @@ package body LSP.Messages is
       DocumentSelector'Write (S, V.documentSelector);
       JS.End_Object;
    end Write_StaticRegistrationOptions;
+
+   -----------------------------------
+   -- Write_String_Or_MarkupContent --
+   -----------------------------------
+
+   procedure Write_String_Or_MarkupContent
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : String_Or_MarkupContent)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+   begin
+      case V.Is_String is
+         when True =>
+            JS.Write
+              (GNATCOLL.JSON.Create (To_UTF_8_Unbounded_String (V.String)));
+         when False =>
+            MarkupContent'Write (S, V.Content);
+      end case;
+   end Write_String_Or_MarkupContent;
 
    -------------------------
    -- Write_String_Vector --

--- a/source/protocol/lsp-messages.adb
+++ b/source/protocol/lsp-messages.adb
@@ -898,6 +898,25 @@ package body LSP.Messages is
       JS.End_Object;
    end Read_ExecuteCommandParams;
 
+   ----------------------------------
+   -- Read_foldingRange_Capability --
+   ----------------------------------
+
+   procedure Read_foldingRange_Capability
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out foldingRange_Capability)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+   begin
+      JS.Start_Object;
+      Read_Optional_Boolean
+        (JS, +"dynamicRegistration", V.dynamicRegistration);
+      Read_Optional_Number (JS, +"rangeLimit", V.rangeLimit);
+      Read_Optional_Boolean (JS, +"lineFoldingOnly", V.lineFoldingOnly);
+      JS.End_Object;
+   end Read_foldingRange_Capability;
+
    ----------------
    -- Read_Hover --
    ----------------
@@ -1933,6 +1952,8 @@ package body LSP.Messages is
       Optional_rename_Capability'Read (S, V.rename);
       JS.Key ("publishDiagnostics");
       Optional_publishDiagnostics_Capability'Read (S, V.publishDiagnostics);
+      JS.Key ("foldingRange");
+      Optional_foldingRange_Capability'Read (S, V.foldingRange);
       JS.End_Object;
    end Read_TextDocumentClientCapabilities;
 
@@ -3008,6 +3029,25 @@ package body LSP.Messages is
       JS.End_Object;
    end Write_ExecuteCommandParams;
 
+   -----------------------------------
+   -- Write_foldingRange_Capability --
+   -----------------------------------
+
+   procedure Write_foldingRange_Capability
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : foldingRange_Capability)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+   begin
+      JS.Start_Object;
+      Write_Optional_Boolean
+        (JS, +"dynamicRegistration", V.dynamicRegistration);
+      Write_Optional_Number (JS, +"rangeLimit", V.rangeLimit);
+      Write_Optional_Boolean (JS, +"lineFoldingOnly", V.lineFoldingOnly);
+      JS.End_Object;
+   end Write_foldingRange_Capability;
+
    -----------------
    -- Write_Hover --
    -----------------
@@ -4033,6 +4073,8 @@ package body LSP.Messages is
       Optional_rename_Capability'Write (S, V.rename);
       JS.Key ("publishDiagnostics");
       Optional_publishDiagnostics_Capability'Write (S, V.publishDiagnostics);
+      JS.Key ("foldingRange");
+      Optional_foldingRange_Capability'Write (S, V.foldingRange);
       JS.End_Object;
    end Write_TextDocumentClientCapabilities;
 

--- a/source/protocol/lsp-messages.adb
+++ b/source/protocol/lsp-messages.adb
@@ -1588,6 +1588,18 @@ package body LSP.Messages is
       JS.End_Object;
    end Read_TextDocumentEdit;
 
+   --------------------------
+   -- Read_Document_Change --
+   --------------------------
+
+   procedure Read_Document_Change
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out Document_Change) is
+   begin
+      --  FIXME: rewrite reading procedure
+      TextDocumentEdit'Read (S, V.Text_Document_Edit);
+   end Read_Document_Change;
+
    ---------------------------------
    -- Read_TextDocumentIdentifier --
    ---------------------------------
@@ -1800,7 +1812,7 @@ package body LSP.Messages is
          JS.End_Object;
       else
          JS.Key ("documentChanges");
-         TextDocumentEdit_Vector'Write (S, V.documentChanges);
+         Document_Change_Vector'Write (S, V.documentChanges);
       end if;
 
       JS.End_Object;
@@ -3191,6 +3203,26 @@ package body LSP.Messages is
       JS.End_Object;
    end Write_TextDocumentEdit;
 
+   ---------------------------
+   -- Write_Document_Change --
+   ---------------------------
+
+   procedure Write_Document_Change
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : Document_Change) is
+   begin
+      case V.Kind is
+         when Text_Document_Edit =>
+            TextDocumentEdit'Write (S, V.Text_Document_Edit);
+         when Create_File =>
+            CreateFile'Write (S, V.Create_File);
+         when Rename_File =>
+            RenameFile'Write (S, V.Rename_File);
+         when Delete_File =>
+            DeleteFile'Write (S, V.Delete_File);
+      end case;
+   end Write_Document_Change;
+
    ----------------------------------
    -- Write_TextDocumentIdentifier --
    ----------------------------------
@@ -3381,7 +3413,7 @@ package body LSP.Messages is
          end if;
       else
          JS.Key ("documentChanges");
-         TextDocumentEdit_Vector'Write (S, V.documentChanges);
+         Document_Change_Vector'Write (S, V.documentChanges);
       end if;
       JS.End_Object;
    end Write_WorkspaceEdit;

--- a/source/protocol/lsp-messages.adb
+++ b/source/protocol/lsp-messages.adb
@@ -1394,6 +1394,23 @@ package body LSP.Messages is
       JS.End_Object;
    end Read_PublishDiagnosticsParams;
 
+   ----------------------------------------
+   -- Read_publishDiagnostics_Capability --
+   ----------------------------------------
+
+   procedure Read_publishDiagnostics_Capability
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out publishDiagnostics_Capability)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+   begin
+      JS.Start_Object;
+      Read_Optional_Boolean
+        (JS, +"relatedInformation", V.relatedInformation);
+      JS.End_Object;
+   end Read_publishDiagnostics_Capability;
+
    ---------------------------
    -- Read_ReferenceContext --
    ---------------------------
@@ -1914,6 +1931,8 @@ package body LSP.Messages is
       dynamicRegistration'Read (S, V.colorProvider);
       JS.Key ("rename");
       Optional_rename_Capability'Read (S, V.rename);
+      JS.Key ("publishDiagnostics");
+      Optional_publishDiagnostics_Capability'Read (S, V.publishDiagnostics);
       JS.End_Object;
    end Read_TextDocumentClientCapabilities;
 
@@ -3494,6 +3513,23 @@ package body LSP.Messages is
       JS.End_Object;
    end Write_PublishDiagnosticsParams;
 
+   -----------------------------------------
+   -- Write_publishDiagnostics_Capability --
+   -----------------------------------------
+
+   procedure Write_publishDiagnostics_Capability
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : publishDiagnostics_Capability)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+   begin
+      JS.Start_Object;
+      Write_Optional_Boolean
+        (JS, +"relatedInformation", V.relatedInformation);
+      JS.End_Object;
+   end Write_publishDiagnostics_Capability;
+
    ----------------------------
    -- Write_ReferenceContext --
    ----------------------------
@@ -3995,6 +4031,8 @@ package body LSP.Messages is
       dynamicRegistration'Write (S, V.colorProvider);
       JS.Key ("rename");
       Optional_rename_Capability'Write (S, V.rename);
+      JS.Key ("publishDiagnostics");
+      Optional_publishDiagnostics_Capability'Write (S, V.publishDiagnostics);
       JS.End_Object;
    end Write_TextDocumentClientCapabilities;
 

--- a/source/protocol/lsp-messages.adb
+++ b/source/protocol/lsp-messages.adb
@@ -1785,6 +1785,8 @@ package body LSP.Messages is
       dynamicRegistration'Read (S, V.symbol);
       JS.Key ("executeCommand");
       dynamicRegistration'Read (S, V.executeCommand);
+      Read_Optional_Boolean (JS, +"workspaceFolders", V.workspaceFolders);
+      Read_Optional_Boolean (JS, +"configuration", V.configuration);
       JS.End_Object;
    end Read_WorkspaceClientCapabilities;
 
@@ -3453,6 +3455,8 @@ package body LSP.Messages is
       dynamicRegistration'Write (S, V.symbol);
       JS.Key ("executeCommand");
       dynamicRegistration'Write (S, V.executeCommand);
+      Write_Optional_Boolean (JS, +"workspaceFolders", V.workspaceFolders);
+      Write_Optional_Boolean (JS, +"configuration", V.configuration);
       JS.End_Object;
    end Write_WorkspaceClientCapabilities;
 

--- a/source/protocol/lsp-messages.adb
+++ b/source/protocol/lsp-messages.adb
@@ -345,6 +345,28 @@ package body LSP.Messages is
       end if;
    end Read_CodeActionKind;
 
+   ----------------------------------------------
+   -- Read_codeActionLiteralSupport_Capability --
+   ----------------------------------------------
+
+   procedure Read_codeActionLiteralSupport_Capability
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out codeActionLiteralSupport_Capability)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+   begin
+      JS.Start_Object;
+
+      JS.Key ("codeActionKind");
+      JS.Start_Object;
+      JS.Key ("valueSet");
+      CodeActionKindSet'Read (S, V.codeActionKind);
+      JS.End_Object;
+
+      JS.End_Object;
+   end Read_codeActionLiteralSupport_Capability;
+
    ---------------------------
    -- Read_CodeActionParams --
    ---------------------------
@@ -365,6 +387,26 @@ package body LSP.Messages is
       CodeActionContext'Read (S, V.context);
       JS.End_Object;
    end Read_CodeActionParams;
+
+   --------------------------------
+   -- Read_codeAction_Capability --
+   --------------------------------
+
+   procedure Read_codeAction_Capability
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out codeAction_Capability)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+   begin
+      JS.Start_Object;
+      Read_Optional_Boolean
+        (JS, +"dynamicRegistration", V.dynamicRegistration);
+      JS.Key ("codeActionLiteralSupport");
+      Optional_codeActionLiteralSupport_Capability'Read
+        (S, V.codeActionLiteralSupport);
+      JS.End_Object;
+   end Read_codeAction_Capability;
 
    --------------------------
    -- Read_CodeLensOptions --
@@ -1845,7 +1887,7 @@ package body LSP.Messages is
       JS.Key ("implementation");
       Optional_implementation_Capability'Read (S, V.implementation);
       JS.Key ("codeAction");
-      dynamicRegistration'Read (S, V.codeAction);
+      Optional_codeAction_Capability'Read (S, V.codeAction);
       JS.Key ("codeLens");
       dynamicRegistration'Read (S, V.codeLens);
       JS.Key ("documentLink");
@@ -2356,6 +2398,28 @@ package body LSP.Messages is
       JS.Write (GNATCOLL.JSON.Create (Image (V)));
    end Write_CodeActionKind;
 
+   -----------------------------------------------
+   -- Write_codeActionLiteralSupport_Capability --
+   -----------------------------------------------
+
+   procedure Write_codeActionLiteralSupport_Capability
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : codeActionLiteralSupport_Capability)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+   begin
+      JS.Start_Object;
+
+      JS.Key ("codeActionKind");
+      JS.Start_Object;
+      JS.Key ("valueSet");
+      CodeActionKindSet'Write (S, V.codeActionKind);
+      JS.End_Object;
+
+      JS.End_Object;
+   end Write_codeActionLiteralSupport_Capability;
+
    ----------------------------
    -- Write_CodeActionParams --
    ----------------------------
@@ -2376,6 +2440,26 @@ package body LSP.Messages is
       CodeActionContext'Write (S, V.context);
       JS.End_Object;
    end Write_CodeActionParams;
+
+   ---------------------------------
+   -- Write_codeAction_Capability --
+   ---------------------------------
+
+   procedure Write_codeAction_Capability
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : codeAction_Capability)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+   begin
+      JS.Start_Object;
+      Write_Optional_Boolean
+        (JS, +"dynamicRegistration", V.dynamicRegistration);
+      JS.Key ("codeActionLiteralSupport");
+      Optional_codeActionLiteralSupport_Capability'Write
+        (S, V.codeActionLiteralSupport);
+      JS.End_Object;
+   end Write_codeAction_Capability;
 
    ---------------------------
    -- Write_CodeLensOptions --
@@ -3864,7 +3948,7 @@ package body LSP.Messages is
       JS.Key ("implementation");
       Optional_implementation_Capability'Write (S, V.implementation);
       JS.Key ("codeAction");
-      dynamicRegistration'Write (S, V.codeAction);
+      Optional_codeAction_Capability'Write (S, V.codeAction);
       JS.Key ("codeLens");
       dynamicRegistration'Write (S, V.codeLens);
       JS.Key ("documentLink");

--- a/source/protocol/lsp-messages.adb
+++ b/source/protocol/lsp-messages.adb
@@ -4416,24 +4416,18 @@ package body LSP.Messages is
       if V.documentChanges.Is_Empty then
          JS.Key ("changes");
 
-         if V.changes.Is_Empty then
-            --  Special case for an empty result: return 'changes:{}'
-            --  Without it JSON_Stream optimizes result to nothing.
-            JS.Write (GNATCOLL.JSON.Create_Object);
-         else
-            JS.Start_Object;
-            for Cursor in V.changes.Iterate loop
-               JS.Key
-                 (Ada.Strings.Wide_Unbounded.Unbounded_Wide_String
-                    (TextDocumentEdit_Maps.Key (Cursor)));
-               JS.Start_Array;
-               for Edit of V.changes (Cursor) loop
-                  TextEdit'Write (S, Edit);
-               end loop;
-               JS.End_Array;
+         JS.Start_Object;
+         for Cursor in V.changes.Iterate loop
+            JS.Key
+              (Ada.Strings.Wide_Unbounded.Unbounded_Wide_String
+                 (TextDocumentEdit_Maps.Key (Cursor)));
+            JS.Start_Array;
+            for Edit of V.changes (Cursor) loop
+               TextEdit'Write (S, Edit);
             end loop;
-            JS.End_Object;
-         end if;
+            JS.End_Array;
+         end loop;
+         JS.End_Object;
       else
          JS.Key ("documentChanges");
          Document_Change_Vector'Write (S, V.documentChanges);

--- a/source/protocol/lsp-messages.adb
+++ b/source/protocol/lsp-messages.adb
@@ -1222,6 +1222,43 @@ package body LSP.Messages is
       JS.End_Object;
    end Read_FileSystemWatcher;
 
+   -----------------------
+   -- Read_FoldingRange --
+   -----------------------
+
+   procedure Read_FoldingRange
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out FoldingRange)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+   begin
+      JS.Start_Object;
+      Read_Number (JS, +"startLine", V.startLine);
+      Read_Optional_Number (JS, +"startCharacter", V.startCharacter);
+      Read_Number (JS, +"endLine", V.endLine);
+      Read_Optional_Number (JS, +"endCharacter", V.endCharacter);
+      Read_Optional_String (JS, +"kind", V.kind);
+      JS.End_Object;
+   end Read_FoldingRange;
+
+   -----------------------------
+   -- Read_FoldingRangeParams --
+   -----------------------------
+
+   procedure Read_FoldingRangeParams
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out FoldingRangeParams)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+   begin
+      JS.Start_Object;
+      JS.Key ("textDocument");
+      TextDocumentIdentifier'Read (S, V.textDocument);
+      JS.End_Object;
+   end Read_FoldingRangeParams;
+
    ----------------------------------
    -- Read_foldingRange_Capability --
    ----------------------------------
@@ -3918,6 +3955,43 @@ package body LSP.Messages is
       WatchKind_Set'Write (S, V.kind);
       JS.End_Object;
    end Write_FileSystemWatcher;
+
+   ------------------------
+   -- Write_FoldingRange --
+   ------------------------
+
+   procedure Write_FoldingRange
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : FoldingRange)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+   begin
+      JS.Start_Object;
+      Write_Number (JS, +"startLine", V.startLine);
+      Write_Optional_Number (JS, +"startCharacter", V.startCharacter);
+      Write_Number (JS, +"endLine", V.endLine);
+      Write_Optional_Number (JS, +"endCharacter", V.endCharacter);
+      Write_Optional_String (JS, +"kind", V.kind);
+      JS.End_Object;
+   end Write_FoldingRange;
+
+   ------------------------------
+   -- Write_FoldingRangeParams --
+   ------------------------------
+
+   procedure Write_FoldingRangeParams
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : FoldingRangeParams)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+   begin
+      JS.Start_Object;
+      JS.Key ("textDocument");
+      TextDocumentIdentifier'Write (S, V.textDocument);
+      JS.End_Object;
+   end Write_FoldingRangeParams;
 
    ---------------------------------
    -- Write_ExecuteCommandOptions --

--- a/source/protocol/lsp-messages.adb
+++ b/source/protocol/lsp-messages.adb
@@ -383,7 +383,16 @@ package body LSP.Messages is
       JS.Start_Object;
       Read_Optional_Boolean
         (JS, +"dynamicRegistration", V.dynamicRegistration);
-      Read_Optional_Boolean (JS, +"snippetSupport", V.snippetSupport);
+      JS.Key ("completionItem");
+      Optional_completionItemCapability'Read (S, V.completionItem);
+
+      JS.Key ("completionItemKind");
+      JS.Start_Object;
+      JS.Key ("valueSet");
+      Optional_CompletionItemKindSet'Read (S, V.completionItemKind);
+      JS.End_Object;
+
+      Read_Optional_Boolean (JS, +"contextSupport", V.contextSupport);
       JS.End_Object;
    end Read_completion;
 
@@ -437,6 +446,30 @@ package body LSP.Messages is
       Optional_Command'Read (S, V.command);
       JS.End_Object;
    end Read_CompletionItem;
+
+   -----------------------------------
+   -- Read_completionItemCapability --
+   -----------------------------------
+
+   procedure Read_completionItemCapability
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out completionItemCapability)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+   begin
+      JS.Start_Object;
+      Read_Optional_Boolean (JS, +"snippetSupport", V.snippetSupport);
+      Read_Optional_Boolean
+        (JS, +"commitCharactersSupport", V.commitCharactersSupport);
+
+      JS.Key ("documentationFormat");
+      MarkupKind_Vector'Read (S, V.documentationFormat);
+      Read_Optional_Boolean (JS, +"deprecatedSupport", V.deprecatedSupport);
+      Read_Optional_Boolean (JS, +"preselectSupport", V.preselectSupport);
+
+      JS.End_Object;
+   end Read_completionItemCapability;
 
    -----------------------------
    -- Read_CompletionItemKind --
@@ -2246,7 +2279,16 @@ package body LSP.Messages is
       JS.Start_Object;
       Write_Optional_Boolean
         (JS, +"dynamicRegistration", V.dynamicRegistration);
-      Write_Optional_Boolean (JS, +"snippetSupport", V.snippetSupport);
+      JS.Key ("completionItem");
+      Optional_completionItemCapability'Write (S, V.completionItem);
+
+      JS.Key ("completionItemKind");
+      JS.Start_Object;
+      JS.Key ("valueSet");
+      Optional_CompletionItemKindSet'Write (S, V.completionItemKind);
+      JS.End_Object;
+
+      Write_Optional_Boolean (JS, +"contextSupport", V.contextSupport);
       JS.End_Object;
    end Write_completion;
 
@@ -2285,6 +2327,30 @@ package body LSP.Messages is
       Optional_Command'Write (S, V.command);
       JS.End_Object;
    end Write_CompletionItem;
+
+   ------------------------------------
+   -- Write_completionItemCapability --
+   ------------------------------------
+
+   procedure Write_completionItemCapability
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : completionItemCapability)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+   begin
+      JS.Start_Object;
+      Write_Optional_Boolean (JS, +"snippetSupport", V.snippetSupport);
+      Write_Optional_Boolean
+        (JS, +"commitCharactersSupport", V.commitCharactersSupport);
+
+      JS.Key ("documentationFormat");
+      MarkupKind_Vector'Write (S, V.documentationFormat);
+      Write_Optional_Boolean (JS, +"deprecatedSupport", V.deprecatedSupport);
+      Write_Optional_Boolean (JS, +"preselectSupport", V.preselectSupport);
+
+      JS.End_Object;
+   end Write_completionItemCapability;
 
    ------------------------------
    -- Write_CompletionItemKind --

--- a/source/protocol/lsp-messages.adb
+++ b/source/protocol/lsp-messages.adb
@@ -509,6 +509,37 @@ package body LSP.Messages is
       JS.End_Object;
    end Read_CompletionList;
 
+   ----------------------------
+   -- Read_CompletionContext --
+   ----------------------------
+
+   procedure Read_CompletionContext
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out CompletionContext)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+
+      Map : constant
+        array (LSP_Number range 1 .. 3) of CompletionTriggerKind :=
+        (Invoked, TriggerCharacter, TriggerForIncompleteCompletions);
+
+      Value : LSP_Number;
+   begin
+      JS.Start_Object;
+      JS.Key ("kind");
+      Value := JS.Read.Get;
+
+      if Value in Map'Range then
+         V.triggerKind := Map (Value);
+      else
+         V.triggerKind := Invoked;
+      end if;
+
+      Read_Optional_String (JS, +"triggerCharacter", V.triggerCharacter);
+      JS.End_Object;
+   end Read_CompletionContext;
+
    -------------------------
    -- Read_CompletionItem --
    -------------------------
@@ -598,6 +629,27 @@ package body LSP.Messages is
       Read_String_Vector (JS, +"triggerCharacters", V.triggerCharacters);
       JS.End_Object;
    end Read_CompletionOptions;
+
+   ---------------------------
+   -- Read_CompletionParams --
+   ---------------------------
+
+   procedure Read_CompletionParams
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out CompletionParams)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+   begin
+      JS.Start_Object;
+      JS.Key ("textDocument");
+      TextDocumentIdentifier'Read (S, V.textDocument);
+      JS.Key ("position");
+      Position'Read (S, V.position);
+      JS.Key ("context");
+      Optional_CompletionContext'Read (S, V.context);
+      JS.End_Object;
+   end Read_CompletionParams;
 
    ----------------------------
    -- Read_ConfigurationItem --
@@ -3071,6 +3123,25 @@ package body LSP.Messages is
       JS.End_Object;
    end Write_completion;
 
+   -----------------------------
+   -- Write_CompletionContext --
+   -----------------------------
+
+   procedure Write_CompletionContext
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : CompletionContext)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+
+      Map : constant array (CompletionTriggerKind) of LSP_Number := (1, 2, 3);
+   begin
+      JS.Start_Object;
+      Write_Number (JS, +"kind", Map (V.triggerKind));
+      Write_Optional_String (JS, +"triggerCharacter", V.triggerCharacter);
+      JS.End_Object;
+   end Write_CompletionContext;
+
    --------------------------
    -- Write_CompletionItem --
    --------------------------
@@ -3184,6 +3255,27 @@ package body LSP.Messages is
       Write_String_Vector (JS, +"triggerCharacters", V.triggerCharacters);
       JS.End_Object;
    end Write_CompletionOptions;
+
+   ----------------------------
+   -- Write_CompletionParams --
+   ----------------------------
+
+   procedure Write_CompletionParams
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : CompletionParams)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+   begin
+      JS.Start_Object;
+      JS.Key ("textDocument");
+      TextDocumentIdentifier'Write (S, V.textDocument);
+      JS.Key ("position");
+      Position'Write (S, V.position);
+      JS.Key ("context");
+      Optional_CompletionContext'Write (S, V.context);
+      JS.End_Object;
+   end Write_CompletionParams;
 
    -----------------------------
    -- Write_ConfigurationItem --

--- a/source/protocol/lsp-messages.adb
+++ b/source/protocol/lsp-messages.adb
@@ -1733,6 +1733,8 @@ package body LSP.Messages is
       Optional_Provider_Options'Read (S, V.declarationProvider);
       JS.Key ("executeCommandProvider");
       ExecuteCommandOptions'Read (S, V.executeCommandProvider);
+      JS.Key ("workspace");
+      Optional_workspace_Options'Read (S, V.workspace);
 
       Read_Optional_Boolean (JS, +"alsCalledByProvider",
                              V.alsCalledByProvider);
@@ -2388,6 +2390,41 @@ package body LSP.Messages is
       Read_String (JS, +"name", V.name);
       JS.End_Object;
    end Read_WorkspaceFolder;
+
+   ---------------------------
+   -- Read_workspaceFolders --
+   ---------------------------
+
+   procedure Read_workspaceFolders
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out workspaceFolders)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+   begin
+      JS.Start_Object;
+      Read_Optional_Boolean (JS, +"supported", V.supported);
+      JS.Key ("changeNotifications");
+      Optional_Boolean_Or_String'Read (S, V.changeNotifications);
+      JS.End_Object;
+   end Read_workspaceFolders;
+
+   ----------------------------
+   -- Read_workspace_Options --
+   ----------------------------
+
+   procedure Read_workspace_Options
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out workspace_Options)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+   begin
+      JS.Start_Object;
+      JS.Key ("workspaceFolders");
+      Optional_workspaceFolders'Read (S, V.workspaceFolders);
+      JS.End_Object;
+   end Read_workspace_Options;
 
    --------------------------------
    -- Read_WorkspaceSymbolParams --
@@ -3984,6 +4021,8 @@ package body LSP.Messages is
       Optional_Provider_Options'Write (S, V.declarationProvider);
       JS.Key ("executeCommandProvider");
       ExecuteCommandOptions'Write (S, V.executeCommandProvider);
+      JS.Key ("workspace");
+      Optional_workspace_Options'Write (S, V.workspace);
 
       --  ALS extensions
 
@@ -4588,6 +4627,41 @@ package body LSP.Messages is
       Write_String (JS, +"name", V.name);
       JS.End_Object;
    end Write_WorkspaceFolder;
+
+   ----------------------------
+   -- Write_workspaceFolders --
+   ----------------------------
+
+   procedure Write_workspaceFolders
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : workspaceFolders)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+   begin
+      JS.Start_Object;
+      Write_Optional_Boolean (JS, +"supported", V.supported);
+      JS.Key ("changeNotifications");
+      Optional_Boolean_Or_String'Write (S, V.changeNotifications);
+      JS.End_Object;
+   end Write_workspaceFolders;
+
+   -----------------------------
+   -- Write_workspace_Options --
+   -----------------------------
+
+   procedure Write_workspace_Options
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : workspace_Options)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+   begin
+      JS.Start_Object;
+      JS.Key ("workspaceFolders");
+      Optional_workspaceFolders'Write (S, V.workspaceFolders);
+      JS.End_Object;
+   end Write_workspace_Options;
 
    ---------------------------------
    -- Write_WorkspaceSymbolParams --

--- a/source/protocol/lsp-messages.adb
+++ b/source/protocol/lsp-messages.adb
@@ -1892,6 +1892,8 @@ package body LSP.Messages is
       dynamicRegistration'Read (S, V.codeLens);
       JS.Key ("documentLink");
       dynamicRegistration'Read (S, V.documentLink);
+      JS.Key ("colorProvider");
+      dynamicRegistration'Read (S, V.colorProvider);
       JS.Key ("rename");
       dynamicRegistration'Read (S, V.rename);
       JS.End_Object;
@@ -3953,6 +3955,8 @@ package body LSP.Messages is
       dynamicRegistration'Write (S, V.codeLens);
       JS.Key ("documentLink");
       dynamicRegistration'Write (S, V.documentLink);
+      JS.Key ("colorProvider");
+      dynamicRegistration'Write (S, V.colorProvider);
       JS.Key ("rename");
       dynamicRegistration'Write (S, V.rename);
       JS.End_Object;

--- a/source/protocol/lsp-messages.adb
+++ b/source/protocol/lsp-messages.adb
@@ -1002,6 +1002,8 @@ package body LSP.Messages is
          V.trace := LSP.Types.Verbose;
       end if;
 
+      JS.Key ("workspaceFolders");
+      Optional_WorkspaceFolder_Vector'Read (S, V.workspaceFolders);
       JS.End_Object;
    end Read_InitializeParams;
 
@@ -2279,6 +2281,23 @@ package body LSP.Messages is
       JS.End_Object;
    end Read_WorkspaceEdit;
 
+   --------------------------
+   -- Read_WorkspaceFolder --
+   --------------------------
+
+   procedure Read_WorkspaceFolder
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out WorkspaceFolder)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+   begin
+      JS.Start_Object;
+      Read_String (JS, +"uri", V.uri);
+      Read_String (JS, +"name", V.name);
+      JS.End_Object;
+   end Read_WorkspaceFolder;
+
    --------------------------------
    -- Read_WorkspaceSymbolParams --
    --------------------------------
@@ -3149,6 +3168,8 @@ package body LSP.Messages is
          Write_Optional_String (JS, +"trace", Trace);
       end if;
 
+      JS.Key ("workspaceFolders");
+      Optional_WorkspaceFolder_Vector'Write (S, V.workspaceFolders);
       JS.End_Object;
    end Write_InitializeParams;
 
@@ -4384,6 +4405,23 @@ package body LSP.Messages is
       end if;
       JS.End_Object;
    end Write_WorkspaceEdit;
+
+   ---------------------------
+   -- Write_WorkspaceFolder --
+   ---------------------------
+
+   procedure Write_WorkspaceFolder
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : WorkspaceFolder)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+   begin
+      JS.Start_Object;
+      Write_String (JS, +"uri", V.uri);
+      Write_String (JS, +"name", V.name);
+      JS.End_Object;
+   end Write_WorkspaceFolder;
 
    ---------------------------------
    -- Write_WorkspaceSymbolParams --

--- a/source/protocol/lsp-messages.adb
+++ b/source/protocol/lsp-messages.adb
@@ -599,6 +599,40 @@ package body LSP.Messages is
       JS.End_Object;
    end Read_CompletionOptions;
 
+   ----------------------------
+   -- Read_ConfigurationItem --
+   ----------------------------
+
+   procedure Read_ConfigurationItem
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out ConfigurationItem)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+   begin
+      JS.Start_Object;
+      Read_Optional_String (JS, +"scopeUri", V.scopeUri);
+      Read_Optional_String (JS, +"section", V.section);
+      JS.End_Object;
+   end Read_ConfigurationItem;
+
+   ------------------------------
+   -- Read_ConfigurationParams --
+   ------------------------------
+
+   procedure Read_ConfigurationParams
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out ConfigurationParams)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+   begin
+      JS.Start_Object;
+      JS.Key ("items");
+      ConfigurationItem_Vector'Read (S, V.items);
+      JS.End_Object;
+   end Read_ConfigurationParams;
+
    ---------------------
    -- Read_Diagnostic --
    ---------------------
@@ -3085,6 +3119,40 @@ package body LSP.Messages is
       Write_String_Vector (JS, +"triggerCharacters", V.triggerCharacters);
       JS.End_Object;
    end Write_CompletionOptions;
+
+   -----------------------------
+   -- Write_ConfigurationItem --
+   -----------------------------
+
+   procedure Write_ConfigurationItem
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : ConfigurationItem)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+   begin
+      JS.Start_Object;
+      Write_Optional_String (JS, +"scopeUri", V.scopeUri);
+      Write_Optional_String (JS, +"section", V.section);
+      JS.End_Object;
+   end Write_ConfigurationItem;
+
+   -------------------------------
+   -- Write_ConfigurationParams --
+   -------------------------------
+
+   procedure Write_ConfigurationParams
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : ConfigurationParams)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+   begin
+      JS.Start_Object;
+      JS.Key ("items");
+      ConfigurationItem_Vector'Write (S, V.items);
+      JS.End_Object;
+   end Write_ConfigurationParams;
 
    ----------------------
    -- Write_Diagnostic --

--- a/source/protocol/lsp-messages.adb
+++ b/source/protocol/lsp-messages.adb
@@ -646,6 +646,24 @@ package body LSP.Messages is
       JS.End_Object;
    end Read_DidSaveTextDocumentParams;
 
+   ---------------------------------
+   -- Read_declaration_Capability --
+   ---------------------------------
+
+   procedure Read_declaration_Capability
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out declaration_Capability)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+   begin
+      JS.Start_Object;
+      Read_Optional_Boolean
+        (JS, +"dynamicRegistration", V.dynamicRegistration);
+      Read_Optional_Boolean (JS, +"linkSupport", V.linkSupport);
+      JS.End_Object;
+   end Read_declaration_Capability;
+
    --------------------------
    -- Read_documentChanges --
    --------------------------
@@ -1786,6 +1804,8 @@ package body LSP.Messages is
       dynamicRegistration'Read (S, V.rangeFormatting);
       JS.Key ("onTypeFormatting");
       dynamicRegistration'Read (S, V.onTypeFormatting);
+      JS.Key ("declaration");
+      Optional_declaration_Capability'Read (S, V.declaration);
       JS.Key ("definition");
       dynamicRegistration'Read (S, V.definition);
       JS.Key ("typeDefinition");
@@ -2608,6 +2628,24 @@ package body LSP.Messages is
       Write_Optional_String (JS, +"text", V.text);
       JS.End_Object;
    end Write_DidSaveTextDocumentParams;
+
+   ----------------------------------
+   -- Write_declaration_Capability --
+   ----------------------------------
+
+   procedure Write_declaration_Capability
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : declaration_Capability)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+   begin
+      JS.Start_Object;
+      Write_Optional_Boolean
+        (JS, +"dynamicRegistration", V.dynamicRegistration);
+      Write_Optional_Boolean (JS, +"linkSupport", V.linkSupport);
+      JS.End_Object;
+   end Write_declaration_Capability;
 
    ---------------------------
    -- Write_documentChanges --
@@ -3740,6 +3778,8 @@ package body LSP.Messages is
       dynamicRegistration'Write (S, V.rangeFormatting);
       JS.Key ("onTypeFormatting");
       dynamicRegistration'Write (S, V.onTypeFormatting);
+      JS.Key ("declaration");
+      Optional_declaration_Capability'Write (S, V.declaration);
       JS.Key ("definition");
       dynamicRegistration'Write (S, V.definition);
       JS.Key ("typeDefinition");

--- a/source/protocol/lsp-messages.adb
+++ b/source/protocol/lsp-messages.adb
@@ -1362,37 +1362,29 @@ package body LSP.Messages is
       JS.End_Object;
    end Read_RenameParams;
 
-   -----------------------------------
-   -- Read_ResourceOperationKindSet --
-   -----------------------------------
+   --------------------------------
+   -- Read_ResourceOperationKind --
+   --------------------------------
 
-   procedure Read_ResourceOperationKindSet
+   procedure Read_ResourceOperationKind
      (S : access Ada.Streams.Root_Stream_Type'Class;
-      V : out ResourceOperationKindSet)
+      V : out ResourceOperationKind)
    is
       JS : LSP.JSON_Streams.JSON_Stream'Class renames
         LSP.JSON_Streams.JSON_Stream'Class (S.all);
+      Value : constant GNATCOLL.JSON.JSON_Value := JS.Read;
+      Text  : constant GNATCOLL.JSON.UTF8_String := Value.Get;
    begin
-      V := (others => False);
-      JS.Start_Array;
-      while not JS.End_Of_Array loop
-         declare
-            Value : constant GNATCOLL.JSON.JSON_Value := JS.Read;
-            Text  : constant GNATCOLL.JSON.UTF8_String := Value.Get;
-         begin
-            if Text = "create" then
-               V (create) := True;
-            elsif Text = "rename" then
-               V (rename) := True;
-            elsif Text = "delete" then
-               V (delete) := True;
-            else
-               null;
-            end if;
-         end;
-      end loop;
-      JS.End_Array;
-   end Read_ResourceOperationKindSet;
+      if Text = "create" then
+         V := create;
+      elsif Text = "rename" then
+         V := rename;
+      elsif Text = "delete" then
+         V := delete;
+      else
+         V := create;
+      end if;
+   end Read_ResourceOperationKind;
 
    ------------------------
    -- Read_ResponseError --
@@ -1652,30 +1644,6 @@ package body LSP.Messages is
    begin
       V := SymbolKind'Val (JS.Read.Get - 1);
    end Read_SymbolKind;
-
-   ------------------------
-   -- Read_SymbolKindSet --
-   ------------------------
-
-   procedure Read_SymbolKindSet
-     (S : access Ada.Streams.Root_Stream_Type'Class;
-      V : out SymbolKindSet)
-   is
-      JS : LSP.JSON_Streams.JSON_Stream'Class renames
-        LSP.JSON_Streams.JSON_Stream'Class (S.all);
-   begin
-      V := (others => False);
-      JS.Start_Array;
-      while not JS.End_Of_Array loop
-         declare
-            Key : SymbolKind;
-         begin
-            SymbolKind'Read (S, Key);
-            V (Key) := True;
-         end;
-      end loop;
-      JS.End_Array;
-   end Read_SymbolKindSet;
 
    --------------------------
    -- Read_synchronization --
@@ -3224,13 +3192,13 @@ package body LSP.Messages is
       JS.End_Object;
    end Write_RenameParams;
 
-   ------------------------------------
-   -- Write_ResourceOperationKindSet --
-   ------------------------------------
+   ---------------------------------
+   -- Write_ResourceOperationKind --
+   ---------------------------------
 
-   procedure Write_ResourceOperationKindSet
+   procedure Write_ResourceOperationKind
      (S : access Ada.Streams.Root_Stream_Type'Class;
-      V : ResourceOperationKindSet)
+      V : ResourceOperationKind)
    is
       function To_String
         (Value : ResourceOperationKind)
@@ -3257,16 +3225,8 @@ package body LSP.Messages is
       JS : LSP.JSON_Streams.JSON_Stream'Class renames
         LSP.JSON_Streams.JSON_Stream'Class (S.all);
    begin
-      JS.Start_Array;
-
-      for K in V'Range loop
-         if V (K) then
-            JS.Write (GNATCOLL.JSON.Create (To_String (K)));
-         end if;
-      end loop;
-
-      JS.End_Array;
-   end Write_ResourceOperationKindSet;
+      JS.Write (GNATCOLL.JSON.Create (To_String (V)));
+   end Write_ResourceOperationKind;
 
    -------------------------
    -- Write_ResponseError --
@@ -3511,33 +3471,6 @@ package body LSP.Messages is
         (GNATCOLL.JSON.Create
            (Integer'(SymbolKind'Pos (V)) + 1));
    end Write_SymbolKind;
-
-   -------------------------
-   -- Write_SymbolKindSet --
-   -------------------------
-
-   procedure Write_SymbolKindSet
-     (S : access Ada.Streams.Root_Stream_Type'Class;
-      V : SymbolKindSet)
-   is
-      JS : LSP.JSON_Streams.JSON_Stream'Class renames
-        LSP.JSON_Streams.JSON_Stream'Class (S.all);
-   begin
-      if V = (SymbolKind => False) then
-         JS.Write (GNATCOLL.JSON.Create (GNATCOLL.JSON.Empty_Array));
-         return;
-      end if;
-
-      JS.Start_Array;
-
-      for K in V'Range loop
-         if V (K) then
-            SymbolKind'Write (S, K);
-         end if;
-      end loop;
-
-      JS.End_Array;
-   end Write_SymbolKindSet;
 
    ---------------------------
    -- Write_synchronization --

--- a/source/protocol/lsp-messages.adb
+++ b/source/protocol/lsp-messages.adb
@@ -366,32 +366,6 @@ package body LSP.Messages is
       JS.End_Object;
    end Read_Command;
 
-   -------------------------
-   -- Read_Command_Vector --
-   -------------------------
-
-   procedure Read_Command_Vector
-     (S : access Ada.Streams.Root_Stream_Type'Class;
-      V : out Command_Vector)
-   is
-      JS : LSP.JSON_Streams.JSON_Stream'Class renames
-        LSP.JSON_Streams.JSON_Stream'Class (S.all);
-   begin
-      V.Clear;
-      JS.Start_Array;
-
-      while not JS.End_Of_Array loop
-         declare
-            Item : Command;
-         begin
-            Command'Read (S, Item);
-            V.Append (Item);
-         end;
-      end loop;
-
-      JS.End_Array;
-   end Read_Command_Vector;
-
    ---------------------
    -- Read_completion --
    ---------------------
@@ -409,32 +383,6 @@ package body LSP.Messages is
       Read_Optional_Boolean (JS, +"snippetSupport", V.snippetSupport);
       JS.End_Object;
    end Read_completion;
-
-   --------------------------------
-   -- Read_CompletionItem_Vector --
-   --------------------------------
-
-   procedure Read_CompletionItem_Vector
-     (S : access Ada.Streams.Root_Stream_Type'Class;
-      V : out CompletionItem_Vector)
-   is
-      JS : LSP.JSON_Streams.JSON_Stream'Class renames
-        LSP.JSON_Streams.JSON_Stream'Class (S.all);
-   begin
-      V.Clear;
-      JS.Start_Array;
-
-      while not JS.End_Of_Array loop
-         declare
-            Item : CompletionItem;
-         begin
-            CompletionItem'Read (S, Item);
-            V.Append (Item);
-         end;
-      end loop;
-
-      JS.End_Array;
-   end Read_CompletionItem_Vector;
 
    -------------------------
    -- Read_CompletionList --
@@ -539,30 +487,6 @@ package body LSP.Messages is
       Read_String (JS, +"message", V.message);
       JS.End_Object;
    end Read_Diagnostic;
-
-   ----------------------------
-   -- Read_Diagnostic_Vector --
-   ----------------------------
-
-   procedure Read_Diagnostic_Vector
-     (S : access Ada.Streams.Root_Stream_Type'Class;
-      V : out Diagnostic_Vector)
-   is
-      JS : LSP.JSON_Streams.JSON_Stream'Class renames
-        LSP.JSON_Streams.JSON_Stream'Class (S.all);
-   begin
-      V.Clear;
-      JS.Start_Array;
-      while not JS.End_Of_Array loop
-         declare
-            Item : Diagnostic;
-         begin
-            Diagnostic'Read (S, Item);
-            V.Append (Item);
-         end;
-      end loop;
-      JS.End_Array;
-   end Read_Diagnostic_Vector;
 
    -----------------------------
    -- Read_DiagnosticSeverity --
@@ -701,30 +625,6 @@ package body LSP.Messages is
       V.kind := DocumentHighlightKind'Val (JS.Read.Get - 1);
       JS.End_Object;
    end Read_DocumentHighlight;
-
-   -----------------------------------
-   -- Read_DocumentHighlight_Vector --
-   -----------------------------------
-
-   procedure Read_DocumentHighlight_Vector
-     (S : access Ada.Streams.Root_Stream_Type'Class;
-      V : out DocumentHighlight_Vector)
-   is
-      JS : LSP.JSON_Streams.JSON_Stream'Class renames
-        LSP.JSON_Streams.JSON_Stream'Class (S.all);
-   begin
-      V.Clear;
-      JS.Start_Array;
-      while not JS.End_Of_Array loop
-         declare
-            Item : DocumentHighlight;
-         begin
-            DocumentHighlight'Read (S, Item);
-            V.Append (Item);
-         end;
-      end loop;
-      JS.End_Array;
-   end Read_DocumentHighlight_Vector;
 
    --------------------------------
    -- Read_DocumentHighlightKind --
@@ -1006,32 +906,6 @@ package body LSP.Messages is
       JS.End_Object;
    end Read_Location;
 
-   --------------------------
-   -- Read_Location_Vector --
-   --------------------------
-
-   procedure Read_Location_Vector
-     (S : access Ada.Streams.Root_Stream_Type'Class;
-      V : out Location_Vector)
-   is
-      JS : LSP.JSON_Streams.JSON_Stream'Class renames
-        LSP.JSON_Streams.JSON_Stream'Class (S.all);
-   begin
-      V.Clear;
-      JS.Start_Array;
-
-      while not JS.End_Of_Array loop
-         declare
-            Item : Location;
-         begin
-            Location'Read (S, Item);
-            V.Append (Item);
-         end;
-      end loop;
-
-      JS.End_Array;
-   end Read_Location_Vector;
-
    ---------------------------
    -- Read_LogMessageParams --
    ---------------------------
@@ -1078,30 +952,6 @@ package body LSP.Messages is
             V := (Is_String => True, Value => Empty_LSP_String);
       end case;
    end Read_MarkedString;
-
-   ------------------------------
-   -- Read_MarkedString_Vector --
-   ------------------------------
-
-   procedure Read_MarkedString_Vector
-     (S : access Ada.Streams.Root_Stream_Type'Class;
-      V : out MarkedString_Vector)
-   is
-      JS : LSP.JSON_Streams.JSON_Stream'Class renames
-        LSP.JSON_Streams.JSON_Stream'Class (S.all);
-   begin
-      V.Clear;
-      JS.Start_Array;
-      while not JS.End_Of_Array loop
-         declare
-            Item : MarkedString;
-         begin
-            MarkedString'Read (S, Item);
-            V.Append (Item);
-         end;
-      end loop;
-      JS.End_Array;
-   end Read_MarkedString_Vector;
 
    procedure Read_MessageType
     (Stream : in out LSP.JSON_Streams.JSON_Stream'Class;
@@ -1239,30 +1089,6 @@ package body LSP.Messages is
       Read_Optional_String (JS, +"documentation", V.documentation);
       JS.End_Object;
    end Read_ParameterInformation;
-
-   --------------------------------------
-   -- Read_ParameterInformation_Vector --
-   --------------------------------------
-
-   procedure Read_ParameterInformation_Vector
-     (S : access Ada.Streams.Root_Stream_Type'Class;
-      V : out ParameterInformation_Vector)
-   is
-      JS : LSP.JSON_Streams.JSON_Stream'Class renames
-        LSP.JSON_Streams.JSON_Stream'Class (S.all);
-   begin
-      V.Clear;
-      JS.Start_Array;
-      while not JS.End_Of_Array loop
-         declare
-            Item : ParameterInformation;
-         begin
-            ParameterInformation'Read (S, Item);
-            V.Append (Item);
-         end;
-      end loop;
-      JS.End_Array;
-   end Read_ParameterInformation_Vector;
 
    -------------------
    -- Read_Position --
@@ -1512,32 +1338,6 @@ package body LSP.Messages is
       JS.End_Object;
    end Read_SignatureInformation;
 
-   --------------------------------------
-   -- Read_SignatureInformation_Vector --
-   --------------------------------------
-
-   procedure Read_SignatureInformation_Vector
-     (S : access Ada.Streams.Root_Stream_Type'Class;
-      V : out SignatureInformation_Vector)
-   is
-      JS : LSP.JSON_Streams.JSON_Stream'Class renames
-        LSP.JSON_Streams.JSON_Stream'Class (S.all);
-   begin
-      V.Clear;
-      JS.Start_Array;
-
-      while not JS.End_Of_Array loop
-         declare
-            Item : SignatureInformation;
-         begin
-            SignatureInformation'Read (S, Item);
-            V.Append (Item);
-         end;
-      end loop;
-
-      JS.End_Array;
-   end Read_SignatureInformation_Vector;
-
    ------------------------
    -- Read_SignatureHelp --
    ------------------------
@@ -1680,32 +1480,6 @@ package body LSP.Messages is
       JS.End_Object;
    end Read_SymbolInformation;
 
-   -----------------------------------
-   -- Read_SymbolInformation_Vector --
-   -----------------------------------
-
-   procedure Read_SymbolInformation_Vector
-     (S : access Ada.Streams.Root_Stream_Type'Class;
-      V : out SymbolInformation_Vector)
-   is
-      JS : LSP.JSON_Streams.JSON_Stream'Class renames
-        LSP.JSON_Streams.JSON_Stream'Class (S.all);
-   begin
-      V.Clear;
-      JS.Start_Array;
-
-      while not JS.End_Of_Array loop
-         declare
-            Item : SymbolInformation;
-         begin
-            SymbolInformation'Read (S, Item);
-            V.Append (Item);
-         end;
-      end loop;
-
-      JS.End_Array;
-   end Read_SymbolInformation_Vector;
-
    --------------------------
    -- Read_synchronization --
    --------------------------
@@ -1792,30 +1566,6 @@ package body LSP.Messages is
       JS.End_Object;
    end Read_TextDocumentContentChangeEvent;
 
-   ------------------------------------------------
-   -- Read_TextDocumentContentChangeEvent_Vector --
-   ------------------------------------------------
-
-   procedure Read_TextDocumentContentChangeEvent_Vector
-     (S : access Ada.Streams.Root_Stream_Type'Class;
-      V : out TextDocumentContentChangeEvent_Vector)
-   is
-      JS : LSP.JSON_Streams.JSON_Stream'Class renames
-        LSP.JSON_Streams.JSON_Stream'Class (S.all);
-   begin
-      V.Clear;
-      JS.Start_Array;
-      while not JS.End_Of_Array loop
-         declare
-            Item : TextDocumentContentChangeEvent;
-         begin
-            TextDocumentContentChangeEvent'Read (S, Item);
-            V.Append (Item);
-         end;
-      end loop;
-      JS.End_Array;
-   end Read_TextDocumentContentChangeEvent_Vector;
-
    ---------------------------
    -- Read_TextDocumentEdit --
    ---------------------------
@@ -1834,30 +1584,6 @@ package body LSP.Messages is
       TextEdit_Vector'Read (S, V.edits);
       JS.End_Object;
    end Read_TextDocumentEdit;
-
-   ----------------------------------
-   -- Read_TextDocumentEdit_Vector --
-   ----------------------------------
-
-   procedure Read_TextDocumentEdit_Vector
-     (S : access Ada.Streams.Root_Stream_Type'Class;
-      V : out TextDocumentEdit_Vector)
-   is
-      JS : LSP.JSON_Streams.JSON_Stream'Class renames
-        LSP.JSON_Streams.JSON_Stream'Class (S.all);
-   begin
-      V.Clear;
-      JS.Start_Array;
-      while not JS.End_Of_Array loop
-         declare
-            Item : TextDocumentEdit;
-         begin
-            TextDocumentEdit'Read (S, Item);
-            V.Append (Item);
-         end;
-      end loop;
-      JS.End_Array;
-   end Read_TextDocumentEdit_Vector;
 
    ---------------------------------
    -- Read_TextDocumentIdentifier --
@@ -1971,30 +1697,6 @@ package body LSP.Messages is
       Read_String (JS, +"newText", V.newText);
       JS.End_Object;
    end Read_TextEdit;
-
-   --------------------------
-   -- Read_TextEdit_Vector --
-   --------------------------
-
-   procedure Read_TextEdit_Vector
-     (S : access Ada.Streams.Root_Stream_Type'Class;
-      V : out TextEdit_Vector)
-   is
-      JS : LSP.JSON_Streams.JSON_Stream'Class renames
-        LSP.JSON_Streams.JSON_Stream'Class (S.all);
-   begin
-      V.Clear;
-      JS.Start_Array;
-      while not JS.End_Of_Array loop
-         declare
-            Item : TextEdit;
-         begin
-            TextEdit'Read (S, Item);
-            V.Append (Item);
-         end;
-      end loop;
-      JS.End_Array;
-   end Read_TextEdit_Vector;
 
    ------------------------------------------
    -- Read_VersionedTextDocumentIdentifier --
@@ -2299,29 +2001,6 @@ package body LSP.Messages is
       JS.End_Object;
    end Write_Command;
 
-   --------------------------
-   -- Write_Command_Vector --
-   --------------------------
-
-   procedure Write_Command_Vector
-     (S : access Ada.Streams.Root_Stream_Type'Class;
-      V : Command_Vector)
-   is
-      JS : LSP.JSON_Streams.JSON_Stream'Class renames
-        LSP.JSON_Streams.JSON_Stream'Class (S.all);
-   begin
-      if V.Is_Empty then
-         JS.Write (GNATCOLL.JSON.Create (GNATCOLL.JSON.Empty_Array));
-         return;
-      end if;
-
-      JS.Start_Array;
-      for Item of V loop
-         Command'Write (S, Item);
-      end loop;
-      JS.End_Array;
-   end Write_Command_Vector;
-
    ----------------------
    -- Write_completion --
    ----------------------
@@ -2375,29 +2054,6 @@ package body LSP.Messages is
       Optional_Command'Write (S, V.command);
       JS.End_Object;
    end Write_CompletionItem;
-
-   ---------------------------------
-   -- Write_CompletionItem_Vector --
-   ---------------------------------
-
-   procedure Write_CompletionItem_Vector
-     (S : access Ada.Streams.Root_Stream_Type'Class;
-      V : CompletionItem_Vector)
-   is
-      JS : LSP.JSON_Streams.JSON_Stream'Class renames
-        LSP.JSON_Streams.JSON_Stream'Class (S.all);
-   begin
-      if V.Is_Empty then
-         JS.Write (GNATCOLL.JSON.Create (GNATCOLL.JSON.Empty_Array));
-         return;
-      end if;
-
-      JS.Start_Array;
-      for Item of V loop
-         CompletionItem'Write (S, Item);
-      end loop;
-      JS.End_Array;
-   end Write_CompletionItem_Vector;
 
    ------------------------------
    -- Write_CompletionItemKind --
@@ -2471,24 +2127,6 @@ package body LSP.Messages is
       Write_String (JS, +"message", V.message);
       JS.End_Object;
    end Write_Diagnostic;
-
-   -----------------------------
-   -- Write_Diagnostic_Vector --
-   -----------------------------
-
-   procedure Write_Diagnostic_Vector
-     (S : access Ada.Streams.Root_Stream_Type'Class;
-      V : Diagnostic_Vector)
-   is
-      JS : LSP.JSON_Streams.JSON_Stream'Class renames
-        LSP.JSON_Streams.JSON_Stream'Class (S.all);
-   begin
-      JS.Start_Array;
-      for Item of V loop
-         Diagnostic'Write (S, Item);
-      end loop;
-      JS.End_Array;
-   end Write_Diagnostic_Vector;
 
    ------------------------------
    -- Write_DiagnosticSeverity --
@@ -2632,29 +2270,6 @@ package body LSP.Messages is
 
       JS.End_Object;
    end Write_DocumentHighlight;
-
-   ------------------------------------
-   -- Write_DocumentHighlight_Vector --
-   ------------------------------------
-
-   procedure Write_DocumentHighlight_Vector
-     (S : access Ada.Streams.Root_Stream_Type'Class;
-      V : DocumentHighlight_Vector)
-   is
-      JS : LSP.JSON_Streams.JSON_Stream'Class renames
-        LSP.JSON_Streams.JSON_Stream'Class (S.all);
-   begin
-      if V.Is_Empty then
-         JS.Write (GNATCOLL.JSON.Create (GNATCOLL.JSON.Empty_Array));
-         return;
-      end if;
-
-      JS.Start_Array;
-      for Item of V loop
-         DocumentHighlight'Write (S, Item);
-      end loop;
-      JS.End_Array;
-   end Write_DocumentHighlight_Vector;
 
    ---------------------------------
    -- Write_DocumentHighlightKind --
@@ -2912,29 +2527,6 @@ package body LSP.Messages is
       JS.End_Object;
    end Write_Location;
 
-   ---------------------------
-   -- Write_Location_Vector --
-   ---------------------------
-
-   procedure Write_Location_Vector
-     (S : access Ada.Streams.Root_Stream_Type'Class;
-      V : Location_Vector)
-   is
-      JS : LSP.JSON_Streams.JSON_Stream'Class renames
-        LSP.JSON_Streams.JSON_Stream'Class (S.all);
-   begin
-      if V.Is_Empty then
-         JS.Write (GNATCOLL.JSON.Create (GNATCOLL.JSON.Empty_Array));
-         return;
-      end if;
-
-      JS.Start_Array;
-      for Item of V loop
-         Location'Write (S, Item);
-      end loop;
-      JS.End_Array;
-   end Write_Location_Vector;
-
    ----------------------------
    -- Write_LogMessageParams --
    ----------------------------
@@ -2972,29 +2564,6 @@ package body LSP.Messages is
          JS.End_Object;
       end if;
    end Write_MarkedString;
-
-   -------------------------------
-   -- Write_MarkedString_Vector --
-   -------------------------------
-
-   procedure Write_MarkedString_Vector
-     (S : access Ada.Streams.Root_Stream_Type'Class;
-      V : MarkedString_Vector)
-   is
-      JS : LSP.JSON_Streams.JSON_Stream'Class renames
-        LSP.JSON_Streams.JSON_Stream'Class (S.all);
-   begin
-      if V.Is_Empty then
-         JS.Write (GNATCOLL.JSON.Create (GNATCOLL.JSON.Empty_Array));
-         return;
-      end if;
-
-      JS.Start_Array;
-      for Item of V loop
-         MarkedString'Write (S, Item);
-      end loop;
-      JS.End_Array;
-   end Write_MarkedString_Vector;
 
    -----------------------
    -- Write_MessageType --
@@ -3143,29 +2712,6 @@ package body LSP.Messages is
       Write_Optional_String (JS, +"documentation", V.documentation);
       JS.End_Object;
    end Write_ParameterInformation;
-
-   ---------------------------------------
-   -- Write_ParameterInformation_Vector --
-   ---------------------------------------
-
-   procedure Write_ParameterInformation_Vector
-     (S : access Ada.Streams.Root_Stream_Type'Class;
-      V : ParameterInformation_Vector)
-   is
-      JS : LSP.JSON_Streams.JSON_Stream'Class renames
-        LSP.JSON_Streams.JSON_Stream'Class (S.all);
-   begin
-      if V.Is_Empty then
-         JS.Write (GNATCOLL.JSON.Create (GNATCOLL.JSON.Empty_Array));
-         return;
-      end if;
-
-      JS.Start_Array;
-      for Item of V loop
-         ParameterInformation'Write (S, Item);
-      end loop;
-      JS.End_Array;
-   end Write_ParameterInformation_Vector;
 
    --------------------
    -- Write_Position --
@@ -3469,28 +3015,6 @@ package body LSP.Messages is
       JS.End_Object;
    end Write_SignatureInformation;
 
-   ---------------------------------------
-   -- Write_SignatureInformation_Vector --
-   ---------------------------------------
-
-   procedure Write_SignatureInformation_Vector
-     (S : access Ada.Streams.Root_Stream_Type'Class;
-      V : SignatureInformation_Vector)
-   is
-      JS : LSP.JSON_Streams.JSON_Stream'Class renames
-        LSP.JSON_Streams.JSON_Stream'Class (S.all);
-   begin
-      if V.Is_Empty then
-         JS.Write (GNATCOLL.JSON.Create (GNATCOLL.JSON.Empty_Array));
-      else
-         JS.Start_Array;
-         for Item of V loop
-            SignatureInformation'Write (S, Item);
-         end loop;
-         JS.End_Array;
-      end if;
-   end Write_SignatureInformation_Vector;
-
    ----------------
    -- Write_Span --
    ----------------
@@ -3554,28 +3078,6 @@ package body LSP.Messages is
       Write_Optional_String (JS, +"containerName", V.containerName);
       JS.End_Object;
    end Write_SymbolInformation;
-
-   ------------------------------------
-   -- Write_SymbolInformation_Vector --
-   ------------------------------------
-
-   procedure Write_SymbolInformation_Vector
-     (S : access Ada.Streams.Root_Stream_Type'Class;
-      V : SymbolInformation_Vector)
-   is
-      JS : LSP.JSON_Streams.JSON_Stream'Class renames
-        LSP.JSON_Streams.JSON_Stream'Class (S.all);
-   begin
-      if V.Is_Empty then
-         JS.Write (GNATCOLL.JSON.Create (GNATCOLL.JSON.Empty_Array));
-      else
-         JS.Start_Array;
-         for Item of V loop
-            SymbolInformation'Write (S, Item);
-         end loop;
-         JS.End_Array;
-      end if;
-   end Write_SymbolInformation_Vector;
 
    ---------------------------
    -- Write_synchronization --
@@ -3663,26 +3165,6 @@ package body LSP.Messages is
       JS.End_Object;
    end Write_TextDocumentContentChangeEvent;
 
-   -------------------------------------------------
-   -- Write_TextDocumentContentChangeEvent_Vector --
-   -------------------------------------------------
-
-   procedure Write_TextDocumentContentChangeEvent_Vector
-     (S : access Ada.Streams.Root_Stream_Type'Class;
-      V : TextDocumentContentChangeEvent_Vector)
-   is
-      JS : LSP.JSON_Streams.JSON_Stream'Class renames
-        LSP.JSON_Streams.JSON_Stream'Class (S.all);
-   begin
-      JS.Start_Array;
-
-      for Item of V loop
-         TextDocumentContentChangeEvent'Write (S, Item);
-      end loop;
-
-      JS.End_Array;
-   end Write_TextDocumentContentChangeEvent_Vector;
-
    ----------------------------
    -- Write_TextDocumentEdit --
    ----------------------------
@@ -3701,29 +3183,6 @@ package body LSP.Messages is
       TextEdit_Vector'Write (S, V.edits);
       JS.End_Object;
    end Write_TextDocumentEdit;
-
-   -----------------------------------
-   -- Write_TextDocumentEdit_Vector --
-   -----------------------------------
-
-   procedure Write_TextDocumentEdit_Vector
-     (S : access Ada.Streams.Root_Stream_Type'Class;
-      V : TextDocumentEdit_Vector)
-   is
-      JS : LSP.JSON_Streams.JSON_Stream'Class renames
-        LSP.JSON_Streams.JSON_Stream'Class (S.all);
-   begin
-      if V.Is_Empty then
-         JS.Write (GNATCOLL.JSON.Create (GNATCOLL.JSON.Empty_Array));
-         return;
-      end if;
-
-      JS.Start_Array;
-      for Item of V loop
-         TextDocumentEdit'Write (S, Item);
-      end loop;
-      JS.End_Array;
-   end Write_TextDocumentEdit_Vector;
 
    ----------------------------------
    -- Write_TextDocumentIdentifier --
@@ -3835,24 +3294,6 @@ package body LSP.Messages is
       Write_String (JS, +"newText", V.newText);
       JS.End_Object;
    end Write_TextEdit;
-
-   ---------------------------
-   -- Write_TextEdit_Vector --
-   ---------------------------
-
-   procedure Write_TextEdit_Vector
-     (S : access Ada.Streams.Root_Stream_Type'Class;
-      V : TextEdit_Vector)
-   is
-      JS : LSP.JSON_Streams.JSON_Stream'Class renames
-        LSP.JSON_Streams.JSON_Stream'Class (S.all);
-   begin
-      JS.Start_Array;
-      for Item of V loop
-         TextEdit'Write (S, Item);
-      end loop;
-      JS.End_Array;
-   end Write_TextEdit_Vector;
 
    -------------------------------------------
    -- Write_VersionedTextDocumentIdentifier --
@@ -4009,55 +3450,6 @@ package body LSP.Messages is
       Location_Vector'Write (S, V.refs);
       JS.End_Object;
    end Write_ALS_Subprogram_And_References;
-
-   -----------------------------------------------
-   -- Read_ALS_Subprogram_And_References_Vector --
-   -----------------------------------------------
-
-   procedure Read_ALS_Subprogram_And_References_Vector
-     (S : access Ada.Streams.Root_Stream_Type'Class;
-      V : out ALS_Subprogram_And_References_Vector)
-   is
-      JS : LSP.JSON_Streams.JSON_Stream'Class renames
-        LSP.JSON_Streams.JSON_Stream'Class (S.all);
-   begin
-      V.Clear;
-      JS.Start_Array;
-
-      while not JS.End_Of_Array loop
-         declare
-            Item : ALS_Subprogram_And_References;
-         begin
-            ALS_Subprogram_And_References'Read (S, Item);
-            V.Append (Item);
-         end;
-      end loop;
-
-      JS.End_Array;
-   end Read_ALS_Subprogram_And_References_Vector;
-
-   ------------------------------------------------
-   -- Write_ALS_Subprogram_And_References_Vector --
-   ------------------------------------------------
-
-   procedure Write_ALS_Subprogram_And_References_Vector
-     (S : access Ada.Streams.Root_Stream_Type'Class;
-      V : ALS_Subprogram_And_References_Vector)
-   is
-      JS : LSP.JSON_Streams.JSON_Stream'Class renames
-        LSP.JSON_Streams.JSON_Stream'Class (S.all);
-   begin
-      if V.Is_Empty then
-         JS.Write (GNATCOLL.JSON.Create (GNATCOLL.JSON.Empty_Array));
-         return;
-      end if;
-
-      JS.Start_Array;
-      for Item of V loop
-         ALS_Subprogram_And_References'Write (S, Item);
-      end loop;
-      JS.End_Array;
-   end Write_ALS_Subprogram_And_References_Vector;
 
    --------------------------
    -- Write_ALSDebugParams --

--- a/source/protocol/lsp-messages.adb
+++ b/source/protocol/lsp-messages.adb
@@ -488,8 +488,28 @@ package body LSP.Messages is
       LSP.Types.Read_Number_Or_String (JS, +"code", V.code);
       Read_Optional_String (JS, +"source", V.source);
       Read_String (JS, +"message", V.message);
+      JS.Key ("relatedInformation");
+      DiagnosticRelatedInformation_Vector'Read (S, V.relatedInformation);
       JS.End_Object;
    end Read_Diagnostic;
+
+   ---------------------------------------
+   -- Read_DiagnosticRelatedInformation --
+   ---------------------------------------
+
+   procedure Read_DiagnosticRelatedInformation
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out DiagnosticRelatedInformation)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+   begin
+      JS.Start_Object;
+      JS.Key ("location");
+      Location'Read (S, V.location);
+      Read_String (JS, +"message", V.message);
+      JS.End_Object;
+   end Read_DiagnosticRelatedInformation;
 
    -----------------------------
    -- Read_DiagnosticSeverity --
@@ -2173,8 +2193,32 @@ package body LSP.Messages is
       Write_Number_Or_String (JS, +"code", V.code);
       Write_Optional_String (JS, +"source", V.source);
       Write_String (JS, +"message", V.message);
+
+      if not V.relatedInformation.Is_Empty then
+         JS.Key ("relatedInformation");
+         DiagnosticRelatedInformation_Vector'Write (S, V.relatedInformation);
+      end if;
+
       JS.End_Object;
    end Write_Diagnostic;
+
+   ----------------------------------------
+   -- Write_DiagnosticRelatedInformation --
+   ----------------------------------------
+
+   procedure Write_DiagnosticRelatedInformation
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : DiagnosticRelatedInformation)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+   begin
+      JS.Start_Object;
+      JS.Key ("location");
+      Location'Write (S, V.location);
+      Write_String (JS, +"message", V.message);
+      JS.End_Object;
+   end Write_DiagnosticRelatedInformation;
 
    ------------------------------
    -- Write_DiagnosticSeverity --

--- a/source/protocol/lsp-messages.adb
+++ b/source/protocol/lsp-messages.adb
@@ -1807,9 +1807,11 @@ package body LSP.Messages is
       JS.Key ("declaration");
       Optional_declaration_Capability'Read (S, V.declaration);
       JS.Key ("definition");
-      dynamicRegistration'Read (S, V.definition);
+      Optional_definition_Capability'Read (S, V.definition);
       JS.Key ("typeDefinition");
-      dynamicRegistration'Read (S, V.typeDefinition);
+      Optional_typeDefinition_Capability'Read (S, V.typeDefinition);
+      JS.Key ("implementation");
+      Optional_implementation_Capability'Read (S, V.implementation);
       JS.Key ("codeAction");
       dynamicRegistration'Read (S, V.codeAction);
       JS.Key ("codeLens");
@@ -3781,9 +3783,11 @@ package body LSP.Messages is
       JS.Key ("declaration");
       Optional_declaration_Capability'Write (S, V.declaration);
       JS.Key ("definition");
-      dynamicRegistration'Write (S, V.definition);
+      Optional_definition_Capability'Write (S, V.definition);
       JS.Key ("typeDefinition");
-      dynamicRegistration'Write (S, V.typeDefinition);
+      Optional_typeDefinition_Capability'Write (S, V.typeDefinition);
+      JS.Key ("implementation");
+      Optional_implementation_Capability'Write (S, V.implementation);
       JS.Key ("codeAction");
       dynamicRegistration'Write (S, V.codeAction);
       JS.Key ("codeLens");

--- a/source/protocol/lsp-messages.adb
+++ b/source/protocol/lsp-messages.adb
@@ -235,6 +235,7 @@ package body LSP.Messages is
    begin
       JS.Start_Object;
       Read_Boolean (JS, +"applied", V.applied);
+      Read_Optional_String (JS, +"failureReason", V.failureReason);
       JS.End_Object;
    end Read_ApplyWorkspaceEditResult;
 
@@ -2686,6 +2687,7 @@ package body LSP.Messages is
    begin
       JS.Start_Object;
       Write_Boolean (JS, +"applied", V.applied);
+      Write_Optional_String (JS, +"failureReason", V.failureReason);
       JS.End_Object;
    end Write_ApplyWorkspaceEditResult;
 

--- a/source/protocol/lsp-messages.adb
+++ b/source/protocol/lsp-messages.adb
@@ -74,9 +74,12 @@ package body LSP.Messages is
      Item   : LSP.Types.Optional_Boolean);
 
    procedure Write_Optional_Number
-    (Stream : in out LSP.JSON_Streams.JSON_Stream'Class;
-     Key    : LSP.Types.LSP_String;
-     Item   : LSP.Types.Optional_Number);
+    (Stream     : in out LSP.JSON_Streams.JSON_Stream'Class;
+     Key        : LSP.Types.LSP_String;
+     Item       : LSP.Types.Optional_Number;
+     Write_Null : Boolean := False);
+   --  If Item has a value write its value into Key. Otherwise if Write_Null,
+   --  then write 'null' into Key. Otherwise do nothing.
 
    procedure Write_Optional_AlsReferenceKind_Set
     (Stream : access LSP.JSON_Streams.JSON_Stream'Class;
@@ -1712,7 +1715,7 @@ package body LSP.Messages is
       JS.Start_Object;
       JS.Key ("uri");
       DocumentUri'Read (S, V.uri);
-      Read_Number (JS, +"version", LSP_Number (V.version));
+      Read_Optional_Number (JS, +"version", V.version);
       JS.End_Object;
    end Read_VersionedTextDocumentIdentifier;
 
@@ -2641,12 +2644,16 @@ package body LSP.Messages is
    ---------------------------
 
    procedure Write_Optional_Number
-    (Stream : in out LSP.JSON_Streams.JSON_Stream'Class;
-     Key    : LSP.Types.LSP_String;
-     Item   : LSP.Types.Optional_Number) is
+    (Stream     : in out LSP.JSON_Streams.JSON_Stream'Class;
+     Key        : LSP.Types.LSP_String;
+     Item       : LSP.Types.Optional_Number;
+     Write_Null : Boolean := False) is
    begin
       if Item.Is_Set then
          Write_Number (Stream, Key, Item.Value);
+      elsif Write_Null then
+         Stream.Key (Ada.Strings.Wide_Unbounded.Unbounded_Wide_String (Key));
+         Stream.Write (GNATCOLL.JSON.Create);
       end if;
    end Write_Optional_Number;
 
@@ -3309,7 +3316,7 @@ package body LSP.Messages is
       JS.Start_Object;
       JS.Key ("uri");
       DocumentUri'Write (S, V.uri);
-      Write_Number (JS, +"version", LSP_Number (V.version));
+      Write_Optional_Number (JS, +"version", V.version, Write_Null => True);
       JS.End_Object;
    end Write_VersionedTextDocumentIdentifier;
 

--- a/source/protocol/lsp-messages.adb
+++ b/source/protocol/lsp-messages.adb
@@ -524,6 +524,8 @@ package body LSP.Messages is
       Read_Optional_String (JS, +"detail", V.detail);
       JS.Key ("documentation");
       Optional_String_Or_MarkupContent'Read (S, V.documentation);
+      Read_Optional_Boolean (JS, +"deprecated", V.deprecated);
+      Read_Optional_Boolean (JS, +"preselect", V.preselect);
       Read_Optional_String (JS, +"sortText", V.sortText);
       Read_Optional_String (JS, +"filterText", V.filterText);
       Read_Optional_String (JS, +"insertText", V.insertText);
@@ -2795,6 +2797,8 @@ package body LSP.Messages is
       Write_Optional_String (JS, +"detail", V.detail);
       JS.Key ("documentation");
       Optional_String_Or_MarkupContent'Write (S, V.documentation);
+      Write_Optional_Boolean (JS, +"deprecated", V.deprecated);
+      Write_Optional_Boolean (JS, +"preselect", V.preselect);
       Write_Optional_String (JS, +"sortText", V.sortText);
       Write_Optional_String (JS, +"filterText", V.filterText);
       Write_Optional_String (JS, +"insertText", V.insertText);

--- a/source/protocol/lsp-messages.adb
+++ b/source/protocol/lsp-messages.adb
@@ -1538,6 +1538,22 @@ package body LSP.Messages is
       JS.End_Object;
    end Read_ResponseMessage;
 
+   ------------------------
+   -- Read_RenameOptions --
+   ------------------------
+
+   procedure Read_RenameOptions
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out RenameOptions)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+   begin
+      JS.Start_Object;
+      Read_Optional_Boolean (JS, +"prepareProvider", V.prepareProvider);
+      JS.End_Object;
+   end Read_RenameOptions;
+
    -----------------------
    -- Read_RenameParams --
    -----------------------
@@ -1672,7 +1688,8 @@ package body LSP.Messages is
       JS.Key ("documentOnTypeFormattingProvider");
       Optional_DocumentOnTypeFormattingOptions'Read
         (S, V.documentOnTypeFormattingProvider);
-      Read_Optional_Boolean (JS, +"renameProvider", V.renameProvider);
+      JS.Key ("renameProvider");
+      Optional_RenameOptions'Read (S, V.renameProvider);
       JS.Key ("documentLinkProvider");
       DocumentLinkOptions'Read (S, V.documentLinkProvider);
       JS.Key ("executeCommandProvider");
@@ -3698,6 +3715,22 @@ package body LSP.Messages is
       JS.End_Object;
    end Write_RequestMessage;
 
+   -------------------------
+   -- Write_RenameOptions --
+   -------------------------
+
+   procedure Write_RenameOptions
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : RenameOptions)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+   begin
+      JS.Start_Object;
+      Write_Optional_Boolean (JS, +"prepareProvider", V.prepareProvider);
+      JS.End_Object;
+   end Write_RenameOptions;
+
    ------------------------
    -- Write_RenameParams --
    ------------------------
@@ -3860,7 +3893,8 @@ package body LSP.Messages is
       JS.Key ("documentOnTypeFormattingProvider");
       Optional_DocumentOnTypeFormattingOptions'Write
         (S, V.documentOnTypeFormattingProvider);
-      Write_Optional_Boolean (JS, +"renameProvider", V.renameProvider);
+      JS.Key ("renameProvider");
+      Optional_RenameOptions'Write (S, V.renameProvider);
       JS.Key ("documentLinkProvider");
       DocumentLinkOptions'Write (S, V.documentLinkProvider);
       JS.Key ("executeCommandProvider");

--- a/source/protocol/lsp-messages.adb
+++ b/source/protocol/lsp-messages.adb
@@ -1036,6 +1036,50 @@ package body LSP.Messages is
       end case;
    end Read_MarkedString;
 
+   ------------------------
+   -- Read_MarkupContent --
+   ------------------------
+
+   procedure Read_MarkupContent
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out MarkupContent)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+   begin
+      JS.Start_Object;
+      JS.Key ("kind");
+      MarkupKind'Read (S, V.kind);
+      Read_String (JS, +"value", V.value);
+      JS.End_Object;
+   end Read_MarkupContent;
+
+   ---------------------
+   -- Read_MarkupKind --
+   ---------------------
+
+   procedure Read_MarkupKind
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out MarkupKind)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+      Value : constant GNATCOLL.JSON.JSON_Value := JS.Read;
+   begin
+      if Value.Kind in GNATCOLL.JSON.JSON_String_Type then
+         if Standard.String'(Value.Get) = "markdown" then
+            V := markdown;
+            return;
+         end if;
+      end if;
+
+      V := plaintext;
+   end Read_MarkupKind;
+
+   ----------------------
+   -- Read_MessageType --
+   ----------------------
+
    procedure Read_MessageType
     (Stream : in out LSP.JSON_Streams.JSON_Stream'Class;
      Key    : LSP.Types.LSP_String;
@@ -2855,6 +2899,43 @@ package body LSP.Messages is
          JS.End_Object;
       end if;
    end Write_MarkedString;
+
+   -------------------------
+   -- Write_MarkupContent --
+   -------------------------
+
+   procedure Write_MarkupContent
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : MarkupContent)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+   begin
+      JS.Start_Object;
+      JS.Key ("kind");
+      MarkupKind'Write (S, V.kind);
+      Write_String (JS, +"value", V.value);
+      JS.End_Object;
+   end Write_MarkupContent;
+
+   ----------------------
+   -- Write_MarkupKind --
+   ----------------------
+
+   procedure Write_MarkupKind
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : MarkupKind)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+   begin
+      case V is
+         when plaintext =>
+            JS.Write (GNATCOLL.JSON.Create ("plaintext"));
+         when markdown =>
+            JS.Write (GNATCOLL.JSON.Create ("markdown"));
+      end case;
+   end Write_MarkupKind;
 
    -----------------------
    -- Write_MessageType --

--- a/source/protocol/lsp-messages.adb
+++ b/source/protocol/lsp-messages.adb
@@ -691,6 +691,23 @@ package body LSP.Messages is
       JS.End_Object;
    end Read_DidChangeTextDocumentParams;
 
+   ------------------------------------------
+   -- Read_DidChangeWorkspaceFoldersParams --
+   ------------------------------------------
+
+   procedure Read_DidChangeWorkspaceFoldersParams
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out DidChangeWorkspaceFoldersParams)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+   begin
+      JS.Start_Object;
+      JS.Key ("event");
+      WorkspaceFoldersChangeEvent'Read (S, V.event);
+      JS.End_Object;
+   end Read_DidChangeWorkspaceFoldersParams;
+
    -------------------------------------
    -- Read_DidCloseTextDocumentParams --
    -------------------------------------
@@ -2571,6 +2588,25 @@ package body LSP.Messages is
       JS.End_Object;
    end Read_WorkspaceFolder;
 
+   --------------------------------------
+   -- Read_WorkspaceFoldersChangeEvent --
+   --------------------------------------
+
+   procedure Read_WorkspaceFoldersChangeEvent
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out WorkspaceFoldersChangeEvent)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+   begin
+      JS.Start_Object;
+      JS.Key ("added");
+      WorkspaceFolder_Vector'Read (S, V.added);
+      JS.Key ("removed");
+      WorkspaceFolder_Vector'Read (S, V.removed);
+      JS.End_Object;
+   end Read_WorkspaceFoldersChangeEvent;
+
    ---------------------------
    -- Read_workspaceFolders --
    ---------------------------
@@ -3147,6 +3183,23 @@ package body LSP.Messages is
       TextDocumentContentChangeEvent_Vector'Write (S, V.contentChanges);
       JS.End_Object;
    end Write_DidChangeTextDocumentParams;
+
+   -------------------------------------------
+   -- Write_DidChangeWorkspaceFoldersParams --
+   -------------------------------------------
+
+   procedure Write_DidChangeWorkspaceFoldersParams
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : DidChangeWorkspaceFoldersParams)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+   begin
+      JS.Start_Object;
+      JS.Key ("event");
+      WorkspaceFoldersChangeEvent'Write (S, V.event);
+      JS.End_Object;
+   end Write_DidChangeWorkspaceFoldersParams;
 
    --------------------------------------
    -- Write_DidCloseTextDocumentParams --
@@ -4936,6 +4989,25 @@ package body LSP.Messages is
       Write_String (JS, +"name", V.name);
       JS.End_Object;
    end Write_WorkspaceFolder;
+
+   ---------------------------------------
+   -- Write_WorkspaceFoldersChangeEvent --
+   ---------------------------------------
+
+   procedure Write_WorkspaceFoldersChangeEvent
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : WorkspaceFoldersChangeEvent)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+   begin
+      JS.Start_Object;
+      JS.Key ("added");
+      WorkspaceFolder_Vector'Write (S, V.added);
+      JS.Key ("removed");
+      WorkspaceFolder_Vector'Write (S, V.removed);
+      JS.End_Object;
+   end Write_WorkspaceFoldersChangeEvent;
 
    ----------------------------
    -- Write_workspaceFolders --

--- a/source/protocol/lsp-messages.adb
+++ b/source/protocol/lsp-messages.adb
@@ -502,6 +502,47 @@ package body LSP.Messages is
       JS.End_Object;
    end Read_ColorInformation;
 
+   ----------------------------
+   -- Read_ColorPresentation --
+   ----------------------------
+
+   procedure Read_ColorPresentation
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out ColorPresentation)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+   begin
+      JS.Start_Object;
+      Read_String (JS, +"label", V.label);
+      JS.Key ("textEdit");
+      Optional_TextEdit'Read (S, V.textEdit);
+      JS.Key ("additionalTextEdits");
+      TextEdit_Vector'Read (S, V.additionalTextEdits);
+      JS.End_Object;
+   end Read_ColorPresentation;
+
+   ----------------------------------
+   -- Read_ColorPresentationParams --
+   ----------------------------------
+
+   procedure Read_ColorPresentationParams
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out ColorPresentationParams)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+   begin
+      JS.Start_Object;
+      JS.Key ("textDocument");
+      TextDocumentIdentifier'Read (S, V.textDocument);
+      JS.Key ("color");
+      RGBA_Color'Read (S, V.color);
+      JS.Key ("range");
+      Span'Read (S, V.span);
+      JS.End_Object;
+   end Read_ColorPresentationParams;
+
    ------------------
    -- Read_Command --
    ------------------
@@ -3194,6 +3235,51 @@ package body LSP.Messages is
       RGBA_Color'Write (S, V.color);
       JS.End_Object;
    end Write_ColorInformation;
+
+   -----------------------------
+   -- Write_ColorPresentation --
+   -----------------------------
+
+   procedure Write_ColorPresentation
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : ColorPresentation)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+   begin
+      JS.Start_Object;
+      Write_String (JS, +"label", V.label);
+      JS.Key ("textEdit");
+      Optional_TextEdit'Write (S, V.textEdit);
+
+      if not V.additionalTextEdits.Is_Empty then
+         JS.Key ("additionalTextEdits");
+         TextEdit_Vector'Write (S, V.additionalTextEdits);
+      end if;
+
+      JS.End_Object;
+   end Write_ColorPresentation;
+
+   -----------------------------------
+   -- Write_ColorPresentationParams --
+   -----------------------------------
+
+   procedure Write_ColorPresentationParams
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : ColorPresentationParams)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+   begin
+      JS.Start_Object;
+      JS.Key ("textDocument");
+      TextDocumentIdentifier'Write (S, V.textDocument);
+      JS.Key ("color");
+      RGBA_Color'Write (S, V.color);
+      JS.Key ("range");
+      Span'Write (S, V.span);
+      JS.End_Object;
+   end Write_ColorPresentationParams;
 
    -------------------
    -- Write_Command --

--- a/source/protocol/lsp-messages.adb
+++ b/source/protocol/lsp-messages.adb
@@ -483,6 +483,25 @@ package body LSP.Messages is
       JS.End_Object;
    end Read_CodeLensOptions;
 
+   ---------------------------
+   -- Read_ColorInformation --
+   ---------------------------
+
+   procedure Read_ColorInformation
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out ColorInformation)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+   begin
+      JS.Start_Object;
+      JS.Key ("range");
+      Span'Read (S, V.span);
+      JS.Key ("color");
+      RGBA_Color'Read (S, V.color);
+      JS.End_Object;
+   end Read_ColorInformation;
+
    ------------------
    -- Read_Command --
    ------------------
@@ -1853,6 +1872,25 @@ package body LSP.Messages is
       Optional_ResponseError'Read (S, V.error);
    end Read_Response_Prefix;
 
+   ---------------------
+   -- Read_RGBA_Color --
+   ---------------------
+
+   procedure Read_RGBA_Color
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out RGBA_Color)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+   begin
+      JS.Start_Object;
+      Read_Number (JS, +"red", V.red);
+      Read_Number (JS, +"green", V.green);
+      Read_Number (JS, +"blue", V.blue);
+      Read_Number (JS, +"alpha", V.alpha);
+      JS.End_Object;
+   end Read_RGBA_Color;
+
    --------------------------
    -- Read_ResponseMessage --
    --------------------------
@@ -3138,6 +3176,25 @@ package body LSP.Messages is
       JS.End_Object;
    end Write_CodeLensOptions;
 
+   ----------------------------
+   -- Write_ColorInformation --
+   ----------------------------
+
+   procedure Write_ColorInformation
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : ColorInformation)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+   begin
+      JS.Start_Object;
+      JS.Key ("range");
+      Span'Write (S, V.span);
+      JS.Key ("color");
+      RGBA_Color'Write (S, V.color);
+      JS.End_Object;
+   end Write_ColorInformation;
+
    -------------------
    -- Write_Command --
    -------------------
@@ -4407,6 +4464,25 @@ package body LSP.Messages is
         (JS, +"relatedInformation", V.relatedInformation);
       JS.End_Object;
    end Write_publishDiagnostics_Capability;
+
+   ----------------------
+   -- Write_RGBA_Color --
+   ----------------------
+
+   procedure Write_RGBA_Color
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : RGBA_Color)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+   begin
+      JS.Start_Object;
+      Write_Number (JS, +"red", V.red);
+      Write_Number (JS, +"green", V.green);
+      Write_Number (JS, +"blue", V.blue);
+      Write_Number (JS, +"alpha", V.alpha);
+      JS.End_Object;
+   end Write_RGBA_Color;
 
    ----------------------------
    -- Write_ReferenceContext --

--- a/source/protocol/lsp-messages.adb
+++ b/source/protocol/lsp-messages.adb
@@ -311,6 +311,8 @@ package body LSP.Messages is
       JS.Start_Object;
       JS.Key ("diagnostics");
       Diagnostic_Vector'Read (S, V.diagnostics);
+      JS.Key ("only");
+      Optional_CodeActionKindSet'Read (S, V.only);
       JS.End_Object;
    end Read_CodeActionContext;
 
@@ -2736,6 +2738,8 @@ package body LSP.Messages is
       JS.Start_Object;
       JS.Key ("diagnostics");
       Diagnostic_Vector'Write (S, V.diagnostics);
+      JS.Key ("only");
+      Optional_CodeActionKindSet'Write (S, V.only);
       JS.End_Object;
    end Write_CodeActionContext;
 

--- a/source/protocol/lsp-messages.adb
+++ b/source/protocol/lsp-messages.adb
@@ -1715,7 +1715,7 @@ package body LSP.Messages is
       JS.Key ("completion");
       completion'Read (S, V.completion);
       JS.Key ("hover");
-      dynamicRegistration'Read (S, V.hover);
+      Optional_Hover_Capability'Read (S, V.hover);
       JS.Key ("signatureHelp");
       dynamicRegistration'Read (S, V.signatureHelp);
       JS.Key ("references");
@@ -2740,6 +2740,44 @@ package body LSP.Messages is
    end Write_Hover;
 
    ----------------------------
+   -- Write_Hover_Capability --
+   ----------------------------
+
+   procedure Write_Hover_Capability
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : Hover_Capability)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+   begin
+      JS.Start_Object;
+      Write_Optional_Boolean
+        (JS, +"dynamicRegistration", V.dynamicRegistration);
+      JS.Key ("contentFormat");
+      Optional_MarkupKind_Vector'Write (S, V.contentFormat);
+      JS.End_Object;
+   end Write_Hover_Capability;
+
+   ---------------------------
+   -- Read_Hover_Capability --
+   ---------------------------
+
+   procedure Read_Hover_Capability
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out Hover_Capability)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+   begin
+      JS.Start_Object;
+      Read_Optional_Boolean
+        (JS, +"dynamicRegistration", V.dynamicRegistration);
+      JS.Key ("contentFormat");
+      Optional_MarkupKind_Vector'Read (S, V.contentFormat);
+      JS.End_Object;
+   end Read_Hover_Capability;
+
+   ----------------------------
    -- Write_InitializeParams --
    ----------------------------
 
@@ -3575,7 +3613,7 @@ package body LSP.Messages is
       JS.Key ("completion");
       completion'Write (S, V.completion);
       JS.Key ("hover");
-      dynamicRegistration'Write (S, V.hover);
+      Optional_Hover_Capability'Write (S, V.hover);
       JS.Key ("signatureHelp");
       dynamicRegistration'Write (S, V.signatureHelp);
       JS.Key ("references");

--- a/source/protocol/lsp-messages.adb
+++ b/source/protocol/lsp-messages.adb
@@ -112,7 +112,8 @@ package body LSP.Messages is
       serverErrorEnd       => -32000,
       ServerNotInitialized => -32002,
       UnknownErrorCode     => -32001,
-      RequestCancelled     => -32800);
+      RequestCancelled     => -32800,
+      ContentModified      => -32801);
 
    Write_Reference_Image            : aliased constant Standard.String :=
                                         "write";

--- a/source/protocol/lsp-messages.adb
+++ b/source/protocol/lsp-messages.adb
@@ -1503,6 +1503,24 @@ package body LSP.Messages is
       JS.End_Object;
    end Read_RenameParams;
 
+   ----------------------------
+   -- Read_rename_Capability --
+   ----------------------------
+
+   procedure Read_rename_Capability
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out rename_Capability)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+   begin
+      JS.Start_Object;
+      Read_Optional_Boolean
+        (JS, +"dynamicRegistration", V.dynamicRegistration);
+      Read_Optional_Boolean (JS, +"prepareSupport", V.prepareSupport);
+      JS.End_Object;
+   end Read_rename_Capability;
+
    --------------------------------
    -- Read_ResourceOperationKind --
    --------------------------------
@@ -1895,7 +1913,7 @@ package body LSP.Messages is
       JS.Key ("colorProvider");
       dynamicRegistration'Read (S, V.colorProvider);
       JS.Key ("rename");
-      dynamicRegistration'Read (S, V.rename);
+      Optional_rename_Capability'Read (S, V.rename);
       JS.End_Object;
    end Read_TextDocumentClientCapabilities;
 
@@ -3569,6 +3587,24 @@ package body LSP.Messages is
       JS.End_Object;
    end Write_RenameParams;
 
+   -----------------------------
+   -- Write_rename_Capability --
+   -----------------------------
+
+   procedure Write_rename_Capability
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : rename_Capability)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+   begin
+      JS.Start_Object;
+      Write_Optional_Boolean
+        (JS, +"dynamicRegistration", V.dynamicRegistration);
+      Write_Optional_Boolean (JS, +"prepareSupport", V.prepareSupport);
+      JS.End_Object;
+   end Write_rename_Capability;
+
    ---------------------------------
    -- Write_ResourceOperationKind --
    ---------------------------------
@@ -3958,7 +3994,7 @@ package body LSP.Messages is
       JS.Key ("colorProvider");
       dynamicRegistration'Write (S, V.colorProvider);
       JS.Key ("rename");
-      dynamicRegistration'Write (S, V.rename);
+      Optional_rename_Capability'Write (S, V.rename);
       JS.End_Object;
    end Write_TextDocumentClientCapabilities;
 

--- a/source/protocol/lsp-messages.adb
+++ b/source/protocol/lsp-messages.adb
@@ -314,6 +314,37 @@ package body LSP.Messages is
       JS.End_Object;
    end Read_CodeActionContext;
 
+   -------------------------
+   -- Read_CodeActionKind --
+   -------------------------
+
+   procedure Read_CodeActionKind
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out CodeActionKind)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+      Text : constant Standard.String := JS.Read.Get;
+   begin
+      if Text = "quickfix" then
+         V := QuickFix;
+      elsif Text = "refactor" then
+         V := Refactor;
+      elsif Text = "refactor.extract" then
+         V := RefactorExtract;
+      elsif Text = "refactor.inline" then
+         V := RefactorInline;
+      elsif Text = "refactor.rewrite" then
+         V := RefactorRewrite;
+      elsif Text = "source" then
+         V := Source;
+      elsif Text = "source.organizeImports" then
+         V := SourceOrganizeImports;
+      else
+         V := Empty;
+      end if;
+   end Read_CodeActionKind;
+
    ---------------------------
    -- Read_CodeActionParams --
    ---------------------------
@@ -2281,6 +2312,49 @@ package body LSP.Messages is
       Diagnostic_Vector'Write (S, V.diagnostics);
       JS.End_Object;
    end Write_CodeActionContext;
+
+   --------------------------
+   -- Write_CodeActionKind --
+   --------------------------
+
+   procedure Write_CodeActionKind
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : CodeActionKind)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+
+      function Image (V : CodeActionKind) return GNATCOLL.JSON.UTF8_String;
+
+      -----------
+      -- Image --
+      -----------
+
+      function Image (V : CodeActionKind) return GNATCOLL.JSON.UTF8_String is
+      begin
+         case V is
+            when Empty =>
+               return "";
+            when QuickFix =>
+               return "quickfix";
+            when Refactor =>
+               return "refactor";
+            when RefactorExtract =>
+               return "refactor.extract";
+            when RefactorInline =>
+               return "refactor.inline";
+            when RefactorRewrite =>
+               return "refactor.rewrite";
+            when Source =>
+               return "source";
+            when SourceOrganizeImports =>
+               return "source.organizeImports";
+         end case;
+      end Image;
+
+   begin
+      JS.Write (GNATCOLL.JSON.Create (Image (V)));
+   end Write_CodeActionKind;
 
    ----------------------------
    -- Write_CodeActionParams --

--- a/source/protocol/lsp-messages.adb
+++ b/source/protocol/lsp-messages.adb
@@ -1250,6 +1250,22 @@ package body LSP.Messages is
       JS.End_Object;
    end Read_ParameterInformation;
 
+   ------------------------------------------
+   -- Read_parameterInformation_Capability --
+   ------------------------------------------
+
+   procedure Read_parameterInformation_Capability
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out parameterInformation_Capability)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+   begin
+      JS.Start_Object;
+      Read_Optional_Boolean (JS, +"labelOffsetSupport", V.labelOffsetSupport);
+      JS.End_Object;
+   end Read_parameterInformation_Capability;
+
    -------------------
    -- Read_Position --
    -------------------
@@ -1503,6 +1519,26 @@ package body LSP.Messages is
       JS.End_Object;
    end Read_ServerCapabilities;
 
+   -----------------------------------
+   -- Read_signatureHelp_Capability --
+   -----------------------------------
+
+   procedure Read_signatureHelp_Capability
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out signatureHelp_Capability)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+   begin
+      JS.Start_Object;
+      Read_Optional_Boolean
+        (JS, +"dynamicRegistration", V.dynamicRegistration);
+      JS.Key ("signatureInformation");
+      Optional_signatureInformation_Capability'Read
+        (S, V.signatureInformation);
+      JS.End_Object;
+   end Read_signatureHelp_Capability;
+
    -------------------------------
    -- Read_SignatureInformation --
    -------------------------------
@@ -1521,6 +1557,26 @@ package body LSP.Messages is
       ParameterInformation_Vector'Read (S, V.parameters);
       JS.End_Object;
    end Read_SignatureInformation;
+
+   ------------------------------------------
+   -- Read_signatureInformation_Capability --
+   ------------------------------------------
+
+   procedure Read_signatureInformation_Capability
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out signatureInformation_Capability)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+   begin
+      JS.Start_Object;
+      JS.Key ("documentationFormat");
+      Optional_MarkupKind_Vector'Read (S, V.documentationFormat);
+      JS.Key ("parameterInformation");
+      Optional_parameterInformation_Capability'Read
+        (S, V.parameterInformation);
+      JS.End_Object;
+   end Read_signatureInformation_Capability;
 
    ------------------------
    -- Read_SignatureHelp --
@@ -1717,7 +1773,7 @@ package body LSP.Messages is
       JS.Key ("hover");
       Optional_Hover_Capability'Read (S, V.hover);
       JS.Key ("signatureHelp");
-      dynamicRegistration'Read (S, V.signatureHelp);
+      Optional_signatureHelp_Capability'Read (S, V.signatureHelp);
       JS.Key ("references");
       dynamicRegistration'Read (S, V.references);
       JS.Key ("documentHighlight");
@@ -3161,6 +3217,22 @@ package body LSP.Messages is
       JS.End_Object;
    end Write_ParameterInformation;
 
+   -------------------------------------------
+   -- Write_parameterInformation_Capability --
+   -------------------------------------------
+
+   procedure Write_parameterInformation_Capability
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : parameterInformation_Capability)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+   begin
+      JS.Start_Object;
+      Write_Optional_Boolean (JS, +"labelOffsetSupport", V.labelOffsetSupport);
+      JS.End_Object;
+   end Write_parameterInformation_Capability;
+
    --------------------
    -- Write_Position --
    --------------------
@@ -3480,6 +3552,26 @@ package body LSP.Messages is
       JS.End_Object;
    end Write_SignatureHelpOptions;
 
+   ------------------------------------
+   -- Write_signatureHelp_Capability --
+   ------------------------------------
+
+   procedure Write_signatureHelp_Capability
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : signatureHelp_Capability)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+   begin
+      JS.Start_Object;
+      Write_Optional_Boolean
+        (JS, +"dynamicRegistration", V.dynamicRegistration);
+      JS.Key ("signatureInformation");
+      Optional_signatureInformation_Capability'Write
+        (S, V.signatureInformation);
+      JS.End_Object;
+   end Write_signatureHelp_Capability;
+
    --------------------------------
    -- Write_SignatureInformation --
    --------------------------------
@@ -3498,6 +3590,26 @@ package body LSP.Messages is
       ParameterInformation_Vector'Write (S, V.parameters);
       JS.End_Object;
    end Write_SignatureInformation;
+
+   -------------------------------------------
+   -- Write_signatureInformation_Capability --
+   -------------------------------------------
+
+   procedure Write_signatureInformation_Capability
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : signatureInformation_Capability)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+   begin
+      JS.Start_Object;
+      JS.Key ("documentationFormat");
+      Optional_MarkupKind_Vector'Write (S, V.documentationFormat);
+      JS.Key ("parameterInformation");
+      Optional_parameterInformation_Capability'Write
+        (S, V.parameterInformation);
+      JS.End_Object;
+   end Write_signatureInformation_Capability;
 
    ----------------
    -- Write_Span --
@@ -3615,7 +3727,7 @@ package body LSP.Messages is
       JS.Key ("hover");
       Optional_Hover_Capability'Write (S, V.hover);
       JS.Key ("signatureHelp");
-      dynamicRegistration'Write (S, V.signatureHelp);
+      Optional_signatureHelp_Capability'Write (S, V.signatureHelp);
       JS.Key ("references");
       dynamicRegistration'Write (S, V.references);
       JS.Key ("documentHighlight");

--- a/source/protocol/lsp-messages.ads
+++ b/source/protocol/lsp-messages.ads
@@ -1542,7 +1542,48 @@ package LSP.Messages is
    --			 * that is typing in one will update others too.
    --			 */
    --			snippetSupport?: boolean;
+   --
+   --			/**
+   --			 * The client supports commit characters on a completion item.
+   --			 */
+   --			commitCharactersSupport?: boolean
+   --
+   --			/**
+   --			 * The client supports the following content formats for the documentation
+   --			 * property. The order describes the preferred format of the client.
+   --			 */
+   --			documentationFormat?: MarkupKind[];
+   --
+   --			/**
+   --			 * The client supports the deprecated property on a completion item.
+   --			 */
+   --			deprecatedSupport?: boolean;
+   --
+   --			/**
+   --			 * The client supports the preselect property on a completion item.
+   --			 */
+   --			preselectSupport?: boolean;
    --		}
+   --
+   --		completionItemKind?: {
+   --			/**
+   --			 * The completion item kind values the client supports. When this
+   --			 * property exists the client also guarantees that it will
+   --			 * handle values outside its set gracefully and falls back
+   --			 * to a default value when unknown.
+   --			 *
+   --			 * If this property is not present the client only supports
+   --			 * the completion items kinds from `Text` to `Reference` as defined in
+   --			 * the initial version of the protocol.
+   --			 */
+   --			valueSet?: CompletionItemKind[];
+   --		},
+   --
+   --		/**
+   --		 * The client supports to send additional context information for a
+   --		 * `textDocument/completion` request.
+   --		 */
+   --		contextSupport?: boolean;
    --	};
    --
    --	/**
@@ -1727,9 +1768,85 @@ package LSP.Messages is
    for synchronization'Read use Read_synchronization;
    for synchronization'Write use Write_synchronization;
 
+   type completionItemCapability is record
+      snippetSupport : Optional_Boolean;
+      commitCharactersSupport : Optional_Boolean;
+      documentationFormat : MarkupKind_Vector;
+      deprecatedSupport : Optional_Boolean;
+      preselectSupport : Optional_Boolean;
+   end record;
+
+   procedure Read_completionItemCapability
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out completionItemCapability);
+
+   procedure Write_completionItemCapability
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : completionItemCapability);
+
+   for completionItemCapability'Read use Read_completionItemCapability;
+   for completionItemCapability'Write use Write_completionItemCapability;
+
+   package Optional_completionItemCapabilities is
+     new LSP.Generic_Optional (completionItemCapability);
+
+   type Optional_completionItemCapability is
+     new Optional_completionItemCapabilities.Optional_Type;
+
+   type CompletionItemKind is (
+      Text,
+      Method,
+      A_Function,
+      Constructor,
+      Field,
+      Variable,
+      Class,
+      An_Interface,
+      Module,
+      Property,
+      Unit,
+      Value,
+      Enum,
+      Keyword,
+      Snippet,
+      Color,
+      File,
+      Reference,
+      Folder,
+      EnumMember,
+      A_Constant,
+      Struct,
+      Event,
+      Operator,
+      TypeParameter);
+
+   procedure Read_CompletionItemKind
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out CompletionItemKind);
+   procedure Write_CompletionItemKind
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : CompletionItemKind);
+   for CompletionItemKind'Read use Read_CompletionItemKind;
+   for CompletionItemKind'Write use Write_CompletionItemKind;
+
+   package CompletionItemKindSets is new LSP.Generic_Sets (CompletionItemKind);
+
+   type CompletionItemKindSet is new CompletionItemKindSets.Set;
+
+   Default_CompletionItemKindSet : constant CompletionItemKindSet :=
+     To_Set (From => Text, To => Reference);
+
+   package Optional_CompletionItemKindSets is
+     new LSP.Generic_Optional (CompletionItemKindSet);
+
+   type Optional_CompletionItemKindSet is
+     new Optional_CompletionItemKindSets.Optional_Type;
+
    type completion is record
       dynamicRegistration : Optional_Boolean;
-      snippetSupport : Optional_Boolean;
+      completionItem : Optional_completionItemCapability;
+      completionItemKind : Optional_CompletionItemKindSet;
+      contextSupport : Optional_Boolean;
    end record;
 
    procedure Read_completion
@@ -3197,42 +3314,6 @@ package LSP.Messages is
 
    package Optional_InsertTextFormats is new LSP.Generic_Optional (InsertTextFormat);
    type Optional_InsertTextFormat is new Optional_InsertTextFormats.Optional_Type;
-
-   type CompletionItemKind is (
-      Text,
-      Method,
-      A_Function,
-      Constructor,
-      Field,
-      Variable,
-      Class,
-      An_Interface,
-      Module,
-      Property,
-      Unit,
-      Value,
-      Enum,
-      Keyword,
-      Snippet,
-      Color,
-      File,
-      Reference,
-      Folder,
-      EnumMember,
-      A_Constant,
-      Struct,
-      Event,
-      Operator,
-      TypeParameter);
-
-   procedure Read_CompletionItemKind
-     (S : access Ada.Streams.Root_Stream_Type'Class;
-      V : out CompletionItemKind);
-   procedure Write_CompletionItemKind
-     (S : access Ada.Streams.Root_Stream_Type'Class;
-      V : CompletionItemKind);
-   for CompletionItemKind'Read use Read_CompletionItemKind;
-   for CompletionItemKind'Write use Write_CompletionItemKind;
 
    package Optional_CompletionItemKinds is new LSP.Generic_Optional (CompletionItemKind);
    type Optional_CompletionItemKind is new Optional_CompletionItemKinds.Optional_Type;

--- a/source/protocol/lsp-messages.ads
+++ b/source/protocol/lsp-messages.ads
@@ -1523,6 +1523,30 @@ package LSP.Messages is
    for MarkupContent'Read use Read_MarkupContent;
    for MarkupContent'Write use Write_MarkupContent;
 
+   type String_Or_MarkupContent (Is_String : Boolean := False) is record
+      case Is_String is
+         when True =>
+            String : LSP_String;
+         when False =>
+            Content : MarkupContent;
+      end case;
+   end record;
+
+   procedure Read_String_Or_MarkupContent
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out String_Or_MarkupContent);
+   procedure Write_String_Or_MarkupContent
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : String_Or_MarkupContent);
+   for String_Or_MarkupContent'Read use Read_String_Or_MarkupContent;
+   for String_Or_MarkupContent'Write use Write_String_Or_MarkupContent;
+
+   package Optional_String_Or_MarkupContent_Package is
+     new LSP.Generic_Optional (String_Or_MarkupContent);
+
+   type Optional_String_Or_MarkupContent is
+     new Optional_String_Or_MarkupContent_Package.Optional_Type;
+
    --```typescript
    --/**
    -- * Text document specific client capabilities.
@@ -3930,7 +3954,8 @@ package LSP.Messages is
    --	/**
    --	 * A human-readable string that represents a doc-comment.
    --	 */
-   --	documentation?: string;
+   --	documentation?: string | MarkupContent;
+   --
    --	/**
    --	 * A string that should be used when comparing this item
    --	 * with other items. When `falsy` the label is used.
@@ -4059,7 +4084,7 @@ package LSP.Messages is
       label: LSP_String;
       kind: Optional_CompletionItemKind;
       detail: Optional_String;
-      documentation: Optional_String;
+      documentation: Optional_String_Or_MarkupContent;
       sortText: Optional_String;
       filterText: Optional_String;
       insertText: Optional_String;
@@ -4220,7 +4245,7 @@ package LSP.Messages is
    --	 * The human-readable doc-comment of this signature. Will be shown
    --	 * in the UI but can be omitted.
    --	 */
-   --	documentation?: string;
+   --	documentation?: string | MarkupContent;
    --
    --	/**
    --	 * The parameters of this signature.
@@ -4243,12 +4268,12 @@ package LSP.Messages is
    --	 * The human-readable doc-comment of this parameter. Will be shown
    --	 * in the UI but can be omitted.
    --	 */
-   --	documentation?: string;
+   --	documentation?: string | MarkupContent;
    --}
    --```
    type ParameterInformation is record
       label: LSP_String;
-      documentation: Optional_String;
+      documentation: Optional_String_Or_MarkupContent;
    end record;
 
    procedure Read_ParameterInformation
@@ -4267,7 +4292,7 @@ package LSP.Messages is
 
    type SignatureInformation is record
       label: LSP_String;
-      documentation: Optional_String;
+      documentation: Optional_String_Or_MarkupContent;
       parameters: ParameterInformation_Vector;
    end record;
 

--- a/source/protocol/lsp-messages.ads
+++ b/source/protocol/lsp-messages.ads
@@ -4292,11 +4292,18 @@ package LSP.Messages is
    -- * have a label and a doc-comment.
    -- */
    --interface ParameterInformation {
+   --
    --	/**
-   --	 * The label of this parameter. Will be shown in
-   --	 * the UI.
+   --	 * The label of this parameter information.
+   --	 *
+   --	 * Either a string or an inclusive start and exclusive end offsets within its containing
+   --	 * signature label. (see SignatureInformation.label). The offsets are based on a UTF-16
+   --	 * string representation as `Position` and `Range` does.
+   --	 *
+   --	 * *Note*: a label of type string should be a substring of its containing signature label.
+   --	 * Its intended use case is to highlight the parameter label part in the `SignatureInformation.label`.
    --	 */
-   --	label: string;
+   --	label: string | [number, number];
    --
    --	/**
    --	 * The human-readable doc-comment of this parameter. Will be shown
@@ -4305,8 +4312,26 @@ package LSP.Messages is
    --	documentation?: string | MarkupContent;
    --}
    --```
+   type Parameter_Label (Is_String : Boolean := True) is record
+      case Is_String is
+         when True =>
+            String : LSP_String;
+         when False =>
+            From, Till : UTF_16_Index;
+      end case;
+   end record;
+
+   procedure Read_Parameter_Label
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out Parameter_Label);
+   procedure Write_Parameter_Label
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : Parameter_Label);
+   for Parameter_Label'Read use Read_Parameter_Label;
+   for Parameter_Label'Write use Write_Parameter_Label;
+
    type ParameterInformation is record
-      label: LSP_String;
+      label: Parameter_Label;
       documentation: Optional_String_Or_MarkupContent;
    end record;
 

--- a/source/protocol/lsp-messages.ads
+++ b/source/protocol/lsp-messages.ads
@@ -342,8 +342,12 @@ package LSP.Messages is
 
    package CodeActionKindSets is
      new LSP.Generic_Sets (CodeActionKind);
-
    type CodeActionKindSet is new CodeActionKindSets.Set;
+
+   package Optional_CodeActionKindSets is
+     new LSP.Generic_Optional (CodeActionKindSet);
+   type Optional_CodeActionKindSet is
+     new Optional_CodeActionKindSets.Optional_Type;
 
    --  reference_kinds ALS extension:
    --
@@ -2533,6 +2537,19 @@ package LSP.Messages is
    --}
    --
    --/**
+   -- * Code Action options.
+   -- */
+   --export interface CodeActionOptions {
+   --	/**
+   --	 * CodeActionKinds that this server may return.
+   --	 *
+   --	 * The list of kinds may be generic, such as `CodeActionKind.Refactor`, or the server
+   --	 * may list out every specific kind they provide.
+   --	 */
+   --	codeActionKinds?: CodeActionKind[];
+   --}
+   --
+   --/**
    -- * Code Lens options.
    -- */
    --export interface CodeLensOptions {
@@ -2657,9 +2674,11 @@ package LSP.Messages is
    --	 */
    --	workspaceSymbolProvider?: boolean;
    --	/**
-   --	 * The server provides code actions.
+   --	 * The server provides code actions. The `CodeActionOptions` return type is only
+   --	 * valid if the client signals code action literal support via the property
+   --	 * `textDocument.codeAction.codeActionLiteralSupport`.
    --	 */
-   --	codeActionProvider?: boolean;
+   --	codeActionProvider?: boolean | CodeActionOptions;
    --	/**
    --	 * The server provides code lens.
    --	 */
@@ -2794,6 +2813,24 @@ package LSP.Messages is
    type Optional_SignatureHelpOptions is
      new Optional_SignatureHelpOptionss.Optional_Type;
 
+   type CodeActionOptions is record
+      codeActionKinds: Optional_CodeActionKindSet;
+   end record;
+
+   procedure Read_CodeActionOptions
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out CodeActionOptions);
+   procedure Write_CodeActionOptions
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : CodeActionOptions);
+   for CodeActionOptions'Write use Write_CodeActionOptions;
+   for CodeActionOptions'Read use Read_CodeActionOptions;
+
+   package Optional_CodeActionOptions_Package is
+     new LSP.Generic_Optional (CodeActionOptions);
+   type Optional_CodeActionOptions is
+     new Optional_CodeActionOptions_Package.Optional_Type;
+
    type CodeLensOptions is record
       resolveProvider: LSP.Types.Optional_Boolean;
    end record;
@@ -2875,7 +2912,7 @@ package LSP.Messages is
       documentHighlightProvider: Optional_Boolean;
       documentSymbolProvider: Optional_Boolean;
       workspaceSymbolProvider: Optional_Boolean;
-      codeActionProvider: Optional_Boolean;
+      codeActionProvider: Optional_CodeActionOptions;
       codeLensProvider: Optional_CodeLensOptions;
       documentFormattingProvider: Optional_Boolean;
       documentRangeFormattingProvider: Optional_Boolean;

--- a/source/protocol/lsp-messages.ads
+++ b/source/protocol/lsp-messages.ads
@@ -5725,6 +5725,75 @@ package LSP.Messages is
       This : CodeActionOptions;
    end record;
 
+   --```typescript
+   --interface ColorInformation {
+   --	/**
+   --	 * The range in the document where this color appears.
+   --	 */
+   --	range: Range;
+   --
+   --	/**
+   --	 * The actual color value for this color range.
+   --	 */
+   --	color: Color;
+   --}
+   --
+   --/**
+   -- * Represents a color in RGBA space.
+   -- */
+   --interface Color {
+   --
+   --	/**
+   --	 * The red component of this color in the range [0-1].
+   --	 */
+   --	readonly red: number;
+   --
+   --	/**
+   --	 * The green component of this color in the range [0-1].
+   --	 */
+   --	readonly green: number;
+   --
+   --	/**
+   --	 * The blue component of this color in the range [0-1].
+   --	 */
+   --	readonly blue: number;
+   --
+   --	/**
+   --	 * The alpha component of this color in the range [0-1].
+   --	 */
+   --	readonly alpha: number;
+   --}
+   --```
+   type RGBA_Color is record
+      red: LSP_Number;
+      green: LSP_Number;
+      blue: LSP_Number;
+      alpha: LSP_Number;
+   end record;
+
+   procedure Read_RGBA_Color
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out RGBA_Color);
+   procedure Write_RGBA_Color
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : RGBA_Color);
+   for RGBA_Color'Read use Read_RGBA_Color;
+   for RGBA_Color'Write use Write_RGBA_Color;
+
+   type ColorInformation is record
+      span: LSP.Messages.Span;  --  Range is reservet keyword
+      color: RGBA_Color;
+   end record;
+
+   procedure Read_ColorInformation
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out ColorInformation);
+   procedure Write_ColorInformation
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : ColorInformation);
+   for ColorInformation'Read use Read_ColorInformation;
+   for ColorInformation'Write use Write_ColorInformation;
+
    -----------------------------------------
    -- ALS-specific messages and responses --
    -----------------------------------------

--- a/source/protocol/lsp-messages.ads
+++ b/source/protocol/lsp-messages.ads
@@ -2806,6 +2806,13 @@ package LSP.Messages is
    --	export const Color = 16;
    --	export const File = 17;
    --	export const Reference = 18;
+   --	export const Folder = 19;
+   --	export const EnumMember = 20;
+   --	export const Constant = 21;
+   --	export const Struct = 22;
+   --	export const Event = 23;
+   --	export const Operator = 24;
+   --	export const TypeParameter = 25;
    --}
    --```
    type InsertTextFormat is (PlainText, Snippet);
@@ -2840,7 +2847,14 @@ package LSP.Messages is
       Snippet,
       Color,
       File,
-      Reference);
+      Reference,
+      Folder,
+      EnumMember,
+      A_Constant,
+      Struct,
+      Event,
+      Operator,
+      TypeParameter);
 
    procedure Read_CompletionItemKind
      (S : access Ada.Streams.Root_Stream_Type'Class;

--- a/source/protocol/lsp-messages.ads
+++ b/source/protocol/lsp-messages.ads
@@ -340,6 +340,11 @@ package LSP.Messages is
    for CodeActionKind'Read use Read_CodeActionKind;
    for CodeActionKind'Write use Write_CodeActionKind;
 
+   package CodeActionKindSets is
+     new LSP.Generic_Sets (CodeActionKind);
+
+   type CodeActionKindSet is new CodeActionKindSets.Set;
+
    --  reference_kinds ALS extension:
    --
    --  export type AlsReferenceKind = 'w' | 'c' | 'd';
@@ -1830,6 +1835,28 @@ package LSP.Messages is
    --		 * Whether code action supports dynamic registration.
    --		 */
    --		dynamicRegistration?: boolean;
+   --		/**
+   --		 * The client support code action literals as a valid
+   --		 * response of the `textDocument/codeAction` request.
+   --		 *
+   --		 * Since 3.8.0
+   --		 */
+   --		codeActionLiteralSupport?: {
+   --			/**
+   --			 * The code action kind is support with the following value
+   --			 * set.
+   --			 */
+   --			codeActionKind: {
+   --
+   --				/**
+   --				 * The code action kind values the client supports. When this
+   --				 * property exists the client also guarantees that it will
+   --				 * handle values outside its set gracefully and falls back
+   --				 * to a default value when unknown.
+   --				 */
+   --				valueSet: CodeActionKind[];
+   --			};
+   --		};
    --	};
    --
    --	/**
@@ -2115,6 +2142,49 @@ package LSP.Messages is
    subtype Optional_implementation_Capability is
      Optional_declaration_Capability;
 
+   type codeActionLiteralSupport_Capability is record
+      codeActionKind: CodeActionKindSet;
+   end record;
+
+   procedure Read_codeActionLiteralSupport_Capability
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out codeActionLiteralSupport_Capability);
+
+   procedure Write_codeActionLiteralSupport_Capability
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : codeActionLiteralSupport_Capability);
+
+   for codeActionLiteralSupport_Capability'Read use Read_codeActionLiteralSupport_Capability;
+   for codeActionLiteralSupport_Capability'Write use Write_codeActionLiteralSupport_Capability;
+
+   package Optional_codeActionLiteralSupport_Capabilities is
+     new LSP.Generic_Optional (codeActionLiteralSupport_Capability);
+
+   type Optional_codeActionLiteralSupport_Capability is
+     new Optional_codeActionLiteralSupport_Capabilities.Optional_Type;
+
+   type codeAction_Capability is record
+      dynamicRegistration: Optional_Boolean;
+      codeActionLiteralSupport: Optional_codeActionLiteralSupport_Capability;
+   end record;
+
+   procedure Read_codeAction_Capability
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out codeAction_Capability);
+
+   procedure Write_codeAction_Capability
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : codeAction_Capability);
+
+   for codeAction_Capability'Read use Read_codeAction_Capability;
+   for codeAction_Capability'Write use Write_codeAction_Capability;
+
+   package Optional_codeAction_Capabilities is
+     new LSP.Generic_Optional (codeAction_Capability);
+
+   type Optional_codeAction_Capability is
+     new Optional_codeAction_Capabilities.Optional_Type;
+
    type TextDocumentClientCapabilities is record
       synchronization   : LSP.Messages.synchronization;
       completion        : LSP.Messages.completion;
@@ -2130,7 +2200,7 @@ package LSP.Messages is
       definition        : Optional_definition_Capability;
       typeDefinition    : Optional_typeDefinition_Capability;
       implementation    : Optional_implementation_Capability;
-      codeAction        : dynamicRegistration;
+      codeAction        : Optional_codeAction_Capability;
       codeLens          : dynamicRegistration;
       documentLink      : dynamicRegistration;
       rename            : dynamicRegistration;

--- a/source/protocol/lsp-messages.ads
+++ b/source/protocol/lsp-messages.ads
@@ -573,13 +573,20 @@ package LSP.Messages is
    --```typescript
    --interface VersionedTextDocumentIdentifier extends TextDocumentIdentifier {
    --	/**
-   --	 * The version number of this document.
+   --	 * The version number of this document. If a versioned text document identifier
+   --	 * is sent from the server to the client and the file is not open in the editor
+   --	 * (the server has not received an open notification before) the server can send
+   --	 * `null` to indicate that the version is known and the content on disk is the
+   --	 * truth (as speced with document content ownership).
+   --	 *
+   --	 * The version number of a document will increase after each change, including
+   --	 * undo/redo. The number doesn't need to be consecutive.
    --	 */
-   --	version: number;
+   --	version: number | null;
    --}
    --```
    type VersionedTextDocumentIdentifier is new TextDocumentIdentifier with record
-      version: Version_Id;
+      version: Optional_Number;
    end record;
 
    procedure Read_VersionedTextDocumentIdentifier

--- a/source/protocol/lsp-messages.ads
+++ b/source/protocol/lsp-messages.ads
@@ -1902,6 +1902,12 @@ package LSP.Messages is
    --		 * Whether rename supports dynamic registration.
    --		 */
    --		dynamicRegistration?: boolean;
+   --		/**
+   --		 * The client supports testing for validity of rename operations
+   --		 * before execution.
+   --		 */
+   --		prepareSupport?: boolean;
+   --	};
    --	};
    --}
    --```
@@ -2200,6 +2206,28 @@ package LSP.Messages is
    type Optional_codeAction_Capability is
      new Optional_codeAction_Capabilities.Optional_Type;
 
+   type rename_Capability is record
+      dynamicRegistration: Optional_Boolean;
+      prepareSupport: Optional_Boolean;
+   end record;
+
+   procedure Read_rename_Capability
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out rename_Capability);
+
+   procedure Write_rename_Capability
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : rename_Capability);
+
+   for rename_Capability'Read use Read_rename_Capability;
+   for rename_Capability'Write use Write_rename_Capability;
+
+   package Optional_rename_Capabilities is
+     new LSP.Generic_Optional (rename_Capability);
+
+   type Optional_rename_Capability is
+     new Optional_rename_Capabilities.Optional_Type;
+
    type TextDocumentClientCapabilities is record
       synchronization   : LSP.Messages.synchronization;
       completion        : LSP.Messages.completion;
@@ -2219,7 +2247,7 @@ package LSP.Messages is
       codeLens          : dynamicRegistration;
       documentLink      : dynamicRegistration;
       colorProvider     : dynamicRegistration;
-      rename            : dynamicRegistration;
+      rename            : Optional_rename_Capability;
    end record;
 
    procedure Read_TextDocumentClientCapabilities

--- a/source/protocol/lsp-messages.ads
+++ b/source/protocol/lsp-messages.ads
@@ -424,6 +424,46 @@ package LSP.Messages is
    type Optional_DiagnosticSeverity is new Optional_DiagnosticSeveritys.Optional_Type;
 
    --```typescript
+   --/**
+   -- * Represents a related message and source code location for a diagnostic. This should be
+   -- * used to point to code locations that cause or related to a diagnostics, e.g when duplicating
+   -- * a symbol in a scope.
+   -- */
+   --export interface DiagnosticRelatedInformation {
+   --	/**
+   --	 * The location of this related diagnostic information.
+   --	 */
+   --	location: Location;
+   --
+   --	/**
+   --	 * The message of this related diagnostic information.
+   --	 */
+   --	message: string;
+   --}
+   --```
+   type DiagnosticRelatedInformation is record
+      location: LSP.Messages.Location;
+      message: LSP_String;
+   end record;
+
+   procedure Read_DiagnosticRelatedInformation
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out DiagnosticRelatedInformation);
+   for DiagnosticRelatedInformation'Read use Read_DiagnosticRelatedInformation;
+
+   procedure Write_DiagnosticRelatedInformation
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : DiagnosticRelatedInformation);
+   for DiagnosticRelatedInformation'Write
+     use Write_DiagnosticRelatedInformation;
+
+   package DiagnosticRelatedInformation_Vectors is new LSP.Generic_Vectors
+     (DiagnosticRelatedInformation);
+
+   type DiagnosticRelatedInformation_Vector is
+     new DiagnosticRelatedInformation_Vectors.Vector with null record;
+
+   --```typescript
    --interface Diagnostic {
    --	/**
    --	 * The range at which the message applies.
@@ -451,6 +491,12 @@ package LSP.Messages is
    --	 * The diagnostic's message.
    --	 */
    --	message: string;
+   --
+   --	/**
+   --	 * An array of related diagnostic information, e.g. when symbol-names within
+   --	 * a scope collide all definitions can be marked via this property.
+   --	 */
+   --	relatedInformation?: DiagnosticRelatedInformation[];
    --}
    --```
    type Diagnostic is record
@@ -459,6 +505,7 @@ package LSP.Messages is
       code: LSP_Number_Or_String;
       source: Optional_String;
       message: LSP_String;
+      relatedInformation: DiagnosticRelatedInformation_Vector;
    end record;
 
    procedure Read_Diagnostic

--- a/source/protocol/lsp-messages.ads
+++ b/source/protocol/lsp-messages.ads
@@ -1908,6 +1908,16 @@ package LSP.Messages is
    --		 */
    --		prepareSupport?: boolean;
    --	};
+   --
+   --	/**
+   --	 * Capabilities specific to `textDocument/publishDiagnostics`.
+   --	 */
+   --	publishDiagnostics?: {
+   --		/**
+   --		 * Whether the clients accepts diagnostics with related information.
+   --		 */
+   --		relatedInformation?: boolean;
+   --	};
    --	};
    --}
    --```
@@ -2228,26 +2238,48 @@ package LSP.Messages is
    type Optional_rename_Capability is
      new Optional_rename_Capabilities.Optional_Type;
 
+   type publishDiagnostics_Capability is record
+      relatedInformation: Optional_Boolean;
+   end record;
+
+   procedure Read_publishDiagnostics_Capability
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out publishDiagnostics_Capability);
+
+   procedure Write_publishDiagnostics_Capability
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : publishDiagnostics_Capability);
+
+   for publishDiagnostics_Capability'Read use Read_publishDiagnostics_Capability;
+   for publishDiagnostics_Capability'Write use Write_publishDiagnostics_Capability;
+
+   package Optional_publishDiagnostics_Capabilities is
+     new LSP.Generic_Optional (publishDiagnostics_Capability);
+
+   type Optional_publishDiagnostics_Capability is
+     new Optional_publishDiagnostics_Capabilities.Optional_Type;
+
    type TextDocumentClientCapabilities is record
-      synchronization   : LSP.Messages.synchronization;
-      completion        : LSP.Messages.completion;
-      hover             : Optional_Hover_Capability;
-      signatureHelp     : Optional_signatureHelp_Capability;
-      references        : dynamicRegistration;
-      documentHighlight : dynamicRegistration;
-      documentSymbol    : Optional_Document_Symbol_Capability;
-      formatting        : dynamicRegistration;
-      rangeFormatting   : dynamicRegistration;
-      onTypeFormatting  : dynamicRegistration;
-      declaration       : Optional_declaration_Capability;
-      definition        : Optional_definition_Capability;
-      typeDefinition    : Optional_typeDefinition_Capability;
-      implementation    : Optional_implementation_Capability;
-      codeAction        : Optional_codeAction_Capability;
-      codeLens          : dynamicRegistration;
-      documentLink      : dynamicRegistration;
-      colorProvider     : dynamicRegistration;
-      rename            : Optional_rename_Capability;
+      synchronization    : LSP.Messages.synchronization;
+      completion         : LSP.Messages.completion;
+      hover              : Optional_Hover_Capability;
+      signatureHelp      : Optional_signatureHelp_Capability;
+      references         : dynamicRegistration;
+      documentHighlight  : dynamicRegistration;
+      documentSymbol     : Optional_Document_Symbol_Capability;
+      formatting         : dynamicRegistration;
+      rangeFormatting    : dynamicRegistration;
+      onTypeFormatting   : dynamicRegistration;
+      declaration        : Optional_declaration_Capability;
+      definition         : Optional_definition_Capability;
+      typeDefinition     : Optional_typeDefinition_Capability;
+      implementation     : Optional_implementation_Capability;
+      codeAction         : Optional_codeAction_Capability;
+      codeLens           : dynamicRegistration;
+      documentLink       : dynamicRegistration;
+      colorProvider      : dynamicRegistration;
+      rename             : Optional_rename_Capability;
+      publishDiagnostics : Optional_publishDiagnostics_Capability;
    end record;
 
    procedure Read_TextDocumentClientCapabilities

--- a/source/protocol/lsp-messages.ads
+++ b/source/protocol/lsp-messages.ads
@@ -388,6 +388,84 @@ package LSP.Messages is
 
    type Location_Vector is new Location_Vectors.Vector with null record;
 
+   --```typescript
+   --interface LocationLink {
+   --
+   --	/**
+   --	 * Span of the origin of this link.
+   --	 *
+   --	 * Used as the underlined span for mouse interaction. Defaults to the word range at
+   --	 * the mouse position.
+   --	 */
+   --	originSelectionRange?: Range;
+   --
+   --	/**
+   --	 * The target resource identifier of this link.
+   --	 */
+   --	targetUri: DocumentUri;
+   --
+   --	/**
+   --	 * The full target range of this link. If the target for example is a symbol then target range is the
+   --	 * range enclosing this symbol not including leading/trailing whitespace but everything else
+   --	 * like comments. This information is typically used to highlight the range in the editor.
+   --	 */
+   --	targetRange: Range;
+   --
+   --	/**
+   --	 * The range that should be selected and revealed when this link is being followed, e.g the name of a function.
+   --	 * Must be contained by the the `targetRange`. See also `DocumentSymbol#range`
+   --	 */
+   --	targetSelectionRange: Range;
+   --}
+   --```
+   type LocationLink is record
+      originSelectionRange : Optional_Span;
+      targetUri            : LSP_String;
+      targetRange          : Span;
+      targetSelectionRange : Span;
+      alsKind              : AlsReferenceKind_Set := Empty_Set;
+   end record;
+
+   procedure Read_LocationLink
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out LocationLink);
+   procedure Write_LocationLink
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : LocationLink);
+   for LocationLink'Read use Read_LocationLink;
+   for LocationLink'Write use Write_LocationLink;
+
+   package LocationLink_Vectors is new LSP.Generic_Vectors (LocationLink);
+
+   type LocationLink_Vector is new LocationLink_Vectors.Vector with null record;
+
+   type Location_Or_Link_Kind is
+     (Empty_Vector_Kind,
+      Location_Vector_Kind,
+      LocationLink_Vector_Kind);
+
+   type Location_Or_Link_Vector
+     (Kind : Location_Or_Link_Kind := Empty_Vector_Kind) is
+   record
+      case Kind is
+         when Empty_Vector_Kind =>
+            null;
+         when Location_Vector_Kind =>
+            Locations : Location_Vector;
+         when LocationLink_Vector_Kind =>
+            LocationLinks : LocationLink_Vector;
+      end case;
+   end record;
+
+   procedure Read_Location_Or_Link_Vector
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out Location_Or_Link_Vector);
+   procedure Write_Location_Or_Link_Vector
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : Location_Or_Link_Vector);
+   for Location_Or_Link_Vector'Read use Read_Location_Or_Link_Vector;
+   for Location_Or_Link_Vector'Write use Write_Location_Or_Link_Vector;
+
    --
    --```typescript
    --namespace DiagnosticSeverity {

--- a/source/protocol/lsp-messages.ads
+++ b/source/protocol/lsp-messages.ads
@@ -1880,6 +1880,21 @@ package LSP.Messages is
    --	};
    --
    --	/**
+   --	 * Capabilities specific to the `textDocument/documentColor` and the
+   --	 * `textDocument/colorPresentation` request.
+   --	 *
+   --	 * Since 3.6.0
+   --	 */
+   --	colorProvider?: {
+   --		/**
+   --		 * Whether colorProvider supports dynamic registration. If this is set to `true`
+   --		 * the client supports the new `(ColorProviderOptions & TextDocumentRegistrationOptions & StaticRegistrationOptions)`
+   --		 * return value for the corresponding server capability as well.
+   --		 */
+   --		dynamicRegistration?: boolean;
+   --	}
+   --
+   --	/**
    --	 * Capabilities specific to the `textDocument/rename`
    --	 */
    --	rename?: {
@@ -2203,6 +2218,7 @@ package LSP.Messages is
       codeAction        : Optional_codeAction_Capability;
       codeLens          : dynamicRegistration;
       documentLink      : dynamicRegistration;
+      colorProvider     : dynamicRegistration;
       rename            : dynamicRegistration;
    end record;
 

--- a/source/protocol/lsp-messages.ads
+++ b/source/protocol/lsp-messages.ads
@@ -1616,6 +1616,29 @@ package LSP.Messages is
    --		 * Whether signature help supports dynamic registration.
    --		 */
    --		dynamicRegistration?: boolean;
+   --
+   --		/**
+   --		 * The client supports the following `SignatureInformation`
+   --		 * specific properties.
+   --		 */
+   --		signatureInformation?: {
+   --			/**
+   --			 * The client supports the follow content formats for the documentation
+   --			 * property. The order describes the preferred format of the client.
+   --			 */
+   --			documentationFormat?: MarkupKind[];
+   --
+   --			/**
+   --			 * Client capabilities specific to parameter information.
+   --			 */
+   --			parameterInformation?: {
+   --				/**
+   --				 * The client supports processing label offsets instead of a
+   --				 * simple label string.
+   --				 */
+   --				labelOffsetSupport?: boolean;
+   --			}
+   --		};
    --	};
    --
    --	/**
@@ -1894,6 +1917,75 @@ package LSP.Messages is
    type Optional_Hover_Capability is
      new Optional_Hover_Capabilities.Optional_Type;
 
+   type parameterInformation_Capability is record
+      labelOffsetSupport: Optional_Boolean;
+   end record;
+
+   procedure Read_parameterInformation_Capability
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out parameterInformation_Capability);
+
+   procedure Write_parameterInformation_Capability
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : parameterInformation_Capability);
+
+   for parameterInformation_Capability'Read
+     use Read_parameterInformation_Capability;
+   for parameterInformation_Capability'Write
+     use Write_parameterInformation_Capability;
+
+   package Optional_parameterInformation_Capabilities is
+     new LSP.Generic_Optional (parameterInformation_Capability);
+
+   type Optional_parameterInformation_Capability is
+     new Optional_parameterInformation_Capabilities.Optional_Type;
+
+   type signatureInformation_Capability is record
+      documentationFormat: Optional_MarkupKind_Vector;
+      parameterInformation: Optional_parameterInformation_Capability;
+   end record;
+
+   procedure Read_signatureInformation_Capability
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out signatureInformation_Capability);
+
+   procedure Write_signatureInformation_Capability
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : signatureInformation_Capability);
+
+   for signatureInformation_Capability'Read
+     use Read_signatureInformation_Capability;
+   for signatureInformation_Capability'Write
+     use Write_signatureInformation_Capability;
+
+   package Optional_signatureInformation_Capabilities is
+     new LSP.Generic_Optional (signatureInformation_Capability);
+
+   type Optional_signatureInformation_Capability is
+     new Optional_signatureInformation_Capabilities.Optional_Type;
+
+   type signatureHelp_Capability is record
+      dynamicRegistration: Optional_Boolean;
+      signatureInformation: Optional_signatureInformation_Capability;
+   end record;
+
+   procedure Read_signatureHelp_Capability
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out signatureHelp_Capability);
+
+   procedure Write_signatureHelp_Capability
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : signatureHelp_Capability);
+
+   for signatureHelp_Capability'Read use Read_signatureHelp_Capability;
+   for signatureHelp_Capability'Write use Write_signatureHelp_Capability;
+
+   package Optional_signatureHelp_Capabilities is
+     new LSP.Generic_Optional (signatureHelp_Capability);
+
+   type Optional_signatureHelp_Capability is
+     new Optional_signatureHelp_Capabilities.Optional_Type;
+
    type Document_Symbol_Capability is record
       dynamicRegistration: Optional_Boolean;
       symbolKind: Optional_SymbolKindSet;
@@ -1921,7 +2013,7 @@ package LSP.Messages is
       synchronization   : LSP.Messages.synchronization;
       completion        : LSP.Messages.completion;
       hover             : Optional_Hover_Capability;
-      signatureHelp     : dynamicRegistration;
+      signatureHelp     : Optional_signatureHelp_Capability;
       references        : dynamicRegistration;
       documentHighlight : dynamicRegistration;
       documentSymbol    : Optional_Document_Symbol_Capability;

--- a/source/protocol/lsp-messages.ads
+++ b/source/protocol/lsp-messages.ads
@@ -3252,6 +3252,38 @@ package LSP.Messages is
 
    --```typescript
    --/**
+   -- * A symbol kind.
+   -- */
+   --export namespace SymbolKind {
+   --	export const File = 1;
+   --	export const Module = 2;
+   --	export const Namespace = 3;
+   --	export const Package = 4;
+   --	export const Class = 5;
+   --	export const Method = 6;
+   --	export const Property = 7;
+   --	export const Field = 8;
+   --	export const Constructor = 9;
+   --	export const Enum = 10;
+   --	export const Interface = 11;
+   --	export const Function = 12;
+   --	export const Variable = 13;
+   --	export const Constant = 14;
+   --	export const String = 15;
+   --	export const Number = 16;
+   --	export const Boolean = 17;
+   --	export const Array = 18;
+   --	export const Object = 19;
+   --	export const Key = 20;
+   --	export const Null = 21;
+   --	export const EnumMember = 22;
+   --	export const Struct = 23;
+   --	export const Event = 24;
+   --	export const Operator = 25;
+   --	export const TypeParameter = 26;
+   --}
+   --
+   --/**
    -- * Represents information about programming constructs like variables, classes,
    -- * interfaces etc.
    -- */
@@ -3281,36 +3313,13 @@ package LSP.Messages is
    --
    --	/**
    --	 * The name of the symbol containing this symbol. This information is for
-   --	 * user interface purposes (e.g. to render a qaulifier in the user interface
+   --	 * user interface purposes (e.g. to render a qualifier in the user interface
    --	 * if necessary). It can't be used to re-infer a hierarchy for the document
    --	 * symbols.
    --	 */
    --	containerName?: string;
    --}
    --
-   --/**
-   -- * A symbol kind.
-   -- */
-   --export namespace SymbolKind {
-   --	export const File = 1;
-   --	export const Module = 2;
-   --	export const Namespace = 3;
-   --	export const Package = 4;
-   --	export const Class = 5;
-   --	export const Method = 6;
-   --	export const Property = 7;
-   --	export const Field = 8;
-   --	export const Constructor = 9;
-   --	export const Enum = 10;
-   --	export const Interface = 11;
-   --	export const Function = 12;
-   --	export const Variable = 13;
-   --	export const Constant = 14;
-   --	export const String = 15;
-   --	export const Number = 16;
-   --	export const Boolean = 17;
-   --	export const Array = 18;
-   --}
    --```
    type SymbolKind is
      (File,
@@ -3330,7 +3339,15 @@ package LSP.Messages is
       String,
       Number,
       A_Boolean,
-      An_Array);
+      An_Array,
+      Object,
+      Key,
+      A_Null,
+      EnumMember,
+      Struct,
+      Event,
+      Operator,
+      TypeParameter);
 
    type SymbolInformation is record
       name: LSP_String;

--- a/source/protocol/lsp-messages.ads
+++ b/source/protocol/lsp-messages.ads
@@ -4953,11 +4953,17 @@ package LSP.Messages is
    --	 * The uri this link points to. If missing a resolve request is sent later.
    --	 */
    --	target?: DocumentUri;
+   --	/**
+   --	 * A data entry field that is preserved on a document link between a
+   --	 * DocumentLinkRequest and a DocumentLinkResolveRequest.
+   --	 */
+   --	data?: any;
    --}
    --```
    type DocumentLink is record
       span: LSP.Messages.Span;
       target: DocumentUri;  --  Optional ???
+      --  data?: any
    end record;
 
    --```typescript
@@ -5123,12 +5129,20 @@ package LSP.Messages is
    --```typescript
    --export interface ApplyWorkspaceEditParams {
    --	/**
+   --	 * An optional label of the workspace edit. This label is
+   --	 * presented in the user interface for example on an undo
+   --	 * stack to undo the workspace edit.
+   --	 */
+   --	label?: string;
+   --
+   --	/**
    --	 * The edits to apply.
    --	 */
    --	edit: WorkspaceEdit;
    --}
    --```
    type ApplyWorkspaceEditParams is record
+      label: Optional_String;
       edit: WorkspaceEdit;
    end record;
 
@@ -5138,10 +5152,19 @@ package LSP.Messages is
    --	 * Indicates whether the edit was applied or not.
    --	 */
    --	applied: boolean;
+   --
+   --	/**
+   --	 * An optional textual description for why the edit was not applied.
+   --	 * This may be used may be used by the server for diagnostic
+   --	 * logging or to provide a suitable error for a request that
+   --	 * triggered the edit.
+   --	 */
+   --	failureReason?: string;
    --}
    --```
    type ApplyWorkspaceEditResult is record
       applied: Boolean;
+      failureReason: Optional_String;
    end record;
 
    procedure Read_ApplyWorkspaceEditResult

--- a/source/protocol/lsp-messages.ads
+++ b/source/protocol/lsp-messages.ads
@@ -2575,7 +2575,17 @@ package LSP.Messages is
    --}
    --
    --/**
-   -- * Document link options
+   -- * Rename options
+   -- */
+   --export interface RenameOptions {
+   --	/**
+   --	 * Renames should be checked and tested before being executed.
+   --	 */
+   --	prepareProvider?: boolean;
+   --}
+   --
+   --/**
+   -- * Document link options.
    -- */
    --export interface DocumentLinkOptions {
    --	/**
@@ -2696,9 +2706,11 @@ package LSP.Messages is
    --	 */
    --	documentOnTypeFormattingProvider?: DocumentOnTypeFormattingOptions;
    --	/**
-   --	 * The server provides rename support.
+   --	 * The server provides rename support. RenameOptions may only be
+   --	 * specified if the client states that it supports
+   --	 * `prepareSupport` in its initial `initialize` request.
    --	 */
-   --	renameProvider?: boolean;
+   --	renameProvider?: boolean | RenameOptions;
    --	/**
    --	 * The server provides document link support.
    --	 */
@@ -2785,11 +2797,11 @@ package LSP.Messages is
       V : CompletionOptions);
    for CompletionOptions'Write use Write_CompletionOptions;
 
-   package Optional_CompletionOptionss is
+   package Optional_Completion_Package is
      new LSP.Generic_Optional (CompletionOptions);
 
    type Optional_CompletionOptions is
-     new Optional_CompletionOptionss.Optional_Type;
+     new Optional_Completion_Package.Optional_Type;
 
    type SignatureHelpOptions is record
       triggerCharacters: LSP.Types.LSP_String_Vector;
@@ -2807,11 +2819,11 @@ package LSP.Messages is
 
    for SignatureHelpOptions'Write use Write_SignatureHelpOptions;
 
-   package Optional_SignatureHelpOptionss is
+   package Optional_SignatureHelp_Package is
      new LSP.Generic_Optional (SignatureHelpOptions);
 
    type Optional_SignatureHelpOptions is
-     new Optional_SignatureHelpOptionss.Optional_Type;
+     new Optional_SignatureHelp_Package.Optional_Type;
 
    type CodeActionOptions is record
       codeActionKinds: Optional_CodeActionKindSet;
@@ -2844,11 +2856,11 @@ package LSP.Messages is
    for CodeLensOptions'Read use Read_CodeLensOptions;
    for CodeLensOptions'Write use Write_CodeLensOptions;
 
-   package Optional_CodeLensOptionss is
+   package Optional_CodeLens_Package is
      new LSP.Generic_Optional (CodeLensOptions);
 
    type Optional_CodeLensOptions is
-     new Optional_CodeLensOptionss.Optional_Type;
+     new Optional_CodeLens_Package.Optional_Type;
 
    type DocumentOnTypeFormattingOptions is record
       firstTriggerCharacter: LSP.Types.LSP_String;
@@ -2867,11 +2879,29 @@ package LSP.Messages is
 
    for DocumentOnTypeFormattingOptions'Write use Write_DocumentOnTypeFormattingOptions;
 
-   package Optional_DocumentOnTypeFormattingOptionss is
+   package Optional_DocumentOnTypeFormatting_Package is
      new LSP.Generic_Optional (DocumentOnTypeFormattingOptions);
 
    type Optional_DocumentOnTypeFormattingOptions is
-     new Optional_DocumentOnTypeFormattingOptionss.Optional_Type;
+     new Optional_DocumentOnTypeFormatting_Package.Optional_Type;
+
+   type RenameOptions is record
+      prepareProvider: LSP.Types.Optional_Boolean;
+   end record;
+
+   procedure Read_RenameOptions
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out RenameOptions);
+
+   procedure Write_RenameOptions
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : RenameOptions);
+
+   for RenameOptions'Write use Write_RenameOptions;
+   for RenameOptions'Read use Read_RenameOptions;
+
+   package Optional_Rename_Package is new LSP.Generic_Optional (RenameOptions);
+   type Optional_RenameOptions is new Optional_Rename_Package.Optional_Type;
 
    type DocumentLinkOptions is record
       resolveProvider: LSP.Types.Optional_Boolean;
@@ -2917,7 +2947,7 @@ package LSP.Messages is
       documentFormattingProvider: Optional_Boolean;
       documentRangeFormattingProvider: Optional_Boolean;
       documentOnTypeFormattingProvider: Optional_DocumentOnTypeFormattingOptions;
-      renameProvider: Optional_Boolean;
+      renameProvider: Optional_RenameOptions;
       documentLinkProvider: DocumentLinkOptions;
       executeCommandProvider: ExecuteCommandOptions;
       --	experimental?: any;

--- a/source/protocol/lsp-messages.ads
+++ b/source/protocol/lsp-messages.ads
@@ -5715,6 +5715,16 @@ package LSP.Messages is
    --  CodeAction_Vector represents a sequence of CodeAction OR Command.
    --  Command is represented as CodeAction with just `command` property set.
 
+   --```typescript
+   --export interface CodeActionRegistrationOptions extends TextDocumentRegistrationOptions, CodeActionOptions {
+   --}
+   --```
+   type CodeActionRegistrationOptions is
+     new TextDocumentRegistrationOptions with
+   record
+      This : CodeActionOptions;
+   end record;
+
    -----------------------------------------
    -- ALS-specific messages and responses --
    -----------------------------------------

--- a/source/protocol/lsp-messages.ads
+++ b/source/protocol/lsp-messages.ads
@@ -1474,6 +1474,12 @@ package LSP.Messages is
    package MarkupKind_Vectors is new LSP.Generic_Vectors (MarkupKind);
    type MarkupKind_Vector is new MarkupKind_Vectors.Vector with null record;
 
+   package Optional_MarkupKind_Vectors is
+     new LSP.Generic_Optional (MarkupKind_Vector);
+
+   type Optional_MarkupKind_Vector is
+     new Optional_MarkupKind_Vectors.Optional_Type;
+
    type MarkupContent is record
       kind  : MarkupKind;
       value : LSP_String;
@@ -1594,6 +1600,12 @@ package LSP.Messages is
    --		 * Whether hover supports dynamic registration.
    --		 */
    --		dynamicRegistration?: boolean;
+   --
+   --		/**
+   --		 * The client supports the follow content formats for the content
+   --		 * property. The order describes the preferred format of the client.
+   --		 */
+   --		contentFormat?: MarkupKind[];
    --	};
    --
    --	/**
@@ -1860,6 +1872,28 @@ package LSP.Messages is
    for completion'Read use Read_completion;
    for completion'Write use Write_completion;
 
+   type Hover_Capability is record
+      dynamicRegistration: Optional_Boolean;
+      contentFormat: Optional_MarkupKind_Vector;
+   end record;
+
+   procedure Read_Hover_Capability
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out Hover_Capability);
+
+   procedure Write_Hover_Capability
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : Hover_Capability);
+
+   for Hover_Capability'Read use Read_Hover_Capability;
+   for Hover_Capability'Write use Write_Hover_Capability;
+
+   package Optional_Hover_Capabilities is
+     new LSP.Generic_Optional (Hover_Capability);
+
+   type Optional_Hover_Capability is
+     new Optional_Hover_Capabilities.Optional_Type;
+
    type Document_Symbol_Capability is record
       dynamicRegistration: Optional_Boolean;
       symbolKind: Optional_SymbolKindSet;
@@ -1886,7 +1920,7 @@ package LSP.Messages is
    type TextDocumentClientCapabilities is record
       synchronization   : LSP.Messages.synchronization;
       completion        : LSP.Messages.completion;
-      hover             : dynamicRegistration;
+      hover             : Optional_Hover_Capability;
       signatureHelp     : dynamicRegistration;
       references        : dynamicRegistration;
       documentHighlight : dynamicRegistration;

--- a/source/protocol/lsp-messages.ads
+++ b/source/protocol/lsp-messages.ads
@@ -3957,6 +3957,20 @@ package LSP.Messages is
    --	documentation?: string | MarkupContent;
    --
    --	/**
+   --	 * Indicates if this item is deprecated.
+   --	 */
+   --	deprecated?: boolean;
+   --
+   --	/**
+   --	 * Select this item when showing.
+   --	 *
+   --	 * *Note* that only one completion item can be selected and that the
+   --	 * tool / client decides which item that is. The rule is that the *first*
+   --	 * item of those that match best is selected.
+   --	 */
+   --	preselect?: boolean;
+   --
+   --	/**
    --	 * A string that should be used when comparing this item
    --	 * with other items. When `falsy` the label is used.
    --	 */
@@ -4085,6 +4099,8 @@ package LSP.Messages is
       kind: Optional_CompletionItemKind;
       detail: Optional_String;
       documentation: Optional_String_Or_MarkupContent;
+      deprecated: Optional_Boolean;
+      preselect: Optional_Boolean;
       sortText: Optional_String;
       filterText: Optional_String;
       insertText: Optional_String;

--- a/source/protocol/lsp-messages.ads
+++ b/source/protocol/lsp-messages.ads
@@ -132,6 +132,7 @@ package LSP.Messages is
    --
    --	// Defined by the protocol.
    --	export const RequestCancelled: number = -32800;
+   --	export const ContentModified: number = -32801;
    --}
    --```
    type ErrorCodes is
@@ -144,7 +145,8 @@ package LSP.Messages is
       serverErrorEnd,
       ServerNotInitialized,
       UnknownErrorCode,
-      RequestCancelled);
+      RequestCancelled,
+      ContentModified);
 
    type ResponseError is record
       code: ErrorCodes;

--- a/source/protocol/lsp-messages.ads
+++ b/source/protocol/lsp-messages.ads
@@ -1094,6 +1094,20 @@ package LSP.Messages is
    --		 */
    --		dynamicRegistration?: boolean;
    --	};
+   --
+   --	/**
+   --	 * The client has support for workspace folders.
+   --	 *
+   --	 * Since 3.6.0
+   --	 */
+   --	workspaceFolders?: boolean;
+   --
+   --	/**
+   --	 * The client supports `workspace/configuration` requests.
+   --	 *
+   --	 * Since 3.6.0
+   --	 */
+   --	configuration?: boolean;
    --}
    --```
 
@@ -1152,6 +1166,8 @@ package LSP.Messages is
       didChangeWatchedFiles: dynamicRegistration;
       symbol: dynamicRegistration;
       executeCommand: dynamicRegistration;
+      workspaceFolders: Optional_Boolean;
+      configuration: Optional_Boolean;
    end record;
 
    procedure Read_WorkspaceClientCapabilities

--- a/source/protocol/lsp-messages.ads
+++ b/source/protocol/lsp-messages.ads
@@ -5248,7 +5248,6 @@ package LSP.Messages is
    --	 */
    --	percentage?: number;
    --}
-   --```
    type WorkDoneProgressBegin is record
       kind        : LSP_String := LSP.Types.To_LSP_String ("begin");
       title       : LSP_String;
@@ -5372,6 +5371,56 @@ package LSP.Messages is
      (S : access Ada.Streams.Root_Stream_Type'Class;
       V : Progress_Params);
    for Progress_Params'Write use Write_Progress_Params;
+
+   --```typescript
+   --export interface DidChangeWorkspaceFoldersParams {
+   --	/**
+   --	 * The actual workspace folder change event.
+   --	 */
+   --	event: WorkspaceFoldersChangeEvent;
+   --}
+   --
+   --/**
+   -- * The workspace folder change event.
+   -- */
+   --export interface WorkspaceFoldersChangeEvent {
+   --	/**
+   --	 * The array of added workspace folders
+   --	 */
+   --	added: WorkspaceFolder[];
+   --
+   --	/**
+   --	 * The array of the removed workspace folders
+   --	 */
+   --	removed: WorkspaceFolder[];
+   --}
+   --```
+   type WorkspaceFoldersChangeEvent is record
+      added: WorkspaceFolder_Vector;
+      removed: WorkspaceFolder_Vector;
+   end record;
+
+   procedure Read_WorkspaceFoldersChangeEvent
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out WorkspaceFoldersChangeEvent);
+   procedure Write_WorkspaceFoldersChangeEvent
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : WorkspaceFoldersChangeEvent);
+   for WorkspaceFoldersChangeEvent'Read use Read_WorkspaceFoldersChangeEvent;
+   for WorkspaceFoldersChangeEvent'Write use Write_WorkspaceFoldersChangeEvent;
+
+   type DidChangeWorkspaceFoldersParams is record
+      event: WorkspaceFoldersChangeEvent;
+   end record;
+
+   procedure Read_DidChangeWorkspaceFoldersParams
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out DidChangeWorkspaceFoldersParams);
+   procedure Write_DidChangeWorkspaceFoldersParams
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : DidChangeWorkspaceFoldersParams);
+   for DidChangeWorkspaceFoldersParams'Read use Read_DidChangeWorkspaceFoldersParams;
+   for DidChangeWorkspaceFoldersParams'Write use Write_DidChangeWorkspaceFoldersParams;
 
    -----------------------------------------
    -- ALS-specific messages and responses --

--- a/source/protocol/lsp-messages.ads
+++ b/source/protocol/lsp-messages.ads
@@ -5176,9 +5176,6 @@ package LSP.Messages is
    for ApplyWorkspaceEditResult'Read use Read_ApplyWorkspaceEditResult;
    for ApplyWorkspaceEditResult'Write use Write_ApplyWorkspaceEditResult;
 
-   subtype CompletionParams is TextDocumentPositionParams;
-   --  ??? this is not in sync with protocol v3
-
    ----------------------
    -- Present in v3.15 --
    ----------------------
@@ -5563,6 +5560,90 @@ package LSP.Messages is
       V : DidChangeWatchedFilesRegistrationOptions);
    for DidChangeWatchedFilesRegistrationOptions'Read use Read_DidChangeWatchedFilesRegistrationOptions;
    for DidChangeWatchedFilesRegistrationOptions'Write use Write_DidChangeWatchedFilesRegistrationOptions;
+
+   --```typescript
+   --export interface CompletionParams extends TextDocumentPositionParams {
+   --
+   --	/**
+   --	 * The completion context. This is only available if the client specifies
+   --	 * to send this using `ClientCapabilities.textDocument.completion.contextSupport === true`
+   --	 */
+   --	context?: CompletionContext;
+   --}
+   --
+   --/**
+   -- * How a completion was triggered
+   -- */
+   --export namespace CompletionTriggerKind {
+   --	/**
+   --	 * Completion was triggered by typing an identifier (24x7 code
+   --	 * complete), manual invocation (e.g Ctrl+Space) or via API.
+   --	 */
+   --	export const Invoked: 1 = 1;
+   --
+   --	/**
+   --	 * Completion was triggered by a trigger character specified by
+   --	 * the `triggerCharacters` properties of the `CompletionRegistrationOptions`.
+   --	 */
+   --	export const TriggerCharacter: 2 = 2;
+   --
+   --	/**
+   --	 * Completion was re-triggered as the current completion list is incomplete.
+   --	 */
+   --	export const TriggerForIncompleteCompletions: 3 = 3;
+   --}
+   --export type CompletionTriggerKind = 1 | 2 | 3;
+   --
+   --
+   --/**
+   -- * Contains additional information about the context in which a completion request is triggered.
+   -- */
+   --export interface CompletionContext {
+   --	/**
+   --	 * How the completion was triggered.
+   --	 */
+   --	triggerKind: CompletionTriggerKind;
+   --
+   --	/**
+   --	 * The trigger character (a single character) that has trigger code complete.
+   --	 * Is undefined if `triggerKind !== CompletionTriggerKind.TriggerCharacter`
+   --	 */
+   --	triggerCharacter?: string;
+   --}
+   --```
+
+   type CompletionTriggerKind is
+     (Invoked, TriggerCharacter, TriggerForIncompleteCompletions);
+
+   type CompletionContext is record
+      triggerKind: CompletionTriggerKind;
+      triggerCharacter: Optional_String;
+   end record;
+
+   procedure Read_CompletionContext
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out CompletionContext);
+   procedure Write_CompletionContext
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : CompletionContext);
+   for CompletionContext'Read use Read_CompletionContext;
+   for CompletionContext'Write use Write_CompletionContext;
+
+   package Optional_CompletionContexts is new LSP.Generic_Optional (CompletionContext);
+   type Optional_CompletionContext is new Optional_CompletionContexts.Optional_Type;
+
+   type CompletionParams is new TextDocumentPositionParams with record
+      context: Optional_CompletionContext;
+   end record;
+
+   procedure Read_CompletionParams
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out CompletionParams);
+   procedure Write_CompletionParams
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : CompletionParams);
+   for CompletionParams'Read use Read_CompletionParams;
+   for CompletionParams'Write use Write_CompletionParams;
 
    -----------------------------------------
    -- ALS-specific messages and responses --

--- a/source/protocol/lsp-messages.ads
+++ b/source/protocol/lsp-messages.ads
@@ -2375,6 +2375,42 @@ package LSP.Messages is
    for ClientCapabilities'Write use Write_ClientCapabilities;
 
    --```typescript
+   --export interface WorkspaceFolder {
+   --	/**
+   --	 * The associated URI for this workspace folder.
+   --	 */
+   --	uri: DocumentUri;
+   --
+   --	/**
+   --	 * The name of the workspace folder. Used to refer to this
+   --	 * workspace folder in the user interface.
+   --	 */
+   --	name: string;
+   --}
+   --```
+   type WorkspaceFolder is record
+      uri: DocumentUri;
+      name: LSP_String;
+   end record;
+
+   procedure Read_WorkspaceFolder
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out WorkspaceFolder);
+
+   procedure Write_WorkspaceFolder
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : WorkspaceFolder);
+
+   for WorkspaceFolder'Read use Read_WorkspaceFolder;
+   for WorkspaceFolder'Write use Write_WorkspaceFolder;
+
+   package WorkspaceFolder_Vectors is new LSP.Generic_Vectors (WorkspaceFolder);
+   type WorkspaceFolder_Vector is new WorkspaceFolder_Vectors.Vector with null record;
+
+   package Optional_WorkspaceFolder_Vectors is new LSP.Generic_Optional (WorkspaceFolder_Vector);
+   type Optional_WorkspaceFolder_Vector is new Optional_WorkspaceFolder_Vectors.Optional_Type;
+
+   --```typescript
    --interface InitializeParams {
    --	/**
    --	 * The process Id of the parent process that started
@@ -2412,6 +2448,16 @@ package LSP.Messages is
    --	 * The initial trace setting. If omitted trace is disabled ('off').
    --	 */
    --	trace?: 'off' | 'messages' | 'verbose';
+   --
+   --	/**
+   --	 * The workspace folders configured in the client when the server starts.
+   --	 * This property is only available if the client supports workspace folders.
+   --	 * It can be `null` if the client supports workspace folders but none are
+   --	 * configured.
+   --	 *
+   --	 * Since 3.6.0
+   --	 */
+   --	workspaceFolders?: WorkspaceFolder[] | null;
    --}
    --```
    type InitializeParams is record
@@ -2421,6 +2467,7 @@ package LSP.Messages is
       --  initializationOptions?: any;
       capabilities: ClientCapabilities;
       trace: Trace_Kinds;
+      workspaceFolders: Optional_WorkspaceFolder_Vector;
    end record;
 
    procedure Read_InitializeParams

--- a/source/protocol/lsp-messages.ads
+++ b/source/protocol/lsp-messages.ads
@@ -1408,6 +1408,94 @@ package LSP.Messages is
 
    --```typescript
    --/**
+   -- * Describes the content type that a client supports in various
+   -- * result literals like `Hover`, `ParameterInfo` or `CompletionItem`.
+   -- *
+   -- * Please note that `MarkupKinds` must not start with a `$`. This kinds
+   -- * are reserved for internal usage.
+   -- */
+   --export namespace MarkupKind {
+   --	/**
+   --	 * Plain text is supported as a content format
+   --	 */
+   --	export const PlainText: 'plaintext' = 'plaintext';
+   --
+   --	/**
+   --	 * Markdown is supported as a content format
+   --	 */
+   --	export const Markdown: 'markdown' = 'markdown';
+   --}
+   --export type MarkupKind = 'plaintext' | 'markdown';
+   --
+   --/**
+   -- * A `MarkupContent` literal represents a string value which content is interpreted base on its
+   -- * kind flag. Currently the protocol supports `plaintext` and `markdown` as markup kinds.
+   -- *
+   -- * If the kind is `markdown` then the value can contain fenced code blocks like in GitHub issues.
+   -- * See https://help.github.com/articles/creating-and-highlighting-code-blocks/#syntax-highlighting
+   -- *
+   -- * Here is an example how such a string can be constructed using JavaScript / TypeScript:
+   -- * ```typescript
+   -- * let markdown: MarkdownContent = {
+   -- *  kind: MarkupKind.Markdown,
+   -- *	value: [
+   -- *		'# Header',
+   -- *		'Some text',
+   -- *		'```typescript',
+   -- *		'someCode();',
+   -- *		'```'
+   -- *	].join('\n')
+   -- * };
+   -- * ```
+   -- *
+   -- * *Please Note* that clients might sanitize the return markdown. A client could decide to
+   -- * remove HTML from the markdown to avoid script execution.
+   -- */
+   --export interface MarkupContent {
+   --	/**
+   --	 * The type of the Markup
+   --	 */
+   --	kind: MarkupKind;
+   --
+   --	/**
+   --	 * The content itself
+   --	 */
+   --	value: string;
+   --}
+   --```
+
+   type MarkupKind is (plaintext, markdown);
+
+   procedure Read_MarkupKind
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out MarkupKind);
+
+   procedure Write_MarkupKind
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : MarkupKind);
+   for MarkupKind'Read use Read_MarkupKind;
+   for MarkupKind'Write use Write_MarkupKind;
+
+   package MarkupKind_Vectors is new LSP.Generic_Vectors (MarkupKind);
+   type MarkupKind_Vector is new MarkupKind_Vectors.Vector with null record;
+
+   type MarkupContent is record
+      kind  : MarkupKind;
+      value : LSP_String;
+   end record;
+
+   procedure Read_MarkupContent
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out MarkupContent);
+
+   procedure Write_MarkupContent
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : MarkupContent);
+   for MarkupContent'Read use Read_MarkupContent;
+   for MarkupContent'Write use Write_MarkupContent;
+
+   --```typescript
+   --/**
    -- * Text document specific client capabilities.
    -- */
    --export interface TextDocumentClientCapabilities {

--- a/source/protocol/lsp-messages.ads
+++ b/source/protocol/lsp-messages.ads
@@ -4844,10 +4844,19 @@ package LSP.Messages is
    --	 * An array of diagnostics.
    --	 */
    --	diagnostics: Diagnostic[];
+   --
+   --	/**
+   --	 * Requested kind of actions to return.
+   --	 *
+   --	 * Actions not of this kind are filtered out by the client before being shown. So servers
+   --	 * can omit computing them.
+   --	 */
+   --	only?: CodeActionKind[];
    --}
    --```
    type CodeActionContext is record
       diagnostics: Diagnostic_Vector;
+      only: Optional_CodeActionKindSet;
    end record;
 
    procedure Read_CodeActionContext

--- a/source/protocol/lsp-messages.ads
+++ b/source/protocol/lsp-messages.ads
@@ -26,10 +26,11 @@
 --
 
 with Ada.Containers.Hashed_Maps;
-with LSP.Generic_Vectors;
 with Ada.Streams;
 
 with LSP.Generic_Optional;
+with LSP.Generic_Sets;
+with LSP.Generic_Vectors;
 with LSP.Types; use LSP.Types;
 
 package LSP.Messages is
@@ -1255,18 +1256,21 @@ package LSP.Messages is
 
    type ResourceOperationKind is (create, rename, delete);
 
-   type ResourceOperationKindSet is array (ResourceOperationKind) of Boolean;
-
-   procedure Read_ResourceOperationKindSet
+   procedure Read_ResourceOperationKind
      (S : access Ada.Streams.Root_Stream_Type'Class;
-      V : out ResourceOperationKindSet);
+      V : out ResourceOperationKind);
 
-   procedure Write_ResourceOperationKindSet
+   procedure Write_ResourceOperationKind
      (S : access Ada.Streams.Root_Stream_Type'Class;
-      V : ResourceOperationKindSet);
+      V : ResourceOperationKind);
 
-   for ResourceOperationKindSet'Read use Read_ResourceOperationKindSet;
-   for ResourceOperationKindSet'Write use Write_ResourceOperationKindSet;
+   for ResourceOperationKind'Read use Read_ResourceOperationKind;
+   for ResourceOperationKind'Write use Write_ResourceOperationKind;
+
+   package ResourceOperationKindSets is
+     new LSP.Generic_Sets (ResourceOperationKind);
+
+   type ResourceOperationKindSet is new ResourceOperationKindSets.Set;
 
    package Optional_ResourceOperationKindSets is
      new LSP.Generic_Optional (ResourceOperationKindSet);
@@ -1340,21 +1344,12 @@ package LSP.Messages is
    for SymbolKind'Read use Read_SymbolKind;
    for SymbolKind'Write use Write_SymbolKind;
 
-   type SymbolKindSet is array (SymbolKind) of Boolean;
+   package SymbolKindSets is new LSP.Generic_Sets (SymbolKind);
 
-   procedure Read_SymbolKindSet
-     (S : access Ada.Streams.Root_Stream_Type'Class;
-      V : out SymbolKindSet);
-
-   procedure Write_SymbolKindSet
-     (S : access Ada.Streams.Root_Stream_Type'Class;
-      V : SymbolKindSet);
-
-   for SymbolKindSet'Read use Read_SymbolKindSet;
-   for SymbolKindSet'Write use Write_SymbolKindSet;
+   type SymbolKindSet is new SymbolKindSets.Set;
 
    Default_SymbolKindSet : constant SymbolKindSet :=
-     (File .. An_Array => True, others => False);
+     To_Set (From => File, To => An_Array);
 
    package Optional_SymbolKindSets is
      new LSP.Generic_Optional (SymbolKindSet);

--- a/source/protocol/lsp-messages.ads
+++ b/source/protocol/lsp-messages.ads
@@ -350,6 +350,9 @@ package LSP.Messages is
    type Optional_CodeActionKindSet is
      new Optional_CodeActionKindSets.Optional_Type;
 
+   package Optional_CodeActionKinds is new LSP.Generic_Optional (CodeActionKind);
+   type Optional_CodeActionKind is new Optional_CodeActionKinds.Optional_Type;
+
    --  reference_kinds ALS extension:
    --
    --  export type AlsReferenceKind = 'w' | 'c' | 'd';
@@ -629,6 +632,9 @@ package LSP.Messages is
    package Diagnostic_Vectors is new LSP.Generic_Vectors (Diagnostic);
 
    type Diagnostic_Vector is new Diagnostic_Vectors.Vector with null record;
+
+   package Optional_Diagnostic_Vectors is new LSP.Generic_Optional (Diagnostic_Vector);
+   type Optional_Diagnostic_Vector is new Optional_Diagnostic_Vectors.Optional_Type;
 
    --```typescript
    --interface Command {
@@ -992,6 +998,9 @@ package LSP.Messages is
      (S : access Ada.Streams.Root_Stream_Type'Class;
       V : WorkspaceEdit);
    for WorkspaceEdit'Write use Write_WorkspaceEdit;
+
+   package Optional_WorkspaceEdits is new LSP.Generic_Optional (WorkspaceEdit);
+   type Optional_WorkspaceEdit is new Optional_WorkspaceEdits.Optional_Type;
 
    --```typescript
    --interface TextDocumentItem {
@@ -5644,6 +5653,67 @@ package LSP.Messages is
       V : CompletionParams);
    for CompletionParams'Read use Read_CompletionParams;
    for CompletionParams'Write use Write_CompletionParams;
+
+   --```typescript
+   --/**
+   -- * A code action represents a change that can be performed in code, e.g. to fix a problem or
+   -- * to refactor code.
+   -- *
+   -- * A CodeAction must set either `edit` and/or a `command`. If both are supplied, the `edit` is applied first, then the `command` is executed.
+   -- */
+   --export interface CodeAction {
+   --
+   --	/**
+   --	 * A short, human-readable, title for this code action.
+   --	 */
+   --	title: string;
+   --
+   --	/**
+   --	 * The kind of the code action.
+   --	 *
+   --	 * Used to filter code actions.
+   --	 */
+   --	kind?: CodeActionKind;
+   --
+   --	/**
+   --	 * The diagnostics that this code action resolves.
+   --	 */
+   --	diagnostics?: Diagnostic[];
+   --
+   --	/**
+   --	 * The workspace edit this code action performs.
+   --	 */
+   --	edit?: WorkspaceEdit;
+   --
+   --	/**
+   --	 * A command this code action executes. If a code action
+   --	 * provides an edit and a command, first the edit is
+   --	 * executed and then the command.
+   --	 */
+   --	command?: Command;
+   --}
+   --```
+   type CodeAction is record
+      title: LSP_String;
+      kind: Optional_CodeActionKind;
+      diagnostics: Optional_Diagnostic_Vector;
+      edit: Optional_WorkspaceEdit;
+      command: Optional_Command;
+   end record;
+
+   procedure Read_CodeAction
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out CodeAction);
+   procedure Write_CodeAction
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : CodeAction);
+   for CodeAction'Read use Read_CodeAction;
+   for CodeAction'Write use Write_CodeAction;
+
+   package CodeAction_Vectors is new LSP.Generic_Vectors (CodeAction);
+   type CodeAction_Vector is new CodeAction_Vectors.Vector with null record;
+   --  CodeAction_Vector represents a sequence of CodeAction OR Command.
+   --  Command is represented as CodeAction with just `command` property set.
 
    -----------------------------------------
    -- ALS-specific messages and responses --

--- a/source/protocol/lsp-messages.ads
+++ b/source/protocol/lsp-messages.ads
@@ -4179,6 +4179,24 @@ package LSP.Messages is
    package MarkedString_Vectors is new LSP.Generic_Vectors (MarkedString);
    type MarkedString_Vector is new MarkedString_Vectors.Vector with null record;
 
+   type MarkupContent_Or_MarkedString_Vector (Is_MarkupContent : Boolean := False) is record
+      case Is_MarkupContent is
+         when True =>
+            MarkupContent : LSP.Messages.MarkupContent;
+         when False =>
+            Vector : MarkedString_Vector;
+      end case;
+   end record;
+
+   procedure Read_MarkupContent_Or_MarkedString_Vector
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out MarkupContent_Or_MarkedString_Vector);
+   procedure Write_MarkupContent_Or_MarkedString_Vector
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : MarkupContent_Or_MarkedString_Vector);
+   for MarkupContent_Or_MarkedString_Vector'Read use Read_MarkupContent_Or_MarkedString_Vector;
+   for MarkupContent_Or_MarkedString_Vector'Write use Write_MarkupContent_Or_MarkedString_Vector;
+
    --```typescript
    --/**
    -- * The result of a hover request.
@@ -4187,7 +4205,7 @@ package LSP.Messages is
    --	/**
    --	 * The hover's content
    --	 */
-   --	contents: MarkedString | MarkedString[];
+   --	contents: MarkedString | MarkedString[] | MarkupContent;
    --
    --	/**
    --	 * An optional range is a range inside a text document
@@ -4197,7 +4215,7 @@ package LSP.Messages is
    --}
    --```
    type Hover is record
-      contents: MarkedString_Vector;
+      contents: MarkupContent_Or_MarkedString_Vector;
       Span: Optional_Span;
    end record;
 

--- a/source/protocol/lsp-messages.ads
+++ b/source/protocol/lsp-messages.ads
@@ -1724,7 +1724,28 @@ package LSP.Messages is
    --	};
    --
    --	/**
-   --	 * Capabilities specific to the `textDocument/definition`
+   --		* Capabilities specific to the `textDocument/declaration`
+   --		*/
+   --	declaration?: {
+   --		/**
+   --		 * Whether declaration supports dynamic registration. If this is set to `true`
+   --		 * the client supports the new `(TextDocumentRegistrationOptions & StaticRegistrationOptions)`
+   --		 * return value for the corresponding server capability as well.
+   --		 */
+   --		dynamicRegistration?: boolean;
+   --
+   --		/**
+   --		 * The client supports additional metadata in the form of declaration links.
+   --		 *
+   --		 * Since 3.14.0
+   --		 */
+   --		linkSupport?: boolean;
+   --	};
+   --
+   --	/**
+   --	 * Capabilities specific to the `textDocument/definition`.
+   --	 *
+   --	 * Since 3.14.0
    --	 */
    --	definition?: {
    --		/**
@@ -2009,6 +2030,28 @@ package LSP.Messages is
    type Optional_Document_Symbol_Capability is
      new Optional_Document_Symbol_Capabilities.Optional_Type;
 
+   type declaration_Capability is record
+      dynamicRegistration: Optional_Boolean;
+      linkSupport: Optional_Boolean;
+   end record;
+
+   procedure Read_declaration_Capability
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out declaration_Capability);
+
+   procedure Write_declaration_Capability
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : declaration_Capability);
+
+   for declaration_Capability'Read use Read_declaration_Capability;
+   for declaration_Capability'Write use Write_declaration_Capability;
+
+   package Optional_declaration_Capabilities is
+     new LSP.Generic_Optional (declaration_Capability);
+
+   type Optional_declaration_Capability is
+     new Optional_declaration_Capabilities.Optional_Type;
+
    type TextDocumentClientCapabilities is record
       synchronization   : LSP.Messages.synchronization;
       completion        : LSP.Messages.completion;
@@ -2020,6 +2063,7 @@ package LSP.Messages is
       formatting        : dynamicRegistration;
       rangeFormatting   : dynamicRegistration;
       onTypeFormatting  : dynamicRegistration;
+      declaration       : Optional_declaration_Capability;
       definition        : dynamicRegistration;
       typeDefinition    : dynamicRegistration;
       codeAction        : dynamicRegistration;

--- a/source/protocol/lsp-messages.ads
+++ b/source/protocol/lsp-messages.ads
@@ -26,7 +26,7 @@
 --
 
 with Ada.Containers.Hashed_Maps;
-with Ada.Containers.Vectors;
+with LSP.Generic_Vectors;
 with Ada.Streams;
 
 with LSP.Generic_Optional;
@@ -379,19 +379,9 @@ package LSP.Messages is
    for Location'Read use Read_Location;
    for Location'Write use Write_Location;
 
-   package Location_Vectors is new Ada.Containers.Vectors
-     (Positive, Location);
+   package Location_Vectors is new LSP.Generic_Vectors (Location);
 
    type Location_Vector is new Location_Vectors.Vector with null record;
-
-   procedure Read_Location_Vector
-     (S : access Ada.Streams.Root_Stream_Type'Class;
-      V : out Location_Vector);
-   procedure Write_Location_Vector
-     (S : access Ada.Streams.Root_Stream_Type'Class;
-      V : Location_Vector);
-   for Location_Vector'Read use Read_Location_Vector;
-   for Location_Vector'Write use Write_Location_Vector;
 
    --
    --```typescript
@@ -476,21 +466,9 @@ package LSP.Messages is
       V : Diagnostic);
    for Diagnostic'Write use Write_Diagnostic;
 
-   package Diagnostic_Vectors is new Ada.Containers.Vectors
-     (Positive, Diagnostic);
+   package Diagnostic_Vectors is new LSP.Generic_Vectors (Diagnostic);
 
    type Diagnostic_Vector is new Diagnostic_Vectors.Vector with null record;
-
-   procedure Read_Diagnostic_Vector
-     (S : access Ada.Streams.Root_Stream_Type'Class;
-      V : out Diagnostic_Vector);
-
-   procedure Write_Diagnostic_Vector
-     (S : access Ada.Streams.Root_Stream_Type'Class;
-      V : Diagnostic_Vector);
-
-   for Diagnostic_Vector'Read use Read_Diagnostic_Vector;
-   for Diagnostic_Vector'Write use Write_Diagnostic_Vector;
 
    --```typescript
    --interface Command {
@@ -524,19 +502,9 @@ package LSP.Messages is
    for Command'Read use Read_Command;
    for Command'Write use Write_Command;
 
-   package Command_Vectors is new Ada.Containers.Vectors
-     (Positive, Command);
+   package Command_Vectors is new LSP.Generic_Vectors (Command);
 
    type Command_Vector is new Command_Vectors.Vector with null record;
-
-   procedure Read_Command_Vector
-     (S : access Ada.Streams.Root_Stream_Type'Class;
-      V : out Command_Vector);
-   procedure Write_Command_Vector
-     (S : access Ada.Streams.Root_Stream_Type'Class;
-      V : Command_Vector);
-   for Command_Vector'Read use Read_Command_Vector;
-   for Command_Vector'Write use Write_Command_Vector;
 
    --```typescript
    --interface TextEdit {
@@ -571,18 +539,8 @@ package LSP.Messages is
    package Optional_TextEdits is new LSP.Generic_Optional (TextEdit);
    type Optional_TextEdit is new Optional_TextEdits.Optional_Type;
 
-   package TextEdit_Vectors is new Ada.Containers.Vectors (Positive, TextEdit);
+   package TextEdit_Vectors is new LSP.Generic_Vectors (TextEdit);
    type TextEdit_Vector is new TextEdit_Vectors.Vector with null record;
-
-   procedure Read_TextEdit_Vector
-     (S : access Ada.Streams.Root_Stream_Type'Class;
-      V : out TextEdit_Vector);
-   for TextEdit_Vector'Read use Read_TextEdit_Vector;
-
-   procedure Write_TextEdit_Vector
-     (S : access Ada.Streams.Root_Stream_Type'Class;
-      V : TextEdit_Vector);
-   for TextEdit_Vector'Write use Write_TextEdit_Vector;
 
    --
    --```typescript
@@ -660,20 +618,10 @@ package LSP.Messages is
    for TextDocumentEdit'Write use Write_TextDocumentEdit;
 
    package TextDocumentEdit_Vectors is
-     new Ada.Containers.Vectors (Positive, TextDocumentEdit);
+     new LSP.Generic_Vectors (TextDocumentEdit);
 
    type TextDocumentEdit_Vector is
      new TextDocumentEdit_Vectors.Vector with null record;
-
-   procedure Read_TextDocumentEdit_Vector
-     (S : access Ada.Streams.Root_Stream_Type'Class;
-      V : out TextDocumentEdit_Vector);
-   for TextDocumentEdit_Vector'Read use Read_TextDocumentEdit_Vector;
-
-   procedure Write_TextDocumentEdit_Vector
-     (S : access Ada.Streams.Root_Stream_Type'Class;
-      V : TextDocumentEdit_Vector);
-   for TextDocumentEdit_Vector'Write use Write_TextDocumentEdit_Vector;
 
    package TextDocumentEdit_Maps is new Ada.Containers.Hashed_Maps
      (Key_Type        => LSP.Types.LSP_String,
@@ -811,8 +759,7 @@ package LSP.Messages is
       pattern: LSP.Types.Optional_String;
    end record;
 
-   package DocumentFilter_Vectors is new Ada.Containers.Vectors
-     (Positive, DocumentFilter);
+   package DocumentFilter_Vectors is new LSP.Generic_Vectors (DocumentFilter);
    --```typescript
    --export type DocumentSelector = DocumentFilter[];
    --```
@@ -2106,8 +2053,7 @@ package LSP.Messages is
       method: LSP_String;
    end record;
 
-   package Unregistration_Vectors is new Ada.Containers.Vectors
-     (Positive, Unregistration);
+   package Unregistration_Vectors is new LSP.Generic_Vectors (Unregistration);
 
    type UnregistrationParams is
      new Unregistration_Vectors.Vector with null record;
@@ -2209,20 +2155,11 @@ package LSP.Messages is
    for TextDocumentContentChangeEvent'Read use Read_TextDocumentContentChangeEvent;
    for TextDocumentContentChangeEvent'Write use Write_TextDocumentContentChangeEvent;
 
-   package TextDocumentContentChangeEvent_Vectors is new Ada.Containers.Vectors
-     (Positive, TextDocumentContentChangeEvent);
+   package TextDocumentContentChangeEvent_Vectors is new LSP.Generic_Vectors
+     (TextDocumentContentChangeEvent);
 
    type TextDocumentContentChangeEvent_Vector is
      new TextDocumentContentChangeEvent_Vectors.Vector with null record;
-
-   procedure Read_TextDocumentContentChangeEvent_Vector
-     (S : access Ada.Streams.Root_Stream_Type'Class;
-      V : out TextDocumentContentChangeEvent_Vector);
-   procedure Write_TextDocumentContentChangeEvent_Vector
-     (S : access Ada.Streams.Root_Stream_Type'Class;
-      V : TextDocumentContentChangeEvent_Vector);
-   for TextDocumentContentChangeEvent_Vector'Read use Read_TextDocumentContentChangeEvent_Vector;
-   for TextDocumentContentChangeEvent_Vector'Write use Write_TextDocumentContentChangeEvent_Vector;
 
    type DidChangeTextDocumentParams is record
       textDocument: VersionedTextDocumentIdentifier;
@@ -2372,7 +2309,7 @@ package LSP.Messages is
       the_type : FileChangeType;  -- type: is reserver word
    end record;
 
-   package FileEvent_Vectors is new Ada.Containers.Vectors (Positive, FileEvent);
+   package FileEvent_Vectors is new LSP.Generic_Vectors (FileEvent);
    type FileEvent_Vector is new FileEvent_Vectors.Vector with null record;
 
    --```typescript
@@ -2628,19 +2565,9 @@ package LSP.Messages is
    for CompletionItem'Read use Read_CompletionItem;
    for CompletionItem'Write use Write_CompletionItem;
 
-   package CompletionItem_Vectors is new Ada.Containers.Vectors
-     (Positive, CompletionItem);
+   package CompletionItem_Vectors is new LSP.Generic_Vectors (CompletionItem);
    type CompletionItem_Vector is
      new CompletionItem_Vectors.Vector with null record;
-
-   procedure Read_CompletionItem_Vector
-     (S : access Ada.Streams.Root_Stream_Type'Class;
-      V : out CompletionItem_Vector);
-   procedure Write_CompletionItem_Vector
-     (S : access Ada.Streams.Root_Stream_Type'Class;
-      V : CompletionItem_Vector);
-   for CompletionItem_Vector'Read use Read_CompletionItem_Vector;
-   for CompletionItem_Vector'Write use Write_CompletionItem_Vector;
 
    type CompletionList is record
       isIncomplete: Boolean := False;
@@ -2692,18 +2619,8 @@ package LSP.Messages is
    for MarkedString'Read use Read_MarkedString;
    for MarkedString'Write use Write_MarkedString;
 
-   package MarkedString_Vectors is new Ada.Containers.Vectors
-     (Positive, MarkedString);
+   package MarkedString_Vectors is new LSP.Generic_Vectors (MarkedString);
    type MarkedString_Vector is new MarkedString_Vectors.Vector with null record;
-
-   procedure Read_MarkedString_Vector
-     (S : access Ada.Streams.Root_Stream_Type'Class;
-      V : out MarkedString_Vector);
-   procedure Write_MarkedString_Vector
-     (S : access Ada.Streams.Root_Stream_Type'Class;
-      V : MarkedString_Vector);
-   for MarkedString_Vector'Read use Read_MarkedString_Vector;
-   for MarkedString_Vector'Write use Write_MarkedString_Vector;
 
    --```typescript
    --/**
@@ -2827,19 +2744,10 @@ package LSP.Messages is
    for ParameterInformation'Read use Read_ParameterInformation;
    for ParameterInformation'Write use Write_ParameterInformation;
 
-   package ParameterInformation_Vectors is new Ada.Containers.Vectors
-     (Positive, ParameterInformation);
+   package ParameterInformation_Vectors is new LSP.Generic_Vectors
+     (ParameterInformation);
    type ParameterInformation_Vector is
      new ParameterInformation_Vectors.Vector with null record;
-
-   procedure Read_ParameterInformation_Vector
-     (S : access Ada.Streams.Root_Stream_Type'Class;
-      V : out ParameterInformation_Vector);
-   procedure Write_ParameterInformation_Vector
-     (S : access Ada.Streams.Root_Stream_Type'Class;
-      V : ParameterInformation_Vector);
-   for ParameterInformation_Vector'Write use Write_ParameterInformation_Vector;
-   for ParameterInformation_Vector'Read use Read_ParameterInformation_Vector;
 
    type SignatureInformation is record
       label: LSP_String;
@@ -2856,19 +2764,10 @@ package LSP.Messages is
    for SignatureInformation'Read use Read_SignatureInformation;
    for SignatureInformation'Write use Write_SignatureInformation;
 
-   package SignatureInformation_Vectors is new Ada.Containers.Vectors
-     (Positive, SignatureInformation);
+   package SignatureInformation_Vectors is new LSP.Generic_Vectors
+     (SignatureInformation);
    type SignatureInformation_Vector is
      new SignatureInformation_Vectors.Vector with null record;
-
-   procedure Read_SignatureInformation_Vector
-     (S : access Ada.Streams.Root_Stream_Type'Class;
-      V : out SignatureInformation_Vector);
-   procedure Write_SignatureInformation_Vector
-     (S : access Ada.Streams.Root_Stream_Type'Class;
-      V : SignatureInformation_Vector);
-   for SignatureInformation_Vector'Read use Read_SignatureInformation_Vector;
-   for SignatureInformation_Vector'Write use Write_SignatureInformation_Vector;
 
    type SignatureHelp is record
 	signatures: SignatureInformation_Vector;
@@ -2993,20 +2892,11 @@ package LSP.Messages is
    for DocumentHighlight'Read use Read_DocumentHighlight;
    for DocumentHighlight'Write use Write_DocumentHighlight;
 
-   package DocumentHighlight_Vectors is new Ada.Containers.Vectors
-     (Positive, DocumentHighlight);
+   package DocumentHighlight_Vectors is new LSP.Generic_Vectors
+     (DocumentHighlight);
 
    type DocumentHighlight_Vector is
      new DocumentHighlight_Vectors.Vector with null record;
-   procedure Read_DocumentHighlight_Vector
-     (S : access Ada.Streams.Root_Stream_Type'Class;
-      V : out DocumentHighlight_Vector);
-   procedure Write_DocumentHighlight_Vector
-     (S : access Ada.Streams.Root_Stream_Type'Class;
-      V : DocumentHighlight_Vector);
-
-   for DocumentHighlight_Vector'Read use Read_DocumentHighlight_Vector;
-   for DocumentHighlight_Vector'Write use Write_DocumentHighlight_Vector;
 
    --```typescript
    --interface DocumentSymbolParams {
@@ -3127,20 +3017,11 @@ package LSP.Messages is
    for SymbolInformation'Read use Read_SymbolInformation;
    for SymbolInformation'Write use Write_SymbolInformation;
 
-   package SymbolInformation_Vectors is new Ada.Containers.Vectors
-     (Positive, SymbolInformation);
+   package SymbolInformation_Vectors is new LSP.Generic_Vectors
+     (SymbolInformation);
 
    type SymbolInformation_Vector is
      new SymbolInformation_Vectors.Vector with null record;
-
-   procedure Read_SymbolInformation_Vector
-     (S : access Ada.Streams.Root_Stream_Type'Class;
-      V : out SymbolInformation_Vector);
-   procedure Write_SymbolInformation_Vector
-     (S : access Ada.Streams.Root_Stream_Type'Class;
-      V : SymbolInformation_Vector);
-   for SymbolInformation_Vector'Read use Read_SymbolInformation_Vector;
-   for SymbolInformation_Vector'Write use Write_SymbolInformation_Vector;
 
    --```typescript
    --/**
@@ -3721,22 +3602,10 @@ package LSP.Messages is
    for ALS_Subprogram_And_References'Write use
      Write_ALS_Subprogram_And_References;
 
-   package ALS_Subprogram_And_References_Vectors is new Ada.Containers.Vectors
-     (Positive, ALS_Subprogram_And_References);
+   package ALS_Subprogram_And_References_Vectors is new LSP.Generic_Vectors
+     (ALS_Subprogram_And_References);
    type ALS_Subprogram_And_References_Vector is
      new ALS_Subprogram_And_References_Vectors.Vector with null record;
-
-   procedure Read_ALS_Subprogram_And_References_Vector
-     (S : access Ada.Streams.Root_Stream_Type'Class;
-      V : out ALS_Subprogram_And_References_Vector);
-   for ALS_Subprogram_And_References_Vector'Read use
-     Read_ALS_Subprogram_And_References_Vector;
-
-   procedure Write_ALS_Subprogram_And_References_Vector
-     (S : access Ada.Streams.Root_Stream_Type'Class;
-      V : ALS_Subprogram_And_References_Vector);
-   for ALS_Subprogram_And_References_Vector'Write use
-     Write_ALS_Subprogram_And_References_Vector;
 
    type ALS_Debug_Kinds is (Suspend_Execution);
    --  Suspend_Execution - stop processing task until input queue has given

--- a/source/protocol/lsp-messages.ads
+++ b/source/protocol/lsp-messages.ads
@@ -5863,6 +5863,18 @@ package LSP.Messages is
    for ColorPresentation'Read use Read_ColorPresentation;
    for ColorPresentation'Write use Write_ColorPresentation;
 
+   --```typescript
+   --export interface RenameRegistrationOptions extends TextDocumentRegistrationOptions {
+   --	/**
+   --	 * Renames should be checked and tested for validity before being executed.
+   --	 */
+   --	prepareProvider?: boolean;
+   --}
+   --```
+   type RenameRegistrationOptions is new TextDocumentRegistrationOptions with record
+      prepareProvider: Optional_Boolean;
+   end record;
+
    -----------------------------------------
    -- ALS-specific messages and responses --
    -----------------------------------------

--- a/source/protocol/lsp-messages.ads
+++ b/source/protocol/lsp-messages.ads
@@ -2770,6 +2770,32 @@ package LSP.Messages is
    --	 */
    --	executeCommandProvider?: ExecuteCommandOptions;
    --	/**
+   --	 * Workspace specific server capabilities
+   --	 */
+   --	workspace?: {
+   --		/**
+   --		 * The server supports workspace folder.
+   --		 *
+   --		 * Since 3.6.0
+   --		 */
+   --		workspaceFolders?: {
+   --			/**
+   --			* The server has support for workspace folders
+   --			*/
+   --			supported?: boolean;
+   --			/**
+   --			* Whether the server wants to receive workspace folder
+   --			* change notifications.
+   --			*
+   --			* If a strings is provided the string is treated as a ID
+   --			* under which the notification is registered on the client
+   --			* side. The ID can be used to unregister for these events
+   --			* using the `client/unregisterCapability` request.
+   --			*/
+   --			changeNotifications?: string | boolean;
+   --		}
+   --	}
+   --	/**
    --	 * Experimental server capabilities.
    --	 */
    --	experimental?: any;
@@ -3036,6 +3062,51 @@ package LSP.Messages is
    for ExecuteCommandOptions'Write use Write_ExecuteCommandOptions;
    for ExecuteCommandOptions'Read use Read_ExecuteCommandOptions;
 
+   package Optional_Boolean_Or_String_Package is
+     new LSP.Generic_Optional (LSP_Boolean_Or_String);
+
+   type Optional_Boolean_Or_String is
+     new Optional_Boolean_Or_String_Package.Optional_Type;
+
+   type workspaceFolders is record
+      supported: Optional_Boolean;
+      changeNotifications: Optional_Boolean_Or_String;
+   end record;
+
+   procedure Read_workspaceFolders
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out workspaceFolders);
+   procedure Write_workspaceFolders
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : workspaceFolders);
+   for workspaceFolders'Write use Write_workspaceFolders;
+   for workspaceFolders'Read use Read_workspaceFolders;
+
+   package Optional_workspaceFolders_Package is
+     new LSP.Generic_Optional (workspaceFolders);
+
+   type Optional_workspaceFolders is
+     new Optional_workspaceFolders_Package.Optional_Type;
+
+   type workspace_Options is record
+      workspaceFolders: Optional_workspaceFolders;
+   end record;
+
+   procedure Read_workspace_Options
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out workspace_Options);
+   procedure Write_workspace_Options
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : workspace_Options);
+   for workspace_Options'Write use Write_workspace_Options;
+   for workspace_Options'Read use Read_workspace_Options;
+
+   package Optional_workspace_Options_Package is
+     new LSP.Generic_Optional (workspace_Options);
+
+   type Optional_workspace_Options is
+     new Optional_workspace_Options_Package.Optional_Type;
+
    type ServerCapabilities is record
       textDocumentSync: Optional_TextDocumentSyncOptions;
       hoverProvider: Optional_Boolean;
@@ -3059,6 +3130,7 @@ package LSP.Messages is
       foldingRangeProvider: Optional_Provider_Options;
       declarationProvider: Optional_Provider_Options;
       executeCommandProvider: ExecuteCommandOptions;
+      workspace: Optional_workspace_Options;
       --	experimental?: any;
 
       --  ALS-specific capabilities

--- a/source/protocol/lsp-messages.ads
+++ b/source/protocol/lsp-messages.ads
@@ -323,6 +323,23 @@ package LSP.Messages is
    package Optional_Spans is new LSP.Generic_Optional (Span);
    type Optional_Span is new Optional_Spans.Optional_Type;
 
+   type CodeActionKind is
+     (Empty,
+      QuickFix,
+      Refactor, RefactorExtract, RefactorInline, RefactorRewrite,
+      Source, SourceOrganizeImports);
+
+   procedure Read_CodeActionKind
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out CodeActionKind);
+
+   procedure Write_CodeActionKind
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : CodeActionKind);
+
+   for CodeActionKind'Read use Read_CodeActionKind;
+   for CodeActionKind'Write use Write_CodeActionKind;
+
    --  reference_kinds ALS extension:
    --
    --  export type AlsReferenceKind = 'w' | 'c' | 'd';
@@ -4053,6 +4070,88 @@ package LSP.Messages is
    --	 * Context carrying additional information.
    --	 */
    --	context: CodeActionContext;
+   --}
+   --
+   --/**
+   -- * The kind of a code action.
+   -- *
+   -- * Kinds are a hierarchical list of identifiers separated by `.`, e.g. `"refactor.extract.function"`.
+   -- *
+   -- * The set of kinds is open and client needs to announce the kinds it supports to the server during
+   -- * initialization.
+   -- */
+   --export type CodeActionKind = string;
+   --
+   --/**
+   -- * A set of predefined code action kinds
+   -- */
+   --export namespace CodeActionKind {
+   --
+   --	/**
+   --	 * Empty kind.
+   --	 */
+   --	export const Empty: CodeActionKind = '';
+   --
+   --	/**
+   --	 * Base kind for quickfix actions: 'quickfix'
+   --	 */
+   --	export const QuickFix: CodeActionKind = 'quickfix';
+   --
+   --	/**
+   --	 * Base kind for refactoring actions: 'refactor'
+   --	 */
+   --	export const Refactor: CodeActionKind = 'refactor';
+   --
+   --	/**
+   --	 * Base kind for refactoring extraction actions: 'refactor.extract'
+   --	 *
+   --	 * Example extract actions:
+   --	 *
+   --	 * - Extract method
+   --	 * - Extract function
+   --	 * - Extract variable
+   --	 * - Extract interface from class
+   --	 * - ...
+   --	 */
+   --	export const RefactorExtract: CodeActionKind = 'refactor.extract';
+   --
+   --	/**
+   --	 * Base kind for refactoring inline actions: 'refactor.inline'
+   --	 *
+   --	 * Example inline actions:
+   --	 *
+   --	 * - Inline function
+   --	 * - Inline variable
+   --	 * - Inline constant
+   --	 * - ...
+   --	 */
+   --	export const RefactorInline: CodeActionKind = 'refactor.inline';
+   --
+   --	/**
+   --	 * Base kind for refactoring rewrite actions: 'refactor.rewrite'
+   --	 *
+   --	 * Example rewrite actions:
+   --	 *
+   --	 * - Convert JavaScript function to class
+   --	 * - Add or remove parameter
+   --	 * - Encapsulate field
+   --	 * - Make method static
+   --	 * - Move method to base class
+   --	 * - ...
+   --	 */
+   --	export const RefactorRewrite: CodeActionKind = 'refactor.rewrite';
+   --
+   --	/**
+   --	 * Base kind for source actions: `source`
+   --	 *
+   --	 * Source code actions apply to the entire file.
+   --	 */
+   --	export const Source: CodeActionKind = 'source';
+   --
+   --	/**
+   --	 * Base kind for an organize imports source action: `source.organizeImports`
+   --	 */
+   --	export const SourceOrganizeImports: CodeActionKind = 'source.organizeImports';
    --}
    --
    --/**

--- a/source/protocol/lsp-messages.ads
+++ b/source/protocol/lsp-messages.ads
@@ -5422,6 +5422,53 @@ package LSP.Messages is
    for DidChangeWorkspaceFoldersParams'Read use Read_DidChangeWorkspaceFoldersParams;
    for DidChangeWorkspaceFoldersParams'Write use Write_DidChangeWorkspaceFoldersParams;
 
+   --```typescript
+   --export interface ConfigurationParams {
+   --	items: ConfigurationItem[];
+   --}
+   --
+   --export interface ConfigurationItem {
+   --	/**
+   --	 * The scope to get the configuration section for.
+   --	 */
+   --	scopeUri?: DocumentUri;
+   --
+   --	/**
+   --	 * The configuration section asked for.
+   --	 */
+   --	section?: string;
+   --}
+   --```
+   type ConfigurationItem is record
+      scopeUri: Optional_String;
+      section: Optional_String;
+   end record;
+
+   procedure Read_ConfigurationItem
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out ConfigurationItem);
+   procedure Write_ConfigurationItem
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : ConfigurationItem);
+   for ConfigurationItem'Read use Read_ConfigurationItem;
+   for ConfigurationItem'Write use Write_ConfigurationItem;
+
+   package ConfigurationItem_Vectors is new LSP.Generic_Vectors (ConfigurationItem);
+   type ConfigurationItem_Vector is new ConfigurationItem_Vectors.Vector with null record;
+
+   type ConfigurationParams is record
+      items: ConfigurationItem_Vector;
+   end record;
+
+   procedure Read_ConfigurationParams
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out ConfigurationParams);
+   procedure Write_ConfigurationParams
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : ConfigurationParams);
+   for ConfigurationParams'Read use Read_ConfigurationParams;
+   for ConfigurationParams'Write use Write_ConfigurationParams;
+
    -----------------------------------------
    -- ALS-specific messages and responses --
    -----------------------------------------

--- a/source/protocol/lsp-messages.ads
+++ b/source/protocol/lsp-messages.ads
@@ -964,20 +964,63 @@ package LSP.Messages is
    for dynamicRegistration'Read use Read_dynamicRegistration;
    for dynamicRegistration'Write use Write_dynamicRegistration;
 
-   type documentChanges is new Optional_Boolean;
-
-   procedure Read_documentChanges
-     (S : access Ada.Streams.Root_Stream_Type'Class;
-      V : out documentChanges);
-
-   procedure Write_documentChanges
-     (S : access Ada.Streams.Root_Stream_Type'Class;
-      V : documentChanges);
-
-   for documentChanges'Read use Read_documentChanges;
-   for documentChanges'Write use Write_documentChanges;
    --
    --```typescript
+   --
+   --/**
+   -- * The kind of resource operations supported by the client.
+   -- */
+   --export type ResourceOperationKind = 'create' | 'rename' | 'delete';
+   --
+   --export namespace ResourceOperationKind {
+   --
+   --	/**
+   --	 * Supports creating new files and folders.
+   --	 */
+   --	export const Create: ResourceOperationKind = 'create';
+   --
+   --	/**
+   --	 * Supports renaming existing files and folders.
+   --	 */
+   --	export const Rename: ResourceOperationKind = 'rename';
+   --
+   --	/**
+   --	 * Supports deleting existing files and folders.
+   --	 */
+   --	export const Delete: ResourceOperationKind = 'delete';
+   --}
+   --
+   --export type FailureHandlingKind = 'abort' | 'transactional' | 'undo' | 'textOnlyTransactional';
+   --
+   --export namespace FailureHandlingKind {
+   --
+   --	/**
+   --	 * Applying the workspace change is simply aborted if one of the changes provided
+   --	 * fails. All operations executed before the failing operation stay executed.
+   --	 */
+   --	export const Abort: FailureHandlingKind = 'abort';
+   --
+   --	/**
+   --	 * All operations are executed transactionally. That means they either all
+   --	 * succeed or no changes at all are applied to the workspace.
+   --	 */
+   --	export const Transactional: FailureHandlingKind = 'transactional';
+   --
+   --
+   --	/**
+   --	 * If the workspace edit contains only textual file changes they are executed transactionally.
+   --	 * If resource changes (create, rename or delete file) are part of the change the failure
+   --	 * handling strategy is abort.
+   --	 */
+   --	export const TextOnlyTransactional: FailureHandlingKind = 'textOnlyTransactional';
+   --
+   --	/**
+   --	 * The client tries to undo the operations already executed. But there is no
+   --	 * guarantee that this succeeds.
+   --	 */
+   --	export const Undo: FailureHandlingKind = 'undo';
+   --}
+   --
    --/**
    -- * Workspace specific client capabilities.
    -- */
@@ -996,6 +1039,18 @@ package LSP.Messages is
    --		 * The client supports versioned document changes in `WorkspaceEdit`s
    --		 */
    --		documentChanges?: boolean;
+   --
+   --		/**
+   --		 * The resource operations the client supports. Clients should at least
+   --		 * support 'create', 'rename' and 'delete' files and folders.
+   --		 */
+   --		resourceOperations?: ResourceOperationKind[];
+   --
+   --		/**
+   --		 * The failure handling strategy of a client if applying the workspace edit
+   --		 * fails.
+   --		 */
+   --		failureHandling?: FailureHandlingKind;
    --	};
    --
    --	/**
@@ -1041,6 +1096,54 @@ package LSP.Messages is
    --	};
    --}
    --```
+
+   type ResourceOperationKind is (create, rename, delete);
+
+   type ResourceOperationKindSet is array (ResourceOperationKind) of Boolean;
+
+   procedure Read_ResourceOperationKindSet
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out ResourceOperationKindSet);
+
+   procedure Write_ResourceOperationKindSet
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : ResourceOperationKindSet);
+
+   for ResourceOperationKindSet'Read use Read_ResourceOperationKindSet;
+   for ResourceOperationKindSet'Write use Write_ResourceOperationKindSet;
+
+   package Optional_ResourceOperationKindSets is
+     new LSP.Generic_Optional (ResourceOperationKindSet);
+
+   type Optional_ResourceOperationKindSet is
+     new Optional_ResourceOperationKindSets.Optional_Type;
+
+   type FailureHandlingKind is
+     (abortApplying,  --  'abort' is reserver word in Ada, so change it
+      transactional, undo, textOnlyTransactional);
+
+   package Optional_FailureHandlingKinds is
+     new LSP.Generic_Optional (FailureHandlingKind);
+
+   type Optional_FailureHandlingKind is
+     new Optional_FailureHandlingKinds.Optional_Type;
+
+   type documentChanges is record
+      documentChanges : Optional_Boolean;
+      resourceOperations : Optional_ResourceOperationKindSet;
+      failureHandling : Optional_FailureHandlingKind;
+   end record;
+
+   procedure Read_documentChanges
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out documentChanges);
+
+   procedure Write_documentChanges
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : documentChanges);
+
+   for documentChanges'Read use Read_documentChanges;
+   for documentChanges'Write use Write_documentChanges;
 
    type WorkspaceClientCapabilities is record
       applyEdit: Optional_Boolean;

--- a/source/protocol/lsp-messages.ads
+++ b/source/protocol/lsp-messages.ads
@@ -5469,6 +5469,101 @@ package LSP.Messages is
    for ConfigurationParams'Read use Read_ConfigurationParams;
    for ConfigurationParams'Write use Write_ConfigurationParams;
 
+   --```typescript
+   --/**
+   -- * Describe options to be used when registering for file system change events.
+   -- */
+   --export interface DidChangeWatchedFilesRegistrationOptions {
+   --	/**
+   --	 * The watchers to register.
+   --	 */
+   --	watchers: FileSystemWatcher[];
+   --}
+   --
+   --export interface FileSystemWatcher {
+   --	/**
+   --	 * The  glob pattern to watch.
+   --	 *
+   --	 * Glob patterns can have the following syntax:
+   --	 * - `*` to match one or more characters in a path segment
+   --	 * - `?` to match on one character in a path segment
+   --	 * - `**` to match any number of path segments, including none
+   --	 * - `{}` to group conditions (e.g. `**​/*.{ts,js}` matches all TypeScript and JavaScript files)
+   --	 * - `[]` to declare a range of characters to match in a path segment (e.g., `example.[0-9]` to match on `example.0`, `example.1`, …)
+   --	 * - `[!...]` to negate a range of characters to match in a path segment (e.g., `example.[!0-9]` to match on `example.a`, `example.b`, but not `example.0`)
+   --	 */
+   --	globPattern: string;
+   --
+   --	/**
+   --	 * The kind of events of interest. If omitted it defaults
+   --	 * to WatchKind.Create | WatchKind.Change | WatchKind.Delete
+   --	 * which is 7.
+   --	 */
+   --	kind?: number;
+   --}
+   --
+   --export namespace WatchKind {
+   --	/**
+   --	 * Interested in create events.
+   --	 */
+   --	export const Create = 1;
+   --
+   --	/**
+   --	 * Interested in change events
+   --	 */
+   --	export const Change = 2;
+   --
+   --	/**
+   --	 * Interested in delete events
+   --	 */
+   --	export const Delete = 4;
+   --}
+   --```
+
+   type WatchKind is (Create, Change, Delete);
+   type WatchKind_Set is array (WatchKind) of Boolean;
+
+   procedure Read_WatchKind_Set
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out WatchKind_Set);
+   procedure Write_WatchKind_Set
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : WatchKind_Set);
+   for WatchKind_Set'Read use Read_WatchKind_Set;
+   for WatchKind_Set'Write use Write_WatchKind_Set;
+
+   Default_WatchKind_Set : constant WatchKind_Set := (WatchKind => True);
+
+   type FileSystemWatcher is record
+      globPattern: LSP_String;
+      kind: WatchKind_Set;
+   end record;
+
+   procedure Read_FileSystemWatcher
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out FileSystemWatcher);
+   procedure Write_FileSystemWatcher
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : FileSystemWatcher);
+   for FileSystemWatcher'Read use Read_FileSystemWatcher;
+   for FileSystemWatcher'Write use Write_FileSystemWatcher;
+
+   package FileSystemWatcher_Vectors is new LSP.Generic_Vectors (FileSystemWatcher);
+   type FileSystemWatcher_Vector is new FileSystemWatcher_Vectors.Vector with null record;
+
+   type DidChangeWatchedFilesRegistrationOptions is record
+      watchers: FileSystemWatcher_Vector;
+   end record;
+
+   procedure Read_DidChangeWatchedFilesRegistrationOptions
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out DidChangeWatchedFilesRegistrationOptions);
+   procedure Write_DidChangeWatchedFilesRegistrationOptions
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : DidChangeWatchedFilesRegistrationOptions);
+   for DidChangeWatchedFilesRegistrationOptions'Read use Read_DidChangeWatchedFilesRegistrationOptions;
+   for DidChangeWatchedFilesRegistrationOptions'Write use Write_DidChangeWatchedFilesRegistrationOptions;
+
    -----------------------------------------
    -- ALS-specific messages and responses --
    -----------------------------------------

--- a/source/protocol/lsp-messages.ads
+++ b/source/protocol/lsp-messages.ads
@@ -1918,6 +1918,28 @@ package LSP.Messages is
    --		 */
    --		relatedInformation?: boolean;
    --	};
+   --	/**
+   --	 * Capabilities specific to `textDocument/foldingRange` requests.
+   --	 *
+   --	 * Since 3.10.0
+   --	 */
+   --	foldingRange?: {
+   --		/**
+   --		 * Whether implementation supports dynamic registration for folding range providers. If this is set to `true`
+   --		 * the client supports the new `(FoldingRangeProviderOptions & TextDocumentRegistrationOptions & StaticRegistrationOptions)`
+   --		 * return value for the corresponding server capability as well.
+   --		 */
+   --		dynamicRegistration?: boolean;
+   --		/**
+   --		 * The maximum number of folding ranges that the client prefers to receive per document. The value serves as a
+   --		 * hint, servers are free to follow the limit.
+   --		 */
+   --		rangeLimit?: number;
+   --		/**
+   --		 * If set, the client signals that it only supports folding complete lines. If set, client will
+   --		 * ignore specified `startCharacter` and `endCharacter` properties in a FoldingRange.
+   --		 */
+   --		lineFoldingOnly?: boolean;
    --	};
    --}
    --```
@@ -2259,6 +2281,29 @@ package LSP.Messages is
    type Optional_publishDiagnostics_Capability is
      new Optional_publishDiagnostics_Capabilities.Optional_Type;
 
+   type foldingRange_Capability is record
+      dynamicRegistration: Optional_Boolean;
+      rangeLimit: Optional_Number;
+      lineFoldingOnly: Optional_Boolean;
+   end record;
+
+   procedure Read_foldingRange_Capability
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out foldingRange_Capability);
+
+   procedure Write_foldingRange_Capability
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : foldingRange_Capability);
+
+   for foldingRange_Capability'Read use Read_foldingRange_Capability;
+   for foldingRange_Capability'Write use Write_foldingRange_Capability;
+
+   package Optional_foldingRange_Capabilities is
+     new LSP.Generic_Optional (foldingRange_Capability);
+
+   type Optional_foldingRange_Capability is
+     new Optional_foldingRange_Capabilities.Optional_Type;
+
    type TextDocumentClientCapabilities is record
       synchronization    : LSP.Messages.synchronization;
       completion         : LSP.Messages.completion;
@@ -2280,6 +2325,7 @@ package LSP.Messages is
       colorProvider      : dynamicRegistration;
       rename             : Optional_rename_Capability;
       publishDiagnostics : Optional_publishDiagnostics_Capability;
+      foldingRange       : Optional_foldingRange_Capability;
    end record;
 
    procedure Read_TextDocumentClientCapabilities

--- a/source/protocol/lsp-messages.ads
+++ b/source/protocol/lsp-messages.ads
@@ -5794,6 +5794,75 @@ package LSP.Messages is
    for ColorInformation'Read use Read_ColorInformation;
    for ColorInformation'Write use Write_ColorInformation;
 
+   --```typescript
+   --interface ColorPresentationParams {
+   --	/**
+   --	 * The text document.
+   --	 */
+   --	textDocument: TextDocumentIdentifier;
+   --
+   --	/**
+   --	 * The color information to request presentations for.
+   --	 */
+   --	color: Color;
+   --
+   --	/**
+   --	 * The range where the color would be inserted. Serves as a context.
+   --	 */
+   --	range: Range;
+   --}
+   --```
+   type ColorPresentationParams is record
+      textDocument: TextDocumentIdentifier;
+      color: RGBA_Color;
+      span: LSP.Messages.Span;  --  Range is reservet keyword
+   end record;
+
+   procedure Read_ColorPresentationParams
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out ColorPresentationParams);
+   procedure Write_ColorPresentationParams
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : ColorPresentationParams);
+   for ColorPresentationParams'Read use Read_ColorPresentationParams;
+   for ColorPresentationParams'Write use Write_ColorPresentationParams;
+
+   --```typescript
+   --interface ColorPresentation {
+   --	/**
+   --	 * The label of this color presentation. It will be shown on the color
+   --	 * picker header. By default this is also the text that is inserted when selecting
+   --	 * this color presentation.
+   --	 */
+   --	label: string;
+   --	/**
+   --	 * An [edit](#TextEdit) which is applied to a document when selecting
+   --	 * this presentation for the color.  When `falsy` the [label](#ColorPresentation.label)
+   --	 * is used.
+   --	 */
+   --	textEdit?: TextEdit;
+   --	/**
+   --	 * An optional array of additional [text edits](#TextEdit) that are applied when
+   --	 * selecting this color presentation. Edits must not overlap with the main [edit](#ColorPresentation.textEdit) nor with themselves.
+   --	 */
+   --	additionalTextEdits?: TextEdit[];
+   --}
+   --```
+   type ColorPresentation is record
+      label: LSP_String;
+      textEdit: Optional_TextEdit;
+      additionalTextEdits: TextEdit_Vector;
+   end record;
+
+   procedure Read_ColorPresentation
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out ColorPresentation);
+   procedure Write_ColorPresentation
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : ColorPresentation);
+   for ColorPresentation'Read use Read_ColorPresentation;
+   for ColorPresentation'Write use Write_ColorPresentation;
+
    -----------------------------------------
    -- ALS-specific messages and responses --
    -----------------------------------------

--- a/source/protocol/lsp-messages.ads
+++ b/source/protocol/lsp-messages.ads
@@ -5875,6 +5875,103 @@ package LSP.Messages is
       prepareProvider: Optional_Boolean;
    end record;
 
+   --```typescript
+   --export interface FoldingRangeParams {
+   --	/**
+   --	 * The text document.
+   --	 */
+   --	textDocument: TextDocumentIdentifier;
+   --}
+   --
+   --```
+   type FoldingRangeParams is record
+      textDocument: TextDocumentIdentifier;
+   end record;
+
+   procedure Read_FoldingRangeParams
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out FoldingRangeParams);
+   procedure Write_FoldingRangeParams
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : FoldingRangeParams);
+   for FoldingRangeParams'Read use Read_FoldingRangeParams;
+   for FoldingRangeParams'Write use Write_FoldingRangeParams;
+
+   --```typescript
+   --/**
+   -- * Enum of known range kinds
+   -- */
+   --export enum FoldingRangeKind {
+   --	/**
+   --	 * Folding range for a comment
+   --	 */
+   --	Comment = 'comment',
+   --	/**
+   --	 * Folding range for a imports or includes
+   --	 */
+   --	Imports = 'imports',
+   --	/**
+   --	 * Folding range for a region (e.g. `#region`)
+   --	 */
+   --	Region = 'region'
+   --}
+   --
+   --/**
+   -- * Represents a folding range.
+   -- */
+   --export interface FoldingRange {
+   --
+   --	/**
+   --	 * The zero-based line number from where the folded range starts.
+   --	 */
+   --	startLine: number;
+   --
+   --	/**
+   --	 * The zero-based character offset from where the folded range starts. If not defined, defaults to the length of the start line.
+   --	 */
+   --	startCharacter?: number;
+   --
+   --	/**
+   --	 * The zero-based line number where the folded range ends.
+   --	 */
+   --	endLine: number;
+   --
+   --	/**
+   --	 * The zero-based character offset before the folded range ends. If not defined, defaults to the length of the end line.
+   --	 */
+   --	endCharacter?: number;
+   --
+   --	/**
+   --	 * Describes the kind of the folding range such as `comment' or 'region'. The kind
+   --	 * is used to categorize folding ranges and used by commands like 'Fold all comments'. See
+   --	 * [FoldingRangeKind](#FoldingRangeKind) for an enumeration of standardized kinds.
+   --	 */
+   --	kind?: string;
+   --}
+   --```
+   type FoldingRange is record
+      startLine: LSP_Number;
+      startCharacter: Optional_Number;
+      endLine: LSP_Number;
+      endCharacter: Optional_Number;
+      kind: Optional_String;
+   end record;
+
+   procedure Read_FoldingRange
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out FoldingRange);
+   procedure Write_FoldingRange
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : FoldingRange);
+   for FoldingRange'Read use Read_FoldingRange;
+   for FoldingRange'Write use Write_FoldingRange;
+
+   subtype FoldingRangeKind is LSP_String;
+
+   Comment : constant FoldingRangeKind := LSP.Types.To_LSP_String ("comment");
+   Imports : constant FoldingRangeKind := LSP.Types.To_LSP_String ("imports");
+   Region  : constant FoldingRangeKind := LSP.Types.To_LSP_String ("region");
+
    -----------------------------------------
    -- ALS-specific messages and responses --
    -----------------------------------------

--- a/source/protocol/lsp-messages.ads
+++ b/source/protocol/lsp-messages.ads
@@ -1635,6 +1635,8 @@ package LSP.Messages is
    --				/**
    --				 * The client supports processing label offsets instead of a
    --				 * simple label string.
+   --				 *
+   --				 * Since 3.14.0
    --				 */
    --				labelOffsetSupport?: boolean;
    --			}
@@ -1752,18 +1754,54 @@ package LSP.Messages is
    --		 * Whether definition supports dynamic registration.
    --		 */
    --		dynamicRegistration?: boolean;
+   --
+   --		/**
+   --		 * The client supports additional metadata in the form of definition links.
+   --		 */
+   --		linkSupport?: boolean;
    --	};
    --
    --	/**
    --	 * Capabilities specific to the `textDocument/typeDefinition`
+   --	 *
+   --	 * Since 3.6.0
    --	 */
-   --  	typeDefinition?: {
-   --  		/**
-   --  		 * Whether typeDefinition supports dynamic registration.
-   --            */
-   --  		dynamicRegistration?: boolean;
-   --  	};
+   --	typeDefinition?: {
+   --		/**
+   --		 * Whether typeDefinition supports dynamic registration. If this is set to `true`
+   --		 * the client supports the new `(TextDocumentRegistrationOptions & StaticRegistrationOptions)`
+   --		 * return value for the corresponding server capability as well.
+   --		 */
+   --		dynamicRegistration?: boolean;
    --
+   --		/**
+   --		 * The client supports additional metadata in the form of definition links.
+   --		 *
+   --		 * Since 3.14.0
+   --		 */
+   --		linkSupport?: boolean;
+   --	};
+   --
+   --	/**
+   --	 * Capabilities specific to the `textDocument/implementation`.
+   --	 *
+   --	 * Since 3.6.0
+   --	 */
+   --	implementation?: {
+   --		/**
+   --		 * Whether implementation supports dynamic registration. If this is set to `true`
+   --		 * the client supports the new `(TextDocumentRegistrationOptions & StaticRegistrationOptions)`
+   --		 * return value for the corresponding server capability as well.
+   --		 */
+   --		dynamicRegistration?: boolean;
+   --
+   --		/**
+   --		 * The client supports additional metadata in the form of definition links.
+   --		 *
+   --		 * Since 3.14.0
+   --		 */
+   --		linkSupport?: boolean;
+   --	};
    --
    --	/**
    --	 * Capabilities specific to the `textDocument/codeAction`
@@ -2052,6 +2090,12 @@ package LSP.Messages is
    type Optional_declaration_Capability is
      new Optional_declaration_Capabilities.Optional_Type;
 
+   subtype Optional_definition_Capability is Optional_declaration_Capability;
+   subtype Optional_typeDefinition_Capability is
+     Optional_declaration_Capability;
+   subtype Optional_implementation_Capability is
+     Optional_declaration_Capability;
+
    type TextDocumentClientCapabilities is record
       synchronization   : LSP.Messages.synchronization;
       completion        : LSP.Messages.completion;
@@ -2064,8 +2108,9 @@ package LSP.Messages is
       rangeFormatting   : dynamicRegistration;
       onTypeFormatting  : dynamicRegistration;
       declaration       : Optional_declaration_Capability;
-      definition        : dynamicRegistration;
-      typeDefinition    : dynamicRegistration;
+      definition        : Optional_definition_Capability;
+      typeDefinition    : Optional_typeDefinition_Capability;
+      implementation    : Optional_implementation_Capability;
       codeAction        : dynamicRegistration;
       codeLens          : dynamicRegistration;
       documentLink      : dynamicRegistration;

--- a/source/protocol/lsp-messages.ads
+++ b/source/protocol/lsp-messages.ads
@@ -3385,6 +3385,18 @@ package LSP.Messages is
    --	triggerCharacters?: string[];
    --
    --	/**
+   --	 * The list of all possible characters that commit a completion. This field can be used
+   --	 * if clients don't support individual commmit characters per completion item. See
+   --	 * `ClientCapabilities.textDocument.completion.completionItem.commitCharactersSupport`.
+   --	 *
+   --	 * If a server provides both `allCommitCharacters` and commit characters on an individual
+   --	 * completion item the ones on the completion item win.
+   --	 *
+   --     * Since 3.2.0
+   --	 */
+   --	allCommitCharacters?: string[];
+   --
+   --	/**
    --	 * The server provides support to resolve additional
    --	 * information for a completion item.
    --	 */
@@ -3393,6 +3405,7 @@ package LSP.Messages is
    --```
    type CompletionRegistrationOptions is new TextDocumentRegistrationOptions with record
       triggerCharacters: LSP_String_Vector;
+      allCommitCharacters: LSP_String_Vector;
       resolveProvider: Optional_Boolean;
    end record;
 

--- a/source/protocol/lsp-types.ads
+++ b/source/protocol/lsp-types.ads
@@ -106,6 +106,25 @@ package LSP.Types is
    function To_UTF_8_String (Item : LSP.Types.LSP_Number_Or_String)
       return Ada.Strings.UTF_Encoding.UTF_8_String;
 
+   type LSP_Boolean_Or_String (Is_Boolean : Boolean := False) is record
+      case Is_Boolean is
+         when True =>
+            Boolean : Standard.Boolean;
+         when False =>
+            String : LSP_String;
+      end case;
+   end record;
+
+   procedure Read_LSP_Boolean_Or_String
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out LSP_Boolean_Or_String);
+
+   procedure Write_LSP_Boolean_Or_String
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : LSP_Boolean_Or_String);
+   for LSP_Boolean_Or_String'Read use Read_LSP_Boolean_Or_String;
+   for LSP_Boolean_Or_String'Write use Write_LSP_Boolean_Or_String;
+
    type Line_Number is new Natural;
    --  Line number. In LSP first line has zero number
    type UTF_16_Index is new Natural;

--- a/source/server/generated/lsp-server_request_handlers.ads
+++ b/source/server/generated/lsp-server_request_handlers.ads
@@ -99,4 +99,9 @@ package LSP.Server_Request_Handlers is
       Request : LSP.Messages.Server_Requests.ALS_Debug_Request)
       return LSP.Messages.Server_Responses.ALS_Debug_Response is abstract;
 
+   procedure Handle_Error
+     (Self  : access Server_Request_Handler) is null;
+   --  This procedure will be called when an unexpected error is raised in the
+   --  request processing loop.
+
 end LSP.Server_Request_Handlers;

--- a/source/server/lsp-message_loggers.adb
+++ b/source/server/lsp-message_loggers.adb
@@ -558,10 +558,15 @@ package body LSP.Message_Loggers is
          return;
       end if;
 
-      Self.Trace.Trace
-        ("Hover_Response: "
-         & Image (Value)
-         & Ada.Containers.Count_Type'Image (Value.result.contents.Length));
+      if Value.result.contents.Is_MarkupContent then
+         Self.Trace.Trace ("Hover_Response: " & Image (Value));
+      else
+         Self.Trace.Trace
+           ("Hover_Response: "
+            & Image (Value)
+            & Ada.Containers.Count_Type'Image
+              (Value.result.contents.Vector.Length));
+      end if;
    end On_Hover_Response;
 
    ---------------------------

--- a/source/server/lsp-server_backends.ads
+++ b/source/server/lsp-server_backends.ads
@@ -1,0 +1,37 @@
+------------------------------------------------------------------------------
+--                         Language Server Protocol                         --
+--                                                                          --
+--                        Copyright (C) 2019, AdaCore                       --
+--                                                                          --
+-- This is free software;  you can redistribute it  and/or modify it  under --
+-- terms of the  GNU General Public License as published  by the Free Soft- --
+-- ware  Foundation;  either version 3,  or (at your option) any later ver- --
+-- sion.  This software is distributed in the hope  that it will be useful, --
+-- but WITHOUT ANY WARRANTY;  without even the implied warranty of MERCHAN- --
+-- TABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public --
+-- License for  more details.  You should have  received  a copy of the GNU --
+-- General  Public  License  distributed  with  this  software;   see  file --
+-- COPYING3.  If not, go to http://www.gnu.org/licenses for a complete copy --
+-- of the license.                                                          --
+------------------------------------------------------------------------------
+
+--  Define an interface for server backends
+
+with LSP.Messages;
+
+package LSP.Server_Backends is
+
+   type Server_Backend is limited interface;
+   type Server_Backend_Access is access all Server_Backend'Class;
+
+   procedure Before_Work
+     (Self    : access Server_Backend;
+      Message : LSP.Messages.Message'Class) is abstract;
+   --  Called before working on Message
+
+   procedure After_Work
+     (Self    : access Server_Backend;
+      Message : LSP.Messages.Message'Class) is abstract;
+   --  Called after working on Message
+
+end LSP.Server_Backends;

--- a/source/server/lsp-servers.ads
+++ b/source/server/lsp-servers.ads
@@ -27,6 +27,7 @@ with LSP.Message_Loggers;
 with LSP.Messages;
 with LSP.Server_Request_Handlers;
 with LSP.Server_Notification_Receivers;
+with LSP.Server_Backends;
 with LSP.Types;
 
 with GNATCOLL.Traces;
@@ -65,6 +66,7 @@ package LSP.Servers is
         LSP.Server_Request_Handlers.Server_Request_Handler_Access;
       Notification : not null
         LSP.Server_Notification_Receivers.Server_Notification_Receiver_Access;
+      Server       : not null LSP.Server_Backends.Server_Backend_Access;
       On_Error     : not null Uncaught_Exception_Handler;
       Server_Trace : GNATCOLL.Traces.Trace_Handle;
       In_Trace     : GNATCOLL.Traces.Trace_Handle;
@@ -81,11 +83,16 @@ package LSP.Servers is
 
    function Look_Ahead_Message (Self : Server) return Message_Access;
    --  Get next nessage in the queue if any. Only request/notification
-   --  handlers are alloved to call this function.
+   --  handlers are allowed to call this function.
 
    function Input_Queue_Length (Self : Server) return Natural;
    --  Return number of messages pending in Input_Queue.
    --  For debug purposes only!
+
+   function Has_Pending_Work (Self : Server) return Boolean;
+   --  Return True if the server has work in the queue, other than the
+   --  notification/request it's currently processing. This should only be
+   --  called from the processing task.
 
 private
 
@@ -149,7 +156,8 @@ private
         (Request      : not null LSP.Server_Request_Handlers
            .Server_Request_Handler_Access;
          Notification : not null LSP.Server_Notification_Receivers
-           .Server_Notification_Receiver_Access);
+         .Server_Notification_Receiver_Access;
+         Server       : not null LSP.Server_Backends.Server_Backend_Access);
       entry Stop;
       --  Clean shutdown of the task
    end Processing_Task_Type;

--- a/testsuite/ada_lsp/C825-005.xrefs.extending/test.json
+++ b/testsuite/ada_lsp/C825-005.xrefs.extending/test.json
@@ -35,7 +35,7 @@
                      "typeDefinitionProvider": true,
                      "hoverProvider": true,
                      "definitionProvider": true,
-                     "renameProvider": true,
+                     "renameProvider": {},
                      "alsCalledByProvider": true,
                      "referencesProvider": true,
                      "textDocumentSync": 1,

--- a/testsuite/ada_lsp/D301-004.xrefs.generics/test.json
+++ b/testsuite/ada_lsp/D301-004.xrefs.generics/test.json
@@ -35,7 +35,7 @@
                      "typeDefinitionProvider": true,
                      "hoverProvider": true,
                      "definitionProvider": true,
-                     "renameProvider": true,
+                     "renameProvider": {},
                      "alsCalledByProvider": true,
                      "referencesProvider": true,
                      "textDocumentSync": 1,

--- a/testsuite/ada_lsp/D803-003.xrefs.generics_go_to_body/test.json
+++ b/testsuite/ada_lsp/D803-003.xrefs.generics_go_to_body/test.json
@@ -35,7 +35,7 @@
                      "typeDefinitionProvider": true,
                      "hoverProvider": true,
                      "definitionProvider": true,
-                     "renameProvider": true,
+                     "renameProvider": {},
                      "alsCalledByProvider": true,
                      "referencesProvider": true,
                      "textDocumentSync": 1,

--- a/testsuite/ada_lsp/F131-024.xrefs.separate_body/test.json
+++ b/testsuite/ada_lsp/F131-024.xrefs.separate_body/test.json
@@ -40,7 +40,7 @@
                      ],
                      "hoverProvider": true,
                      "definitionProvider": true,
-                     "renameProvider": true,
+                     "renameProvider": {},
                      "alsCalledByProvider": true,
                      "referencesProvider": true,
                      "textDocumentSync": 1,

--- a/testsuite/ada_lsp/F222-029.xrefs.prefixed_notation/test.json
+++ b/testsuite/ada_lsp/F222-029.xrefs.prefixed_notation/test.json
@@ -35,7 +35,7 @@
                      "typeDefinitionProvider": true,
                      "hoverProvider": true,
                      "definitionProvider": true,
-                     "renameProvider": true,
+                     "renameProvider": {},
                      "alsCalledByProvider": true,
                      "referencesProvider": true,
                      "textDocumentSync": 1,

--- a/testsuite/ada_lsp/G323-009.tooltips.function_prototype/test.json
+++ b/testsuite/ada_lsp/G323-009.tooltips.function_prototype/test.json
@@ -40,7 +40,7 @@
                      ],
                      "hoverProvider": true,
                      "definitionProvider": true,
-                     "renameProvider": true,
+                     "renameProvider": {},
                      "alsCalledByProvider": true,
                      "referencesProvider": true,
                      "textDocumentSync": 1,

--- a/testsuite/ada_lsp/JB24-033.xrefs.no_refs_for_non_loaded_projects/test.json
+++ b/testsuite/ada_lsp/JB24-033.xrefs.no_refs_for_non_loaded_projects/test.json
@@ -35,7 +35,7 @@
                      "typeDefinitionProvider": true,
                      "hoverProvider": true,
                      "definitionProvider": true,
-                     "renameProvider": true,
+                     "renameProvider": {},
                      "alsCalledByProvider": true,
                      "referencesProvider": true,
                      "textDocumentSync": 1,

--- a/testsuite/ada_lsp/O208-003.xrefs.aggregate_library_projects/test.json
+++ b/testsuite/ada_lsp/O208-003.xrefs.aggregate_library_projects/test.json
@@ -35,7 +35,7 @@
                      "typeDefinitionProvider": true,
                      "hoverProvider": true,
                      "definitionProvider": true,
-                     "renameProvider": true,
+                     "renameProvider": {},
                      "alsCalledByProvider": true,
                      "referencesProvider": true,
                      "textDocumentSync": 1,

--- a/testsuite/ada_lsp/P107-003.refactoring.underscores/test.json
+++ b/testsuite/ada_lsp/P107-003.refactoring.underscores/test.json
@@ -35,7 +35,7 @@
                      "typeDefinitionProvider": true,
                      "hoverProvider": true,
                      "definitionProvider": true,
-                     "renameProvider": true,
+                     "renameProvider": {},
                      "alsCalledByProvider": true,
                      "referencesProvider": true,
                      "textDocumentSync": 1,

--- a/testsuite/ada_lsp/P429-023.refactoring.rename_clauses/test.json
+++ b/testsuite/ada_lsp/P429-023.refactoring.rename_clauses/test.json
@@ -35,7 +35,7 @@
                      "typeDefinitionProvider": true,
                      "hoverProvider": true,
                      "definitionProvider": true,
-                     "renameProvider": true,
+                     "renameProvider": {},
                      "alsCalledByProvider": true,
                      "referencesProvider": true,
                      "textDocumentSync": 1,

--- a/testsuite/ada_lsp/QB01-002.xrefs.non_ascii_documentation/test.json
+++ b/testsuite/ada_lsp/QB01-002.xrefs.non_ascii_documentation/test.json
@@ -35,7 +35,7 @@
                      "typeDefinitionProvider": true,
                      "hoverProvider": true,
                      "definitionProvider": true,
-                     "renameProvider": true,
+                     "renameProvider": {},
                      "alsCalledByProvider": true,
                      "referencesProvider": true,
                      "textDocumentSync": 1,

--- a/testsuite/ada_lsp/S820-016.called_by.entry/test.json
+++ b/testsuite/ada_lsp/S820-016.called_by.entry/test.json
@@ -39,7 +39,7 @@
                      ], 
                      "hoverProvider": true, 
                      "definitionProvider": true, 
-                     "renameProvider": true, 
+                     "renameProvider": {}, 
                      "alsCalledByProvider": true, 
                      "referencesProvider": true, 
                      "textDocumentSync": 1, 

--- a/testsuite/ada_lsp/SA11-040.definition.fallback/test.json
+++ b/testsuite/ada_lsp/SA11-040.definition.fallback/test.json
@@ -39,7 +39,7 @@
                      ], 
                      "hoverProvider": true, 
                      "definitionProvider": true, 
-                     "renameProvider": true, 
+                     "renameProvider": {}, 
                      "alsCalledByProvider": true, 
                      "referencesProvider": true, 
                      "textDocumentSync": 1, 

--- a/testsuite/ada_lsp/SA22-029.rename_in_comments/hello.gpr
+++ b/testsuite/ada_lsp/SA22-029.rename_in_comments/hello.gpr
@@ -1,0 +1,7 @@
+project Hello is
+
+   for Source_Dirs use (".");
+   for Main use ("main.adb");
+
+ end Hello;
+

--- a/testsuite/ada_lsp/SA22-029.rename_in_comments/main.adb
+++ b/testsuite/ada_lsp/SA22-029.rename_in_comments/main.adb
@@ -1,0 +1,18 @@
+
+with Ada.Text_IO;
+with P1;
+
+procedure Main is
+   List : P1.P_Rec;
+begin
+   List.Flag := False;
+   List.Count := 1;
+
+   Ada.Text_IO.Put_Line ("Hello");
+
+   Ada.Text_IO.Put_Line ("Hello1");
+
+   Ada.Text_IO.Put_Line ("Hello2");
+
+   Ada.Text_IO.Put_Line (List.Count'Img);
+end Main;

--- a/testsuite/ada_lsp/SA22-029.rename_in_comments/p.adb
+++ b/testsuite/ada_lsp/SA22-029.rename_in_comments/p.adb
@@ -1,0 +1,11 @@
+
+with Ada.Text_IO;
+
+package body P is
+
+   procedure Print (S : T) is
+   begin
+      Ada.Text_IO.Put_Line ("T");
+   end Print;
+
+end P;

--- a/testsuite/ada_lsp/SA22-029.rename_in_comments/p.ads
+++ b/testsuite/ada_lsp/SA22-029.rename_in_comments/p.ads
@@ -1,0 +1,16 @@
+
+package P is
+
+   type T is tagged null record;
+
+   ------------
+   --  Print --
+   ------------
+
+   procedure Print (S : T);
+
+   ------------
+   --  Print --
+   ------------
+
+end P;

--- a/testsuite/ada_lsp/SA22-029.rename_in_comments/p1.adb
+++ b/testsuite/ada_lsp/SA22-029.rename_in_comments/p1.adb
@@ -1,0 +1,11 @@
+
+with P;
+
+package body P1 is
+   procedure Print is
+      S : P.T;
+   begin
+      P.Print (S);
+   end Print;
+
+end P1;

--- a/testsuite/ada_lsp/SA22-029.rename_in_comments/p1.ads
+++ b/testsuite/ada_lsp/SA22-029.rename_in_comments/p1.ads
@@ -1,0 +1,10 @@
+
+package P1 is
+
+   type P_Rec is record
+      Flag  : Boolean;
+      Count : Integer;
+   end record;
+
+   procedure Print;
+end P1;

--- a/testsuite/ada_lsp/SA22-029.rename_in_comments/test.json
+++ b/testsuite/ada_lsp/SA22-029.rename_in_comments/test.json
@@ -1,0 +1,251 @@
+[
+   {
+      "comment": [
+         "test automatically generated"
+      ]
+   }, 
+   {
+      "start": {
+         "cmd": [
+            "${ALS}"
+         ]
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "capabilities": {
+                  "workspace": {
+                     "applyEdit": false
+                  }
+               }, 
+               "rootUri": "$URI{.}"
+            }, 
+            "jsonrpc": "2.0", 
+            "id": 1, 
+            "method": "initialize"
+         }, 
+         "wait": [
+            {
+               "id": 1, 
+               "result": {
+                  "capabilities": {
+                     "typeDefinitionProvider": true, 
+                     "alsReferenceKinds": [
+                        "write", 
+                        "call", 
+                        "dispatching call"
+                     ], 
+                     "hoverProvider": true, 
+                     "definitionProvider": true, 
+                     "renameProvider": {}, 
+                     "alsCalledByProvider": true, 
+                     "referencesProvider": true, 
+                     "textDocumentSync": 1, 
+                     "completionProvider": {
+                        "triggerCharacters": [
+                           "."
+                        ], 
+                        "resolveProvider": false
+                     }, 
+                     "documentSymbolProvider": true
+                  }
+               }
+            }
+         ]
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0", 
+            "method": "initialized"
+         }, 
+         "wait": []
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "settings": {
+                  "ada": {
+                     "scenarioVariables": {}, 
+                     "enableDiagnostics": false, 
+                     "defaultCharset": "ISO-8859-1"
+                  }
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "method": "workspace/didChangeConfiguration"
+         }, 
+         "wait": []
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "text": "\npackage P is\n\n   type T is tagged null record;\n\n   ------------\n   --  Print --\n   ------------\n\n   procedure Print (S : T);\n\n   ------------\n   --  Print --\n   ------------\n\nend P;\n", 
+                  "version": 0, 
+                  "uri": "$URI{p.ads}", 
+                  "languageId": "Ada"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "method": "textDocument/didOpen"
+         }, 
+         "wait": []
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "settings": {
+                  "ada": {
+                     "renameInComments": true
+                  }
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "method": "workspace/didChangeConfiguration"
+         }, 
+         "wait": []
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "newName": "Print1", 
+               "position": {
+                  "line": 9, 
+                  "character": 16
+               }, 
+               "textDocument": {
+                  "uri": "$URI{p.ads}"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "id": 2, 
+            "method": "textDocument/rename"
+         }, 
+         "wait": [
+            {
+               "id": 2, 
+               "result": {
+                  "changes": {
+                     "$URI{p.adb}": [
+                        {
+                           "newText": "Print1", 
+                           "range": {
+                              "start": {
+                                 "line": 5, 
+                                 "character": 13
+                              }, 
+                              "end": {
+                                 "line": 5, 
+                                 "character": 18
+                              }
+                           }
+                        }, 
+                        {
+                           "newText": "Print1", 
+                           "range": {
+                              "start": {
+                                 "line": 8, 
+                                 "character": 7
+                              }, 
+                              "end": {
+                                 "line": 8, 
+                                 "character": 12
+                              }
+                           }
+                        }
+                     ], 
+                     "$URI{p.ads}": [
+                        {
+                           "newText": "Print1", 
+                           "range": {
+                              "start": {
+                                 "line": 6, 
+                                 "character": 7
+                              }, 
+                              "end": {
+                                 "line": 6, 
+                                 "character": 18
+                              }
+                           }
+                        }, 
+                        {
+                           "newText": "Print1", 
+                           "range": {
+                              "start": {
+                                 "line": 12, 
+                                 "character": 7
+                              }, 
+                              "end": {
+                                 "line": 12, 
+                                 "character": 18
+                              }
+                           }
+                        }, 
+                        {
+                           "newText": "Print1", 
+                           "range": {
+                              "start": {
+                                 "line": 9, 
+                                 "character": 13
+                              }, 
+                              "end": {
+                                 "line": 9, 
+                                 "character": 18
+                              }
+                           }
+                        }
+                     ], 
+                     "$URI{p1.adb}": [
+                        {
+                           "newText": "Print1", 
+                           "range": {
+                              "start": {
+                                 "line": 7, 
+                                 "character": 8
+                              }, 
+                              "end": {
+                                 "line": 7, 
+                                 "character": 13
+                              }
+                           }
+                        }
+                     ]
+                  }
+               }
+            }
+         ]
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0", 
+            "id": 3, 
+            "method": "shutdown"
+         }, 
+         "wait": [
+            {
+               "id": 3, 
+               "result": null
+            }
+         ]
+      }
+   }, 
+   {
+      "stop": {
+         "exit_code": 0
+      }
+   }
+]

--- a/testsuite/ada_lsp/SA22-029.rename_in_comments/test.yaml
+++ b/testsuite/ada_lsp/SA22-029.rename_in_comments/test.yaml
@@ -1,0 +1,1 @@
+title: 'SA22-029.rename_in_comments'

--- a/testsuite/ada_lsp/SA24-055.called_by_on_abstract/test.json
+++ b/testsuite/ada_lsp/SA24-055.called_by_on_abstract/test.json
@@ -39,7 +39,7 @@
                      ], 
                      "hoverProvider": true, 
                      "definitionProvider": true, 
-                     "renameProvider": true, 
+                     "renameProvider": {}, 
                      "alsCalledByProvider": true, 
                      "referencesProvider": true, 
                      "textDocumentSync": 1, 

--- a/testsuite/ada_lsp/aggregate.simple/test.json
+++ b/testsuite/ada_lsp/aggregate.simple/test.json
@@ -39,7 +39,7 @@
                      ], 
                      "hoverProvider": true, 
                      "definitionProvider": true, 
-                     "renameProvider": true, 
+                     "renameProvider": {}, 
                      "alsCalledByProvider": true, 
                      "referencesProvider": true, 
                      "textDocumentSync": 1, 

--- a/testsuite/ada_lsp/called_by.null_subp/called_by.null_subp.json
+++ b/testsuite/ada_lsp/called_by.null_subp/called_by.null_subp.json
@@ -36,7 +36,7 @@
                      "typeDefinitionProvider": true, 
                      "hoverProvider": true, 
                      "definitionProvider": true, 
-                     "renameProvider": true, 
+                     "renameProvider": {}, 
                      "alsCalledByProvider": true, 
                      "referencesProvider": true, 
                      "textDocumentSync": 1, 

--- a/testsuite/ada_lsp/called_by_dispatching/test.json
+++ b/testsuite/ada_lsp/called_by_dispatching/test.json
@@ -40,7 +40,7 @@
                      ], 
                      "hoverProvider": true, 
                      "definitionProvider": true, 
-                     "renameProvider": true, 
+                     "renameProvider": {}, 
                      "alsCalledByProvider": true, 
                      "referencesProvider": true, 
                      "textDocumentSync": 1, 

--- a/testsuite/ada_lsp/callgraph.named_blocks/test.json
+++ b/testsuite/ada_lsp/callgraph.named_blocks/test.json
@@ -35,7 +35,7 @@
                      "typeDefinitionProvider": true,
                      "hoverProvider": true,
                      "definitionProvider": true,
-                     "renameProvider": true,
+                     "renameProvider": {},
                      "alsCalledByProvider": true,
                      "referencesProvider": true,
                      "textDocumentSync": 1,

--- a/testsuite/ada_lsp/indexing_progress/test.json
+++ b/testsuite/ada_lsp/indexing_progress/test.json
@@ -39,7 +39,7 @@
                      ], 
                      "hoverProvider": true, 
                      "definitionProvider": true, 
-                     "renameProvider": true, 
+                     "renameProvider": {}, 
                      "alsCalledByProvider": true, 
                      "referencesProvider": true, 
                      "textDocumentSync": 1, 

--- a/testsuite/ada_lsp/invalidation.file_contents/test.json
+++ b/testsuite/ada_lsp/invalidation.file_contents/test.json
@@ -35,7 +35,7 @@
                      "typeDefinitionProvider": true, 
                      "hoverProvider": true, 
                      "definitionProvider": true, 
-                     "renameProvider": true, 
+                     "renameProvider": {}, 
                      "alsCalledByProvider": true, 
                      "referencesProvider": true, 
                      "textDocumentSync": 1, 

--- a/testsuite/ada_lsp/rename.not_up_to_date/test.json
+++ b/testsuite/ada_lsp/rename.not_up_to_date/test.json
@@ -35,7 +35,7 @@
                      "typeDefinitionProvider": true,
                      "hoverProvider": true,
                      "definitionProvider": true,
-                     "renameProvider": true,
+                     "renameProvider": {},
                      "alsCalledByProvider": true,
                      "referencesProvider": true,
                      "textDocumentSync": 1,

--- a/testsuite/ada_lsp/rename.not_up_to_date/test.json
+++ b/testsuite/ada_lsp/rename.not_up_to_date/test.json
@@ -70,6 +70,7 @@
                      "projectFile": "default.gpr",
                      "scenarioVariables": {},
                      "enableDiagnostics": false,
+                     "enableIndexing": false,
                      "defaultCharset": "ISO-8859-1"
                   }
                }

--- a/testsuite/ada_lsp/rename/rename.json
+++ b/testsuite/ada_lsp/rename/rename.json
@@ -19,7 +19,7 @@
                 "result":{
                     "capabilities":{
                         "textDocumentSync":1,
-                        "renameProvider":true
+                        "renameProvider":{}
                     }
                 }
             }]


### PR DESCRIPTION
Added:
  - renameInComments configuration option to control whether
       process also comments when renaming or not
  - process comments and includes locations in response when
       comment should be changed