### PR TITLE
Make testsuite output more verbose

### DIFF
--- a/source/tester/tester-tests.adb
+++ b/source/tester/tester-tests.adb
@@ -110,8 +110,10 @@ package body Tester.Tests is
                  (GNATCOLL.JSON.Write
                     (GNATCOLL.JSON.Create (Self.Waits), False));
                Text.Append ("");
-               Text.Append ("Last Message from server:");
-               Text.Append (GNATCOLL.JSON.Write (Self.Last_Message, False));
+               Text.Append ("Full output from server:");
+               Text.Append
+                 (GNATCOLL.JSON.Write
+                    (GNATCOLL.JSON.Create (Self.Full_Server_Output), False));
                Self.Do_Fail (Text);
                exit;
             end;
@@ -410,7 +412,7 @@ package body Tester.Tests is
       end Sort_Reply;
 
    begin
-      Self.Last_Message := JSON;
+      GNATCOLL.JSON.Append (Self.Full_Server_Output, JSON);
 
       if not Self.Sort_Reply.Is_Empty then
          Self.Sort_Reply.Map_JSON_Object (Sort_Reply'Access);

--- a/source/tester/tester-tests.ads
+++ b/source/tester/tester-tests.ads
@@ -38,8 +38,9 @@ private
       Sort_Reply   : GNATCOLL.JSON.JSON_Value;
       Waits        : GNATCOLL.JSON.JSON_Array;
       --  Array of JSON object to wait
-      Last_Message : GNATCOLL.JSON.JSON_Value;
-      --  Last message got from server
+
+      Full_Server_Output : GNATCOLL.JSON.JSON_Array;
+      --  Complete output received from the server
    end record;
 
    overriding procedure On_Error


### PR DESCRIPTION
With the introduction of progress reports, the "last message from
server" is no longer helpful: send the full report to the testsuite
output instead.