### PR TITLE
S813-025: Get overriding subprograms on textDocument/definition

### DIFF
--- a/source/ada/lsp-ada_contexts.adb
+++ b/source/ada/lsp-ada_contexts.adb
@@ -105,6 +105,38 @@ package body LSP.Ada_Contexts is
          return (1 .. 0 => <>);
    end Find_All_References;
 
+   ------------------------
+   -- Find_All_Overrides --
+   ------------------------
+
+   function Find_All_Overrides
+     (Self              : Context;
+      Decl              : Libadalang.Analysis.Basic_Decl;
+      Imprecise_Results : out Boolean)
+      return Libadalang.Analysis.Basic_Decl_Array
+   is
+      Units : constant Libadalang.Analysis.Analysis_Unit_Array :=
+                Self.Analysis_Units;
+   begin
+      Imprecise_Results := False;
+
+      --  Make two attempts: first with precise results, then with the
+      --  imprecise_fallback.
+      begin
+         return Decl.P_Find_All_Overrides (Units);
+      exception
+         when E : Libadalang.Common.Property_Error =>
+            Imprecise_Results := True;
+            Log (Self.Trace, E, "in Find_All_Overrides (precise)");
+            return Decl.P_Find_All_Overrides
+              (Units, Imprecise_Fallback => True);
+      end;
+   exception
+      when E : Libadalang.Common.Property_Error =>
+         Log (Self.Trace, E, "in Find_All_Overrides (imprecise)");
+         return (1 .. 0 => <>);
+   end Find_All_Overrides;
+
    --------------------
    -- Find_All_Calls --
    --------------------

--- a/source/ada/lsp-ada_contexts.ads
+++ b/source/ada/lsp-ada_contexts.ads
@@ -112,6 +112,17 @@ package LSP.Ada_Contexts is
    --  Imprecise_Results is set to True if we don't know whether the results
    --  are precise.
 
