### PR TITLE
SB18-028 Allow requests processing during Indexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,11 @@ files from disk by specifying an `"ada.defaultCharset"` key. The default is
 `iso-8859-1`.
 
 You can explicitly deactivate the emission of diagnostics, via the
-`"ada.enableDiagnostics` key. By default, diagnostics are enabled.
+`"ada.enableDiagnostics"` key. By default, diagnostics are enabled.
+
+By default, the server indexes the source files after loading a project,
+to speed up subsequent requests. This behavior can be controlled
+via the `"ada.enableIndexing"` flag in this request.
 
 Here is an example config file from the gnatcov project:
 

--- a/source/ada/lsp-ada_driver.adb
+++ b/source/ada/lsp-ada_driver.adb
@@ -155,6 +155,7 @@ begin
       Server.Run
         (Error_Decorator'Unchecked_Access,
          Handler'Unchecked_Access,
+         Server       => Handler'Unchecked_Access,
          On_Error     => On_Uncaught_Exception'Unrestricted_Access,
          Server_Trace => Server_Trace,
          In_Trace     => In_Trace,

--- a/source/ada/lsp-ada_handlers.adb
+++ b/source/ada/lsp-ada_handlers.adb
@@ -1606,6 +1606,7 @@ package body LSP.Ada_Handlers is
       scenarioVariables : constant String := "scenarioVariables";
       defaultCharset    : constant String := "defaultCharset";
       enableDiagnostics : constant String := "enableDiagnostics";
+      enableIndexing    : constant String := "enableIndexing";
 
       Ada       : constant LSP.Types.LSP_Any := Value.settings.Get ("ada");
       File      : LSP.Types.LSP_String;
@@ -1639,6 +1640,12 @@ package body LSP.Ada_Handlers is
          --  deactivating of diagnostics via a setting here.
          if Ada.Has_Field (enableDiagnostics) then
             Self.Diagnostics_Enabled := Ada.Get (enableDiagnostics);
+         end if;
+
+         --  Similarly to diagnostics, we support selectively activating
+         --  indexing in the parameters to this request.
+         if Ada.Has_Field (enableIndexing) then
+            Self.Indexing_Enabled := Ada.Get (enableIndexing);
          end if;
       end if;
 
@@ -1872,11 +1879,10 @@ package body LSP.Ada_Handlers is
       Last_Percent    : Natural := 0;
       Current_Percent : Natural := 0;
    begin
-      --  Prevent work if another request is pending
-      --  if Self.Server.Look_Ahead_Message /= null then
-      --     Self.Indexing_Was_Paused := True;
-      --     return;
-      --  end if;
+      --  Prevent work if the indexing has been explicitly disabled
+      if not Self.Indexing_Enabled then
+         return;
+      end if;
 
       --  Collect the contexts and their sources: we do this so that we are
       --  able to produce a progress bar covering the total number of files.

--- a/source/ada/lsp-ada_handlers.ads
+++ b/source/ada/lsp-ada_handlers.ads
@@ -78,6 +78,10 @@ private
       Token_Id : Integer := 0;
       --  An ever-increasing number used to generate unique progress tokens
 
+      Indexing_Enabled  : Boolean := True;
+      --  Whether to index sources in the background. This should be True
+      --  for normal use, and can be disabled for debug or testing purposes.
+
       Indexing_Required : Boolean := False;
       --  Set to True if an indexing operation had been paused in order to
       --  process requests.

--- a/source/server/generated/lsp-server_request_handlers.ads
+++ b/source/server/generated/lsp-server_request_handlers.ads
@@ -99,4 +99,9 @@ package LSP.Server_Request_Handlers is
       Request : LSP.Messages.Server_Requests.ALS_Debug_Request)
       return LSP.Messages.Server_Responses.ALS_Debug_Response is abstract;
 
+   procedure Handle_Error
+     (Self  : access Server_Request_Handler) is null;
+   --  This procedure will be called when an unexpected error is raised in the
+   --  request processing loop.
+
 end LSP.Server_Request_Handlers;

