### PR TITLE
Fix brackets to make hyperlink work

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -42,4 +42,4 @@ related resources.
 ## List of features
  * [Reference kinds](reference_kinds.md)
 
- * [Called by][called_by.md]
+ * [Called by](called_by.md)


### PR DESCRIPTION
Use the same kind of brackets that is used for "Reference kinds" feature description