### PR TITLE
SB22-006 Document the writing of tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,24 +52,6 @@ somewhere in the path.
 
 The `ada_language_server` doesn't require/understand any command line options.
 
-## Debugging
-
-You can activate traces that show all the server input/output. This is done
-by creating a file `$HOME/.als/traces.cfg` with the following contents:
-
-```
-ALS.IN=yes > inout.txt:buffer_size=0
-ALS.OUT=yes > inout.txt:buffer_size=0
-```
-
-When this is present, the ALS will generate a file `$HOME/.als/inout.txt`
-which logs the input received and the output sent by the language server.
-
-## Testsuite
-
-See more about the project testsuite in a
-[separate document](testsuite/README.md).
-
 # Supported LSP Server Requests
 
 ### General Requests
@@ -265,8 +247,9 @@ values in the `lsp-ada` group that can be edited similarly to
 
 ## Contribute
 
-Feel free to dive in!
-[Open an issue](https://github.com/AdaCore/ada_language_server/issues/new) or submit PRs.
+Feel free to dive in! Read the [developer's guide](doc/HACKING.md).
+
+Don't hesitate to [open an issue](https://github.com/AdaCore/ada_language_server/issues/new) or submit PRs.
 
 ## License
 

--- a/doc/HACKING.md
+++ b/doc/HACKING.md
@@ -1,0 +1,37 @@
+# Developing on the Ada Language Server
+
+## Debugging
+
+You can activate traces that show all the server input/output. This is done
+by creating a file `$HOME/.als/traces.cfg` with the following contents:
+
+```
+ALS.IN=yes > inout.txt:buffer_size=0
+ALS.OUT=yes > inout.txt:buffer_size=0
+```
+
+When this is present, the ALS will generate a file `$HOME/.als/inout.txt`
+which logs the input received and the output sent by the language server.
+
+## Writing tests
+
+To write a functional test for Ada Language Server:
+
+  * Choose a meaninful name for your test, for instance `completion_inside_generics`. 
+     We'll refer to this as `<testname>` below
+  * Create a new directory `testsuite/ada_lsp/<testname>` containing your test data
+  * Activate full in/out language server traces. See the Debugging section above.
+  * From the base directory in this repository, run:
+     ```
+     python scripts/traces_to_test.py <testname> <path_to_the_als_traces_file>
+     ```
+
+## Running tests
+
+ * run `make check` to run the entire testsuite
+ * to run an individual test, go to `testsuite` and run `sh run.sh ada_lsp/<testname>`
+    (you will need `https://github.com/AdaCore/e3-testsuite` installed to do this)
+
+## Other tests
+
+See more about the project testsuite [here](../testsuite/README.md).

--- a/scripts/traces_to_test.py
+++ b/scripts/traces_to_test.py
@@ -5,7 +5,7 @@
 
 To use this, do
 
-   traces_to_test.py   path_to_project_root  [path_to_traces_file]  > name_of_test_driver.json
+   traces_to_test.py  name_of_test  [path_to_traces_file]  > name_of_test_driver.json
 
 """
 
@@ -14,7 +14,8 @@ import os
 import json
 from json_transformations import python_to_protocol_string, traces_to_test
 
-root = os.path.abspath(sys.argv[1])
+testname = sys.argv[1]
+root = os.path.abspath(os.path.abspath(os.path.join('testsuite', 'ada_lsp', testname)))
 
 if len(sys.argv) > 2:
     inout_file = sys.argv[2]
@@ -23,4 +24,16 @@ else:
     inout_file = os.path.join(als_dir, 'inout.txt')
 
 test = traces_to_test(inout_file, root)
-print json.dumps(test, indent=3)
+
+os.mkdir(root)
+
+test_yaml_file = os.path.join(root, 'test.yaml')
+print("generating {}".format(test_yaml_file))
+with open(test_yaml_file, "wb") as f:
+    f.write("title: '{}'\n".format(testname))
+
+testfile = os.path.join(root, 'test.json')
+print("generating {}".format(testfile))
+
+with open(testfile, "wb") as f:
+   f.write(json.dumps(test, indent=3))


### PR DESCRIPTION
Create a doc/HACKING.md, move some data from the global README.md
to there.

Slight improvement to traces_to_test.py.