### PR TITLE
SC06-075 Separate Documents from Contexts

### DIFF
--- a/source/ada/lsp-ada_handlers.ads
+++ b/source/ada/lsp-ada_handlers.ads
@@ -19,9 +19,12 @@
 --  language.
 
 with Ada.Containers.Doubly_Linked_Lists;
+with Ada.Containers.Hashed_Maps;
 
 with GNATCOLL.VFS;    use GNATCOLL.VFS;
 with GNATCOLL.Traces;
+with LSP.Ada_Contexts;
+with LSP.Ada_Documents;
 
 with LSP.Messages.Server_Requests;
 with LSP.Messages.Server_Responses;
@@ -29,8 +32,7 @@ with LSP.Server_Backends;
 with LSP.Server_Request_Handlers;
 with LSP.Server_Notification_Receivers;
 with LSP.Servers;
-
-with LSP.Ada_Contexts;
+with LSP.Types;
 
 package LSP.Ada_Handlers is
 
@@ -63,6 +65,15 @@ private
    type Refactoring_Options is record
       Renaming : Renaming_Options;
    end record;
+
+   type Internal_Document_Access is access all LSP.Ada_Documents.Document;
+
+   --  Container for documents indexed by URI
+   package Document_Maps is new Ada.Containers.Hashed_Maps
+     (Key_Type        => LSP.Messages.DocumentUri,
+      Element_Type    => Internal_Document_Access,
+      Hash            => LSP.Types.Hash,
+      Equivalent_Keys => LSP.Types."=");
 
    type Message_Handler
      (Server  : access LSP.Servers.Server;
@@ -117,6 +128,9 @@ private
 
       Refactoring : Refactoring_Options;
       --  Configuration options for refactoring
+
+      Open_Documents : Document_Maps.Map;
+      --  The documents that are currently open
    end record;
 
    overriding procedure Before_Work

--- a/testsuite/ada_lsp/aggregate.references_after_update/agg.gpr
+++ b/testsuite/ada_lsp/aggregate.references_after_update/agg.gpr
@@ -1,0 +1,3 @@
+aggregate project Agg is
+   for Project_Files use ("p/p.gpr", "q/q.gpr");
+end Agg;

--- a/testsuite/ada_lsp/aggregate.references_after_update/common/common.gpr
+++ b/testsuite/ada_lsp/aggregate.references_after_update/common/common.gpr
@@ -1,0 +1,2 @@
+project common is
+end common;

--- a/testsuite/ada_lsp/aggregate.references_after_update/common/common_pack.ads
+++ b/testsuite/ada_lsp/aggregate.references_after_update/common/common_pack.ads
@@ -1,0 +1,3 @@
+package common_pack is
+   Fo : Integer := 42;
+end common_pack;

--- a/testsuite/ada_lsp/aggregate.references_after_update/p/main.adb
+++ b/testsuite/ada_lsp/aggregate.references_after_update/p/main.adb
@@ -1,0 +1,6 @@
+with common_pack; use common_pack;
+procedure Main is
+   A : Integer := Foo;
+begin
+   null;
+end;

--- a/testsuite/ada_lsp/aggregate.references_after_update/p/p.gpr
+++ b/testsuite/ada_lsp/aggregate.references_after_update/p/p.gpr
@@ -1,0 +1,3 @@
+with "../common/common";
+project p is
+end p;

--- a/testsuite/ada_lsp/aggregate.references_after_update/q/main.adb
+++ b/testsuite/ada_lsp/aggregate.references_after_update/q/main.adb
@@ -1,0 +1,6 @@
+with common_pack; use common_pack;
+procedure Main is
+   A : Integer := Foo;
+begin
+   null;
+end;

--- a/testsuite/ada_lsp/aggregate.references_after_update/q/q.gpr
+++ b/testsuite/ada_lsp/aggregate.references_after_update/q/q.gpr
@@ -1,0 +1,3 @@
+with "../common/common";
+project q is
+end q;

--- a/testsuite/ada_lsp/aggregate.references_after_update/test.json
+++ b/testsuite/ada_lsp/aggregate.references_after_update/test.json
@@ -1,0 +1,289 @@
+[
+   {
+      "comment": [
+         "test finding all references accross aggregates after editing a document"
+      ]
+   }, 
+   {
+      "start": {
+         "cmd": [
+            "${ALS}"
+         ]
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "capabilities": {
+                  "textDocument": {
+                     "completion": {
+                        "completionItemKind": {}
+                     }, 
+                     "documentLink": {}, 
+                     "formatting": {}, 
+                     "documentHighlight": {}, 
+                     "synchronization": {}, 
+                     "references": {}, 
+                     "rangeFormatting": {}, 
+                     "onTypeFormatting": {}, 
+                     "codeLens": {}, 
+                     "colorProvider": {}
+                  }, 
+                  "workspace": {
+                     "applyEdit": false, 
+                     "executeCommand": {}, 
+                     "didChangeWatchedFiles": {}, 
+                     "workspaceEdit": {}, 
+                     "didChangeConfiguration": {}
+                  }
+               }, 
+               "rootUri": "$URI{.}"
+            }, 
+            "jsonrpc": "2.0", 
+            "id": 1, 
+            "method": "initialize"
+         }, 
+         "wait": [
+            {
+               "id": 1, 
+               "result": {
+                  "capabilities": {
+                     "executeCommandProvider": {
+                        "commands": []
+                     }, 
+                     "typeDefinitionProvider": true, 
+                     "alsReferenceKinds": [
+                        "write", 
+                        "call", 
+                        "dispatching call"
+                     ], 
+                     "hoverProvider": true, 
+                     "definitionProvider": true, 
+                     "renameProvider": {}, 
+                     "alsCalledByProvider": true, 
+                     "referencesProvider": true, 
+                     "declarationProvider": true, 
+                     "textDocumentSync": 1, 
+                     "documentLinkProvider": {}, 
+                     "completionProvider": {
+                        "triggerCharacters": [
+                           "."
+                        ], 
+                        "resolveProvider": false
+                     }, 
+                     "documentSymbolProvider": true
+                  }
+               }
+            }
+         ]
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0", 
+            "method": "initialized"
+         }, 
+         "wait": []
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "settings": {
+                  "ada": {
+                     "projectFile": "agg.gpr", 
+                     "scenarioVariables": {}, 
+                     "enableDiagnostics": false, 
+                     "defaultCharset": "UTF-8"
+                  }
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "method": "workspace/didChangeConfiguration"
+         }, 
+         "wait": []
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "text": "package common_pack is\n   Fo : Integer := 42;\nend common_pack;\n", 
+                  "version": 0, 
+                  "uri": "$URI{common/common_pack.ads}", 
+                  "languageId": "Ada"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "method": "textDocument/didOpen"
+         }, 
+         "wait": []
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "position": {
+                  "line": 1, 
+                  "character": 4
+               }, 
+               "textDocument": {
+                  "uri": "$URI{common/common_pack.ads}"
+               }, 
+               "context": {
+                  "includeDeclaration": true
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "id": 2, 
+            "method": "textDocument/references"
+         }, 
+         "wait": [
+            {
+               "id": 2, 
+               "result": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 1, 
+                           "character": 3
+                        }, 
+                        "end": {
+                           "line": 1, 
+                           "character": 5
+                        }
+                     }, 
+                     "uri": "$URI{common/common_pack.ads}"
+                  }
+               ]
+            }
+         ]
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "contentChanges": [
+                  {
+                     "text": "package common_pack is\n   Foo : Integer := 42;\nend common_pack;\n"
+                  }
+               ], 
+               "textDocument": {
+                  "version": 1, 
+                  "uri": "$URI{common/common_pack.ads}"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "method": "textDocument/didChange"
+         }, 
+         "wait": []
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "position": {
+                  "line": 1, 
+                  "character": 4
+               }, 
+               "textDocument": {
+                  "uri": "$URI{common/common_pack.ads}"
+               }, 
+               "context": {
+                  "includeDeclaration": true
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "id": 3, 
+            "method": "textDocument/references"
+         }, 
+         "wait": [
+            {
+               "id": 3, 
+               "result": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 2, 
+                           "character": 18
+                        }, 
+                        "end": {
+                           "line": 2, 
+                           "character": 21
+                        }
+                     }, 
+                     "uri": "$URI{p/main.adb}"
+                  }, 
+                  {
+                     "range": {
+                        "start": {
+                           "line": 2, 
+                           "character": 18
+                        }, 
+                        "end": {
+                           "line": 2, 
+                           "character": 21
+                        }
+                     }, 
+                     "uri": "$URI{q/main.adb}"
+                  }, 
+                  {
+                     "range": {
+                        "start": {
+                           "line": 1, 
+                           "character": 3
+                        }, 
+                        "end": {
+                           "line": 1, 
+                           "character": 6
+                        }
+                     }, 
+                     "uri": "$URI{common/common_pack.ads}"
+                  }
+               ]
+            }
+         ]
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{common/common_pack.ads}"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "method": "textDocument/didClose"
+         }, 
+         "wait": []
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0", 
+            "id": 4, 
+            "method": "shutdown"
+         }, 
+         "wait": [
+            {
+               "id": 4, 
+               "result": null
+            }
+         ]
+      }
+   }, 
+   {
+      "stop": {
+         "exit_code": 0
+      }
+   }
+]

--- a/testsuite/ada_lsp/aggregate.references_after_update/test.yaml
+++ b/testsuite/ada_lsp/aggregate.references_after_update/test.yaml
@@ -1,0 +1,1 @@
+title: 'aggregate.references_after_update'


### PR DESCRIPTION
Documents should not belong to specific contexts. For instance, a
document might represent an Ada source which is common to several
project contexts. Following this, a document should not own its
Analysis_Unit, the Analysis_Unit is valid only for a specific context.

Refactor the code in light of this: the documents are now held by
the Message_Handler.

Add a test to check that references for an entity that's common to several
project works after editing the document.