### PR TITLE
SC16-095 Prevent fallback navigation on decls that don't allow a body

### DIFF
--- a/source/ada/lsp-lal_utils.adb
+++ b/source/ada/lsp-lal_utils.adb
@@ -339,6 +339,21 @@ package body LSP.Lal_Utils is
       --  in a package P, we're going to look in the spec and body of P for
       --  any items named Foo, excluding Definition itself.
 
+      --  Eliminate some cases. The subprogram does not have an other part if
+      --  it is an expression function, or an abstract subprogram declaration,
+      --  or a null procedure.
+      declare
+         Parents : constant Ada_Node_Array := Definition.Parents;
+      begin
+         if Parents'Length >= 2 and then Parents (Parents'First + 2).Kind in
+           Libadalang.Common.Ada_Abstract_Subp_Decl
+             | Libadalang.Common.Ada_Null_Subp_Decl
+             | Libadalang.Common.Ada_Expr_Function
+         then
+            return No_Defining_Name;
+         end if;
+      end;
+
       --  First obtain the spec.
       --  Note: we could refine the number of calls to P_Semantic_Parent.
       --  Two calls to P_Semantic_Parents are needed in the case of a

--- a/testsuite/ada_lsp/SC16-095.fallback_when_no_body/p.gpr
+++ b/testsuite/ada_lsp/SC16-095.fallback_when_no_body/p.gpr
@@ -1,0 +1,2 @@
+project p is
+end p;

--- a/testsuite/ada_lsp/SC16-095.fallback_when_no_body/pack.adb
+++ b/testsuite/ada_lsp/SC16-095.fallback_when_no_body/pack.adb
@@ -1,0 +1,24 @@
+package body pack is
+
+   procedure Foo (Y : Integer);
+   
+   function Bla (Y : Integer) return Integer is
+   begin
+      return 2;
+   end Bla;
+   
+   type Y is null record;
+   
+   procedure Nobody (Arg : Y) is
+   begin
+      null;
+   end;
+   
+   procedure Allow_A_Body (Y : Integer) is null;
+
+   procedure Foo (Y : Integer) is
+   begin
+      null;
+   end;
+   
+end pack;

--- a/testsuite/ada_lsp/SC16-095.fallback_when_no_body/pack.ads
+++ b/testsuite/ada_lsp/SC16-095.fallback_when_no_body/pack.ads
@@ -1,0 +1,10 @@
+package pack is
+
+   procedure Foo is null;
+   function Bla return Integer is (42);
+   
+   type X is abstract tagged null record;
+   procedure Nobody (Arg : X) is abstract;
+
+   procedure Allow_A_Body;
+end pack;