+   function Find_All_Overrides
+     (Self              : Context;
+      Decl              : Libadalang.Analysis.Basic_Decl;
+      Imprecise_Results : out Boolean)
+      return Libadalang.Analysis.Basic_Decl_Array;
+   --  Finds all overriding subprograms of the given basic declaration.
+   --  This is used to propose all the implementations of a given subprogram
+   --  when textDocument/definition requests happen on dispatching calls.
+   --  Imprecise_Results is set to True if we don't know whether the results
+   --  are precise.
+
    function Find_All_Calls
      (Self              : Context;
       Definition        : Libadalang.Analysis.Defining_Name;

--- a/testsuite/ada_lsp/definition_and_overridings/class_definition.adb
+++ b/testsuite/ada_lsp/definition_and_overridings/class_definition.adb
@@ -1,0 +1,14 @@
+
+with Ada.Text_Io; use Ada.Text_Io;
+with Ada.Tags;
+
+package body Class_Definition is
+
+   procedure Generic_P1 (E : Extended_A) is
+   begin
+      Put_Line
+        ("Hi, I'm Generic_P1 for: "
+            & Ada.Tags.Expanded_Name (Class_Definition.A'Class (E)'Tag));
+   end Generic_P1;
+
+end Class_Definition;

--- a/testsuite/ada_lsp/definition_and_overridings/class_definition.ads
+++ b/testsuite/ada_lsp/definition_and_overridings/class_definition.ads
@@ -1,0 +1,14 @@
+
+
+
+package Class_Definition is
+
+   type A is abstract tagged null record;
+
+   procedure P1 (Pa : A) is abstract;
+
+   generic
+      type Extended_A is new A with private;
+   procedure Generic_P1 (E : Extended_A);
+
+end Class_Definition;

--- a/testsuite/ada_lsp/definition_and_overridings/class_definition.subclass.adb
+++ b/testsuite/ada_lsp/definition_and_overridings/class_definition.subclass.adb
@@ -1,0 +1,21 @@
+
+package body Class_Definition.Subclass is
+
+   type B is new A with
+      record
+         F : Integer := 0;
+      end record;
+
+   procedure P1 (Pb : B);
+
+   procedure Instansited_P1 is new Generic_P1 (Extended_A => B);
+
+   procedure P1 (Pb : B) renames Instansited_P1;
+
+   function Gen return A'Class is
+      Vb : B;
+   begin
+      return A'Class (Vb);
+   end Gen;
+
+end Class_Definition.Subclass;

--- a/testsuite/ada_lsp/definition_and_overridings/class_definition.subclass.ads
+++ b/testsuite/ada_lsp/definition_and_overridings/class_definition.subclass.ads
@@ -1,0 +1,7 @@
+
+
+package Class_Definition.Subclass is
+
+   function Gen return A'Class;
+
+end Class_Definition.Subclass;

--- a/testsuite/ada_lsp/definition_and_overridings/default.gpr
+++ b/testsuite/ada_lsp/definition_and_overridings/default.gpr
@@ -1,0 +1,8 @@
+project Default is
+   for Main use ("gb.adb");
+
+   package Naming is
+      for Implementation ("Class_Definition.Subclass") use "class_definition.subclass.adb";
+      for Specification ("Class_Definition.Subclass") use "class_definition.subclass.ads";
+   end Naming;
+end Default;

--- a/testsuite/ada_lsp/definition_and_overridings/gb.adb
+++ b/testsuite/ada_lsp/definition_and_overridings/gb.adb
@@ -1,0 +1,13 @@
+
+with Class_Definition.Subclass;
+with User;
+
+procedure Gb is
+
+   V1 : constant Class_Definition.A'Class := Class_Definition.Subclass.Gen;
+   V2 : constant Class_Definition.A'Class := User.Gen;
+
+begin
+   Class_Definition.P1 (V1);
+   Class_Definition.P1 (V2);
+end Gb;

--- a/testsuite/ada_lsp/definition_and_overridings/test.json
+++ b/testsuite/ada_lsp/definition_and_overridings/test.json
@@ -1,0 +1,339 @@
+[
+   {
+      "comment": [
+         "test automatically generated"
+      ]
+   },
+   {
+      "start": {
+         "cmd": [
+            "${ALS}"
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "processId": 17578,
+               "capabilities": {
+                  "textDocument": {
+                     "completion": {
+                        "completionItemKind": {}
+                     },
+                     "documentLink": {},
+                     "formatting": {},
+                     "documentHighlight": {},
+                     "synchronization": {},
+                     "references": {},
+                     "rangeFormatting": {},
+                     "onTypeFormatting": {},
+                     "codeLens": {},
+                     "colorProvider": {}
+                  },
+                  "workspace": {
+                     "applyEdit": false,
+                     "executeCommand": {},
+                     "didChangeWatchedFiles": {},
+                     "workspaceEdit": {},
+                     "didChangeConfiguration": {}
+                  }
+               },
+               "rootUri": "$URI{.}"
+            },
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize"
+         },
+         "wait": [
+            {
+               "id": 1,
+               "result": {
+                  "capabilities": {
+                     "executeCommandProvider": {
+                        "commands": []
+                     },
+                     "typeDefinitionProvider": true,
+                     "alsReferenceKinds": [
+                        "write",
+                        "call",
+                        "dispatching call"
+                     ],
+                     "hoverProvider": true,
+                     "definitionProvider": true,
+                     "renameProvider": {},
+                     "alsCalledByProvider": true,
+                     "referencesProvider": true,
+                     "textDocumentSync": 1,
+                     "documentLinkProvider": {},
+                     "completionProvider": {
+                        "triggerCharacters": [
+                           "."
+                        ],
+                        "resolveProvider": false
+                     },
+                     "documentSymbolProvider": true
+                  }
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "initialized"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "settings": {
+                  "ada": {
+                     "projectFile": "default.gpr",
+                     "scenarioVariables": {},
+                      "enableDiagnostics": false,
+                      "enableIndexing": false,
+                     "defaultCharset": "ISO-8859-1"
+                  }
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "workspace/didChangeConfiguration"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "text": "\nwith Class_Definition.Subclass;\nwith User;\n\nprocedure Gb is\n\n   V1 : constant Class_Definition.A'Class := Class_Definition.Subclass.Gen;\n   V2 : constant Class_Definition.A'Class := User.Gen;\n\nbegin\n   Class_Definition.P1 (V1);\n   Class_Definition.P1 (V2);\nend Gb;\n",
+                  "version": 0,
+                  "uri": "$URI{gb.adb}",
+                  "languageId": "Ada"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "position": {
+                  "line": 10,
+                  "character": 20
+               },
+               "textDocument": {
+                  "uri": "$URI{gb.adb}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "textDocument/definition"
+         },
+         "wait": [
+            {
+               "id": 2,
+               "result": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 7,
+                           "character": 13
+                        },
+                        "end": {
+                           "line": 7,
+                           "character": 15
+                        }
+                     },
+                     "uri": "$URI{class_definition.ads}"
+                  },
+                  {
+                     "range": {
+                        "start": {
+                           "line": 8,
+                           "character": 3
+                        },
+                        "end": {
+                           "line": 8,
+                           "character": 25
+                        }
+                     },
+                     "uri": "$URI{class_definition.subclass.adb}"
+                  },
+                  {
+                     "range": {
+                        "start": {
+                           "line": 12,
+                           "character": 3
+                        },
+                        "end": {
+                           "line": 17,
+                           "character": 10
+                        }
+                     },
+                     "uri": "$URI{user.adb}"
+                  }
+               ]
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "text": "\n\n\npackage Class_Definition is\n\n   type A is abstract tagged null record;\n\n   procedure P1 (Pa : A) is abstract;\n\n   generic\n      type Extended_A is new A with private;\n   procedure Generic_P1 (E : Extended_A);\n\nend Class_Definition;\n",
+                  "version": 0,
+                  "uri": "$URI{class_definition.ads}",
+                  "languageId": "Ada"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "position": {
+                  "line": 7,
+                  "character": 13
+               },
+               "textDocument": {
+                  "uri": "$URI{class_definition.ads}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "textDocument/definition"
+         },
+         "wait": [
+            {
+               "id": 3,
+               "result": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 8,
+                           "character": 3
+                        },
+                        "end": {
+                           "line": 8,
+                           "character": 25
+                        }
+                     },
+                     "uri": "$URI{class_definition.subclass.adb}"
+                  },
+                  {
+                     "range": {
+                        "start": {
+                           "line": 12,
+                           "character": 3
+                        },
+                        "end": {
+                           "line": 17,
+                           "character": 10
+                        }
+                     },
+                     "uri": "$URI{user.adb}"
+                  }
+               ]
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "text": "\npackage body Class_Definition.Subclass is\n\n   type B is new A with\n      record\n         F : Integer := 0;\n      end record;\n\n   procedure P1 (Pb : B);\n\n   procedure Instansited_P1 is new Generic_P1 (Extended_A => B);\n\n   procedure P1 (Pb : B) renames Instansited_P1;\n\n   function Gen return A'Class is\n      Vb : B;\n   begin\n      return A'Class (Vb);\n   end Gen;\n\nend Class_Definition.Subclass;\n",
+                  "version": 0,
+                  "uri": "$URI{class_definition.subclass.adb}",
+                  "languageId": "Ada"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{gb.adb}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didClose"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{class_definition.ads}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didClose"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{class_definition.subclass.adb}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didClose"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": 4,
+            "method": "shutdown"
+         },
+         "wait": [
+            {
+               "id": 4,
+               "result": null
+            }
+         ]
+      }
+   },
+   {
+      "stop": {
+         "exit_code": 0
+      }
+   }
+]

