### PR TITLE
SA22-029 Rename also in comments

### DIFF
--- a/source/ada/lsp-ada_handlers.adb
+++ b/source/ada/lsp-ada_handlers.adb
@@ -16,6 +16,7 @@
 ------------------------------------------------------------------------------
 
 with Ada.Characters.Handling; use Ada.Characters.Handling;
+with Ada.Strings.Wide_Wide_Unbounded;
 with Ada.Strings.UTF_Encoding;
 with Ada.Strings.UTF_Encoding.Wide_Wide_Strings;
 with Ada.Strings.Unbounded; use Ada.Strings.Unbounded;
@@ -1521,6 +1522,49 @@ package body LSP.Ada_Handlers is
          Definition : Defining_Name;
          Imprecise  : Boolean;
          Empty      : LSP.Messages.TextEdit_Vector;
+
+         procedure Process_Comments
+           (Node : Ada_Node;
+            Uri  : LSP.Messages.DocumentUri);
+         --  Iterate over all comments and include them in the responce when
+         --  they contain a remaned word
+
+         -----------------------
+         --  Process_Comments --
+         -----------------------
+
+         procedure Process_Comments
+           (Node : Ada_Node;
+            Uri  : LSP.Messages.DocumentUri)
+         is
+            use Libadalang.Common;
+
+            Token : Token_Reference := First_Token (Node.Unit);
+            Name  : constant Wide_Wide_String :=
+              Ada.Strings.Wide_Wide_Unbounded.To_Wide_Wide_String
+                (Get_Last_Name (Name_Node));
+            Span  : LSP.Messages.Span;
+
+         begin
+            while Token /= No_Token loop
+               if Kind (Data (Token)) = Ada_Comment
+                 and then Contains (Token, Name, Span)
+               then
+                  declare
+                     C : constant LSP.Messages.TextEdit :=
+                       (span    => Span,
+                        newText => Value.newName);
+                  begin
+                     if not Response.result.changes (Uri).Contains (C) then
+                        Response.result.changes (Uri).Append (C);
+                     end if;
+                  end;
+               end if;
+
+               Token := Next (Token);
+            end loop;
+         end Process_Comments;
+
       begin
          if Name_Node = No_Name then
             return;
@@ -1567,6 +1611,11 @@ package body LSP.Ada_Handlers is
                      --  We haven't touched this document yet, create an empty
                      --  change list
                      Response.result.changes.Insert (Location.uri, Empty);