--- a/testsuite/ada_lsp/SC16-095.fallback_when_no_body/test.json
+++ b/testsuite/ada_lsp/SC16-095.fallback_when_no_body/test.json
@@ -1,7 +1,7 @@
 [
    {
       "comment": [
-         "test the fallback navigation to subprograms that don't have an exact profile"
+         "test that we're not using navigation fallback on specs that should have no body"
       ]
    }, 
    {
@@ -16,8 +16,26 @@
          "request": {
             "params": {
                "capabilities": {
+                  "textDocument": {
+                     "completion": {
+                        "completionItemKind": {}
+                     }, 
+                     "documentLink": {}, 
+                     "formatting": {}, 
+                     "documentHighlight": {}, 
+                     "synchronization": {}, 
+                     "references": {}, 
+                     "rangeFormatting": {}, 
+                     "onTypeFormatting": {}, 
+                     "codeLens": {}, 
+                     "colorProvider": {}
+                  }, 
                   "workspace": {
-                     "applyEdit": false
+                     "applyEdit": false, 
+                     "executeCommand": {}, 
+                     "didChangeWatchedFiles": {}, 
+                     "workspaceEdit": {}, 
+                     "didChangeConfiguration": {}
                   }
                }, 
                "rootUri": "$URI{.}"
@@ -31,6 +49,9 @@
                "id": 1, 
                "result": {
                   "capabilities": {
+                     "executeCommandProvider": {
+                        "commands": []
+                     }, 
                      "typeDefinitionProvider": true, 
                      "alsReferenceKinds": [
                         "write", 
@@ -42,7 +63,9 @@
                      "renameProvider": true, 
                      "alsCalledByProvider": true, 
                      "referencesProvider": true, 
+                     "declarationProvider": true, 
                      "textDocumentSync": 1, 
+                     "documentLinkProvider": {}, 
                      "completionProvider": {
                         "triggerCharacters": [
                            "."
@@ -88,9 +111,26 @@
          "request": {
             "params": {
                "textDocument": {
-                  "text": "package P is\n\n   procedure Foo (A : Integer; Other_Param : Boolean);\n\n   package Nested is\n      procedure Foo (A : Integer);\n\n      procedure Bla (A : Integer);\n   end Nested;\n\n   procedure Bla (A : Integer);\n\nend P;\n", 
+                  "text": "package pack is\n\n   procedure Foo is null;\n   function Bla return Integer is (42);\n   \n   type X is abstract tagged null record;\n   procedure Nobody (Arg : X) is abstract;\n\n   procedure Allow_A_Body;\nend pack;\n", 
                   "version": 0, 
-                  "uri": "$URI{p.ads}", 
+                  "uri": "$URI{pack.ads}", 
+                  "languageId": "Ada"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "method": "textDocument/didOpen"
+         }, 
+         "wait": []
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "text": "package body pack is\n\n   procedure Foo (Y : Integer);\n   \n   function Bla (Y : Integer) return Integer is\n   begin\n      return 2;\n   end Bla;\n   \n   type Y is null record;\n   \n   procedure Nobody (Arg : Y) is\n   begin\n      null;\n   end;\n   \n   procedure Allow_A_Body is null;\n\n   procedure Foo (Y : Integer) is\n   begin\n      null;\n   end;\n   \nend pack;\n", 
+                  "version": 0, 
+                  "uri": "$URI{pack.adb}", 
                   "languageId": "Ada"
                }
             }, 
@@ -109,7 +149,7 @@
                   "character": 13
                }, 
                "textDocument": {
-                  "uri": "$URI{p.ads}"
+                  "uri": "$URI{pack.ads}"
                }
             }, 
             "jsonrpc": "2.0", 
@@ -118,29 +158,8 @@
          }, 
          "wait": [
             {
-               "params": {
-                  "message": "The result of 'definition' is approximate.", 
-                  "type": 2
-               }, 
-               "method": "window/showMessage"
-            }, 
-            {
                "id": 2, 
-               "result": [
-                  {
-                     "range": {
-                        "start": {
-                           "line": 6, 
-                           "character": 13
-                        }, 
-                        "end": {
-                           "line": 6, 
-                           "character": 16
-                        }
-                     }, 
-                     "uri": "$URI{p.adb}"
-                  }
-               ]
+               "result": []
             }
          ]
       }
@@ -149,30 +168,12 @@
       "send": {
          "request": {
             "params": {
-               "textDocument": {
-                  "text": "package body P is\n\n   ---------\n   -- Foo --\n   ---------\n\n   procedure Foo (A : Integer) is\n   begin\n      null;\n   end Foo;\n\n   ------------\n   -- Nested --\n   ------------\n\n   package body Nested is\n\n      procedure Foo (A : Integer) is\n      begin\n         null;\n      end Foo;\n\n      procedure Bla (A : Integer; Other_Param : Boolean) is null;\n\n   end Nested;\n\n   procedure Bla is null;\n\nend P;\n", 
-                  "version": 0, 
-                  "uri": "$URI{p.adb}", 
-                  "languageId": "Ada"
-               }
-            }, 
-            "jsonrpc": "2.0", 
-            "method": "textDocument/didOpen"
-         }, 
-         "wait": []
-      }
-   }, 
-   {"comment": "--------- expecting an empty result for the definition of a procedure which 'is null' -------"},
-   {
-      "send": {
-         "request": {
-            "params": {
                "position": {
-                  "line": 22, 
-                  "character": 16
+                  "line": 3, 
+                  "character": 12
                }, 
                "textDocument": {
-                  "uri": "$URI{p.adb}"
+                  "uri": "$URI{pack.ads}"
                }
             }, 
             "jsonrpc": "2.0", 
@@ -191,8 +192,70 @@
       "send": {
          "request": {
             "params": {
+               "position": {
+                  "line": 6, 
+                  "character": 13
+               }, 
                "textDocument": {
-                  "uri": "$URI{p.ads}"
+                  "uri": "$URI{pack.ads}"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "id": 4, 
+            "method": "textDocument/definition"
+         }, 
+         "wait": [
+            {
+               "id": 4, 
+               "result": []
+            }
+         ]
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "position": {
+                  "line": 8, 
+                  "character": 13
+               }, 
+               "textDocument": {
+                  "uri": "$URI{pack.ads}"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "id": 5, 
+            "method": "textDocument/definition"
+         }, 
+         "wait": [
+            {
+               "id": 5, 
+               "result": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 16, 
+                           "character": 13
+                        }, 
+                        "end": {
+                           "line": 16, 
+                           "character": 25
+                        }
+                     }, 
+                     "uri": "$URI{pack.adb}"
+                  }
+               ]
+            }
+         ]
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{pack.ads}"
                }
             }, 
             "jsonrpc": "2.0", 
@@ -206,7 +269,7 @@
          "request": {
             "params": {
                "textDocument": {
-                  "uri": "$URI{p.adb}"
+                  "uri": "$URI{pack.adb}"
                }
             }, 
             "jsonrpc": "2.0", 
@@ -219,12 +282,12 @@
       "send": {
          "request": {
             "jsonrpc": "2.0", 
-            "id": 4, 
+            "id": 6, 
             "method": "shutdown"
          }, 
          "wait": [
             {
-               "id": 4, 
+               "id": 6, 
                "result": null
             }
          ]

--- a/testsuite/ada_lsp/SC16-095.fallback_when_no_body/test.yaml
+++ b/testsuite/ada_lsp/SC16-095.fallback_when_no_body/test.yaml
@@ -1,0 +1,1 @@
+title: 'SC16-095.fallback_when_no_body'


### PR DESCRIPTION
Decls that are 'is null' procedures, abstract subprograms, or
expression functions should not allow a body: prevent the manual
fallback mechanism for finding one.