--- a/testsuite/ada_lsp/definition_and_overridings/test.yaml
+++ b/testsuite/ada_lsp/definition_and_overridings/test.yaml
@@ -1,0 +1,1 @@
+title: 'definition_and_overridings'

--- a/testsuite/ada_lsp/definition_and_overridings/user.adb
+++ b/testsuite/ada_lsp/definition_and_overridings/user.adb
@@ -1,0 +1,26 @@
+
+with Ada.Text_Io; use Ada.Text_Io;
+with Ada.Tags;
+with Class_Definition;
+
+package body User is
+
+   type C is new Class_Definition.A with
+      record
+         F : Integer := 0;
+      end record;
+
+   procedure P1 (Pc : C) is
+   begin
+      Put_Line
+        ("Hi, I'm : "
+         & Ada.Tags.Expanded_Name (Class_Definition.A'Class (Pc)'Tag));
+   end P1;
+
+   function Gen return Class_Definition.A'Class is
+      Vc : C;
+   begin
+      return Class_Definition.A'Class (Vc);
+   end Gen;
+
+end User;

--- a/testsuite/ada_lsp/definition_and_overridings/user.ads
+++ b/testsuite/ada_lsp/definition_and_overridings/user.ads
@@ -1,0 +1,8 @@
+
+with Class_Definition;
+
+package User is
+
+   function Gen return Class_Definition.A'Class;
+
+end User;


### PR DESCRIPTION
We now propose the overriding subprograms declarations when responding
to textDocument/definition requests, if any.

This allows for instance to get the declarations of all the
implementations of a given subprogram when right-clicking on
a dispatching call or ab abstract suprogram declaration.

An automatic test has also been added.