### PR TITLE
SC06-071 Add a valgrind mode to the testsuite

### DIFF
--- a/testsuite/drivers/basic.py
+++ b/testsuite/drivers/basic.py
@@ -31,7 +31,8 @@ class JsonTestDriver(ALSTestDriver):
                 [self.env.tester_run, json],
                 cwd=wd,
                 timeout=120,
-                env={'ALS': self.env.als},
+                env={'ALS': self.env.als,
+                     'ALS_WAIT_FACTOR': str(self.env.wait_factor)},
                 ignore_environ=False)
             output += process.out
 

--- a/testsuite/run_valgrind.sh
+++ b/testsuite/run_valgrind.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+
+# This is a convenience command-line driver made for development mode
+# in valgrind memory check mode
+./run-tests --valgrind_memcheck --loglevel INFO --show-error-output $@


### PR DESCRIPTION
Add a mode to run the testsuite under valgrind.

To do this, the command line to run the language server
must be modifiable: no longer read it from the .json files,
but read it from the environment directly.