+
+                     --  Process comments if it is needed
+                     if Self.Refactoring.Renaming.In_Comments then
+                        Process_Comments (Node.As_Ada_Node, Location.uri);
+                     end if;
                   end if;
 
                   --  When iterating over all contexts (and therefore all
@@ -1611,6 +1660,7 @@ package body LSP.Ada_Handlers is
       defaultCharset    : constant String := "defaultCharset";
       enableDiagnostics : constant String := "enableDiagnostics";
       enableIndexing    : constant String := "enableIndexing";
+      renameInComments  : constant String := "renameInComments";
 
       Ada       : constant LSP.Types.LSP_Any := Value.settings.Get ("ada");
       File      : LSP.Types.LSP_String;
@@ -1650,6 +1700,11 @@ package body LSP.Ada_Handlers is
          --  indexing in the parameters to this request.
          if Ada.Has_Field (enableIndexing) then
             Self.Indexing_Enabled := Ada.Get (enableIndexing);
+         end if;
+
+         if Ada.Has_Field (renameInComments) then
+            Self.Refactoring.Renaming.In_Comments :=
+              Ada.Get (renameInComments);
          end if;
       end if;
 

--- a/source/ada/lsp-ada_handlers.ads
+++ b/source/ada/lsp-ada_handlers.ads
@@ -54,6 +54,16 @@ private
    package Context_Lists is new Ada.Containers.Doubly_Linked_Lists
      (Context_Access);
 
+   --  Options for refactoring/renaming
+   type Renaming_Options is record
+      In_Comments : Boolean := False;
+   end record;
+
+   --  Options for refactoring
+   type Refactoring_Options is record
+      Renaming : Renaming_Options;
+   end record;
+
    type Message_Handler
      (Server  : access LSP.Servers.Server;
       Trace   : GNATCOLL.Traces.Trace_Handle)
@@ -104,6 +114,9 @@ private
       --
       --      * Indexing_Required is set to False when Index_Files has
       --        completed
+
+      Refactoring : Refactoring_Options;
+      --  Configuration options for refactoring
    end record;
 
    overriding procedure Before_Work

--- a/source/ada/lsp-lal_utils.adb
+++ b/source/ada/lsp-lal_utils.adb
@@ -15,11 +15,15 @@
 -- of the license.                                                          --
 ------------------------------------------------------------------------------
 
+with Ada.Wide_Wide_Characters.Handling;
+with Ada.Strings.Wide_Wide_Fixed;
+
 with LSP.Common;        use LSP.Common;
+with LSP.Types;         use LSP.Types;
+
 with Libadalang.Common; use Libadalang.Common;
 
 with Langkit_Support;
-with Langkit_Support.Text;
 with Langkit_Support.Slocs;
 
 package body LSP.Lal_Utils is
@@ -27,6 +31,41 @@ package body LSP.Lal_Utils is
    function Containing_Entity (Ref : Ada_Node) return Defining_Name;
    --  Return the declaration of the subprogram or task that contains Ref.
    --  Return No_Defining_Name if this fails.
+
+   --------------
+   -- Contains --
+   --------------
+
+   function Contains
+     (Token   : Token_Reference;
+      Pattern : Wide_Wide_String;
+      Span    : out LSP.Messages.Span)
+      return Boolean
+   is
+      use Langkit_Support.Text;
+      use Langkit_Support.Slocs;
+
+      T   : constant Text_Type := Ada.Wide_Wide_Characters.Handling.To_Lower
+        (Text (Token));
+      Idx : constant Integer := Ada.Strings.Wide_Wide_Fixed.Index (T, Pattern);
+   begin
+      if Idx < T'First then
+         return False;
+      end if;
+
+      declare
+         Sloc : constant Source_Location_Range := Sloc_Range (Data (Token));
+
+         Line  : constant LSP.Types.Line_Number :=
+           LSP.Types.Line_Number (Sloc.Start_Line) - 1;
+         Start : constant UTF_16_Index := UTF_16_Index
+           (Sloc.Start_Column + Column_Number (Idx - T'First)) - 1;
+      begin
+         Span := (first => (Line, Start),
+                  last  => (Line, Start + T'Length - 1));
+         return True;
+      end;
+   end Contains;
 
    ----------------------
    -- Get_Node_As_Name --
@@ -57,6 +96,20 @@ package body LSP.Lal_Utils is
       return Name_Node.P_Enclosing_Defining_Name;
 
    end Get_Name_As_Defining;
+
+   -------------------
+   -- Get_Last_Name --
+   -------------------
+
+   function Get_Last_Name (Name_Node : Name)
+      return Langkit_Support.Text.Unbounded_Text_Type
+   is
+      Names : constant Unbounded_Text_Type_Array :=
+        P_As_Symbol_Array (Name_Node);
+
+   begin
+      return Names (Names'Last);
+   end Get_Last_Name;
 
    ------------------
    -- Resolve_Name --

--- a/source/ada/lsp-lal_utils.ads
+++ b/source/ada/lsp-lal_utils.ads
@@ -24,8 +24,11 @@ with GNATCOLL.VFS;
 with GNATCOLL.Traces;
 
 with LSP.Ada_Contexts;
+with LSP.Messages;
 
-with Libadalang.Analysis; use Libadalang.Analysis;
+with Libadalang.Analysis;  use Libadalang.Analysis;
+with Libadalang.Common;
+with Langkit_Support.Text;
 
 package LSP.Lal_Utils is
 
@@ -40,6 +43,10 @@ package LSP.Lal_Utils is
    --  Return the definition node (canonical part) of the given name.
    --  Imprecise is set to True if LAL's imprecise fallback mechanism has been
    --  used to compute the cross reference.
+
+   function Get_Last_Name (Name_Node : Name)
+      return Langkit_Support.Text.Unbounded_Text_Type;
+   --  Return the last name, for example if name is A.B.C then return C
 
    function Find_Next_Part
      (Definition : Defining_Name;
@@ -89,5 +96,12 @@ package LSP.Lal_Utils is
    --  these calls are listed, ordered by the name of these subprograms.
    --  Imprecise_Results is set to True if we don't know whether the results
    --  are precise.
+
+   function Contains
+     (Token   : Libadalang.Common.Token_Reference;
+      Pattern : Wide_Wide_String;
+      Span    : out LSP.Messages.Span)
+      return Boolean;
+   --  Return True if the Token text contains Pattern and set position in Span
 
 end LSP.Lal_Utils;


### PR DESCRIPTION
Added:

 * renameInComments configuration option to control whether
    process also comments when renaming or not

 * process comments and includes locations in response when
   comment should be changed