--- a/source/server/lsp-server_backends.ads
+++ b/source/server/lsp-server_backends.ads
@@ -1,0 +1,37 @@
+------------------------------------------------------------------------------
+--                         Language Server Protocol                         --
+--                                                                          --
+--                        Copyright (C) 2019, AdaCore                       --
+--                                                                          --
+-- This is free software;  you can redistribute it  and/or modify it  under --
+-- terms of the  GNU General Public License as published  by the Free Soft- --
+-- ware  Foundation;  either version 3,  or (at your option) any later ver- --
+-- sion.  This software is distributed in the hope  that it will be useful, --
+-- but WITHOUT ANY WARRANTY;  without even the implied warranty of MERCHAN- --
+-- TABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public --
+-- License for  more details.  You should have  received  a copy of the GNU --
+-- General  Public  License  distributed  with  this  software;   see  file --
+-- COPYING3.  If not, go to http://www.gnu.org/licenses for a complete copy --
+-- of the license.                                                          --
+------------------------------------------------------------------------------
+
+--  Define an interface for server backends
+
+with LSP.Messages;
+
+package LSP.Server_Backends is
+
+   type Server_Backend is limited interface;
+   type Server_Backend_Access is access all Server_Backend'Class;
+
+   procedure Before_Work
+     (Self    : access Server_Backend;
+      Message : LSP.Messages.Message'Class) is abstract;
+   --  Called before working on Message
+
+   procedure After_Work
+     (Self    : access Server_Backend;
+      Message : LSP.Messages.Message'Class) is abstract;
+   --  Called after working on Message
+
+end LSP.Server_Backends;

--- a/source/server/lsp-servers.ads
+++ b/source/server/lsp-servers.ads
@@ -27,6 +27,7 @@ with LSP.Message_Loggers;
 with LSP.Messages;
 with LSP.Server_Request_Handlers;
 with LSP.Server_Notification_Receivers;
+with LSP.Server_Backends;
 with LSP.Types;
 
 with GNATCOLL.Traces;
@@ -65,6 +66,7 @@ package LSP.Servers is
         LSP.Server_Request_Handlers.Server_Request_Handler_Access;
       Notification : not null
         LSP.Server_Notification_Receivers.Server_Notification_Receiver_Access;
+      Server       : not null LSP.Server_Backends.Server_Backend_Access;
       On_Error     : not null Uncaught_Exception_Handler;
       Server_Trace : GNATCOLL.Traces.Trace_Handle;
       In_Trace     : GNATCOLL.Traces.Trace_Handle;
@@ -81,11 +83,16 @@ package LSP.Servers is
 
    function Look_Ahead_Message (Self : Server) return Message_Access;
    --  Get next nessage in the queue if any. Only request/notification
-   --  handlers are alloved to call this function.
+   --  handlers are allowed to call this function.
 
    function Input_Queue_Length (Self : Server) return Natural;
    --  Return number of messages pending in Input_Queue.
    --  For debug purposes only!
+
+   function Has_Pending_Work (Self : Server) return Boolean;
+   --  Return True if the server has work in the queue, other than the
+   --  notification/request it's currently processing. This should only be
+   --  called from the processing task.
 
 private
 
@@ -149,7 +156,8 @@ private
         (Request      : not null LSP.Server_Request_Handlers
            .Server_Request_Handler_Access;
          Notification : not null LSP.Server_Notification_Receivers
-           .Server_Notification_Receiver_Access);
+         .Server_Notification_Receiver_Access;
+         Server       : not null LSP.Server_Backends.Server_Backend_Access);
       entry Stop;
       --  Clean shutdown of the task
    end Processing_Task_Type;

--- a/testsuite/ada_lsp/rename.not_up_to_date/test.json
+++ b/testsuite/ada_lsp/rename.not_up_to_date/test.json
@@ -70,6 +70,7 @@
                      "projectFile": "default.gpr",
                      "scenarioVariables": {},
                      "enableDiagnostics": false,
+                     "enableIndexing": false,
                      "defaultCharset": "ISO-8859-1"
                   }
                }


### PR DESCRIPTION
Make the indexing take place "in the background".

To do this,
  * make the index subprogram stop itself when there is work on the queue

  * add an interface that allows the server to do operations after each
    request/operation, and use this to relaunch an indexing request