### PR TITLE
SC05-038 Implement 'textDocument/implementation'

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ The `ada_language_server` doesn't require/understand any command line options.
 | `textDocument/definition`             | :white_check_mark: |
 | `textDocument/declaration`            | :white_check_mark: |
 | `textDocument/typeDefinition`         | :white_check_mark: |
-| `textDocument/implementation`         |                    |
+| `textDocument/implementation`         | :white_check_mark: |
 | `textDocument/references`             | :white_check_mark: |
 | `textDocument/documentHighlight`      |                    |
 | `textDocument/documentSymbol`         | :white_check_mark: |

--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -277,6 +277,8 @@ REQUESTS = [
      'Location_Response'),
     ('textDocument/declaration', 'Declaration', 'TextDocumentPositionParams',
      'Location_Response'),
+    ('textDocument/implementation', 'Implementation',
+     'TextDocumentPositionParams', 'Location_Response'),
     ('textDocument/typeDefinition', 'Type_Definition',
      'TextDocumentPositionParams', 'Location_Response'),
     ('textDocument/highight', 'Highlight', 'TextDocumentPositionParams',

--- a/source/ada/lsp-ada_handlers.ads
+++ b/source/ada/lsp-ada_handlers.ads
@@ -181,6 +181,11 @@ private
       Request : LSP.Messages.Server_Requests.Declaration_Request)
       return LSP.Messages.Server_Responses.Location_Response;
 
+   overriding function On_Implementation_Request
+     (Self    : access Message_Handler;
+      Request : LSP.Messages.Server_Requests.Implementation_Request)
+      return LSP.Messages.Server_Responses.Location_Response;
+
    overriding function On_Type_Definition_Request
      (Self    : access Message_Handler;
       Request : LSP.Messages.Server_Requests.Type_Definition_Request)

--- a/source/ada/lsp-error_decorators.adb
+++ b/source/ada/lsp-error_decorators.adb
@@ -136,6 +136,22 @@ package body LSP.Error_Decorators is
       return LSP.Messages.Server_Responses.Location_Response
         renames Declaration_Request;
 
+   -------------------------------
+   -- On_Implementation_Request --
+   -------------------------------
+
+   function Implementation_Request is new Generic_Request
+     (Request    => LSP.Messages.Server_Requests.Implementation_Request,
+      Response   => LSP.Messages.Server_Responses.Location_Response,
+      Handler    => LSP.Server_Request_Handlers.Server_Request_Handler,
+      On_Request => LSP.Server_Request_Handlers.On_Implementation_Request);
+
+   overriding function On_Implementation_Request
+     (Self    : access Error_Decorator;
+      Request : LSP.Messages.Server_Requests.Implementation_Request)
+      return LSP.Messages.Server_Responses.Location_Response
+        renames Implementation_Request;
+
    ---------------------------
    -- On_Definition_Request --
    ---------------------------

--- a/source/ada/lsp-error_decorators.ads
+++ b/source/ada/lsp-error_decorators.ads
@@ -67,6 +67,11 @@ package LSP.Error_Decorators is
       Request : LSP.Messages.Server_Requests.Declaration_Request)
       return LSP.Messages.Server_Responses.Location_Response;
 
+   overriding function On_Implementation_Request
+     (Self    : access Error_Decorator;
+      Request : LSP.Messages.Server_Requests.Implementation_Request)
+      return LSP.Messages.Server_Responses.Location_Response;
+
    overriding function On_Type_Definition_Request
      (Self    : access Error_Decorator;
       Request : LSP.Messages.Server_Requests.Type_Definition_Request)

--- a/source/ada/lsp-lal_utils.ads
+++ b/source/ada/lsp-lal_utils.ads
@@ -51,7 +51,7 @@ package LSP.Lal_Utils is
    function Find_Next_Part
      (Definition : Defining_Name;
       Trace      : GNATCOLL.Traces.Trace_Handle) return Defining_Name;
-   --  Wrapper around P_Next_Part that returns null if next part
+   --  Wrapper around P_Next_Part that returns No_Defining_Name if next part
    --  is name itself. It also catches Property_Error and reports it in traces.
 
    function Find_Canonical_Part

--- a/source/protocol/generated/lsp-messages-server_requests.adb
+++ b/source/protocol/generated/lsp-messages-server_requests.adb
@@ -47,6 +47,13 @@ package body LSP.Messages.Server_Requests is
    end Visit;
 
    overriding procedure Visit
+     (Self    : Implementation_Request;
+      Handler : access Server_Request_Receiver'Class) is
+   begin
+      Handler.On_Implementation_Request (Self);
+   end Visit;
+
+   overriding procedure Visit
      (Self    : Type_Definition_Request;
       Handler : access Server_Request_Receiver'Class) is
    begin

--- a/source/protocol/generated/lsp-messages-server_requests.ads
+++ b/source/protocol/generated/lsp-messages-server_requests.ads
@@ -80,6 +80,18 @@ package LSP.Messages.Server_Requests is
      (Self    : Declaration_Request;
       Handler : access Server_Request_Receiver'Class);
 
+   package Implementation_Requests is
+     new LSP.Generic_Requests
+       (Server_Request,
+        TextDocumentPositionParams);
+
+   type Implementation_Request is
+     new Implementation_Requests.Request with null record;
+
+   overriding procedure Visit
+     (Self    : Implementation_Request;
+      Handler : access Server_Request_Receiver'Class);
+
    package Type_Definition_Requests is
      new LSP.Generic_Requests
        (Server_Request,

--- a/source/protocol/generated/lsp-server_request_receivers.ads
+++ b/source/protocol/generated/lsp-server_request_receivers.ads
@@ -43,6 +43,11 @@ package LSP.Server_Request_Receivers is
       Value : LSP.Messages.Server_Requests.Declaration_Request)
         is abstract;
 
+   procedure On_Implementation_Request
+     (Self  : access Server_Request_Receiver;
+      Value : LSP.Messages.Server_Requests.Implementation_Request)
+        is abstract;
+
    procedure On_Type_Definition_Request
      (Self  : access Server_Request_Receiver;
       Value : LSP.Messages.Server_Requests.Type_Definition_Request)

--- a/source/protocol/lsp-messages-client_requests.ads
+++ b/source/protocol/lsp-messages-client_requests.ads
@@ -21,8 +21,9 @@ with LSP.Client_Request_Receivers; use LSP.Client_Request_Receivers;
 
 package LSP.Messages.Client_Requests is
 
-   type Client_Request is abstract new LSP.Messages.RequestMessage
-     with null record;
+   type Client_Request is abstract new LSP.Messages.RequestMessage with record
+      Canceled : Boolean := False with Atomic;
+   end record;
 
    procedure Visit
      (Self    : Client_Request;

--- a/source/server/generated/lsp-server_request_handlers.ads
+++ b/source/server/generated/lsp-server_request_handlers.ads
@@ -44,6 +44,11 @@ package LSP.Server_Request_Handlers is
       Request : LSP.Messages.Server_Requests.Declaration_Request)
       return LSP.Messages.Server_Responses.Location_Response is abstract;
 
+   function On_Implementation_Request
+     (Self    : access Server_Request_Handler;
+      Request : LSP.Messages.Server_Requests.Implementation_Request)
+      return LSP.Messages.Server_Responses.Location_Response is abstract;
+
    function On_Type_Definition_Request
      (Self    : access Server_Request_Handler;
       Request : LSP.Messages.Server_Requests.Type_Definition_Request)

--- a/source/server/generated/lsp-servers-decode_request.adb
+++ b/source/server/generated/lsp-servers-decode_request.adb
@@ -90,6 +90,17 @@ begin
       end;
    end if;
 
+   if To_UTF_8_String (Method) = "textDocument/implementation" then
+      declare
+         R : Implementation_Request;
+      begin
+         Set_Common_Request_Fields (R, JS);
+         JS.Key ("params");
+         LSP.Messages.TextDocumentPositionParams'Read (JS'Access, R.params);
+         return R;
+      end;
+   end if;
+
    if To_UTF_8_String (Method) = "textDocument/typeDefinition" then
       declare
          R : Type_Definition_Request;

--- a/source/server/generated/lsp-servers-handle_request.adb
+++ b/source/server/generated/lsp-servers-handle_request.adb
@@ -85,6 +85,18 @@ begin
          end;
       end if;
 
+      if Request in Implementation_Request'Class then
+         declare
+            R : LSP.Messages.ResponseMessage'Class :=
+               Self.On_Implementation_Request
+                  (Implementation_Request (Request));
+         begin
+            R.jsonrpc := +"2.0";
+            R.id := Request.id;
+            return R;
+         end;
+      end if;
+
       if Request in Type_Definition_Request'Class then
          declare
             R : LSP.Messages.ResponseMessage'Class :=

--- a/source/server/lsp-message_loggers.adb
+++ b/source/server/lsp-message_loggers.adb
@@ -328,6 +328,20 @@ package body LSP.Message_Loggers is
          & Image (Value.params));
    end On_Declaration_Request;
 
+   ----------------------------
+   -- On_Implementation_Request --
+   ----------------------------
+
+   overriding procedure On_Implementation_Request
+     (Self  : access Message_Logger;
+      Value : LSP.Messages.Server_Requests.Implementation_Request) is
+   begin
+      Self.Trace.Trace
+        ("Implementation_Request: "
+         & Image (Value)
+         & Image (Value.params));
+   end On_Implementation_Request;
+
    ---------------------------
    -- On_Definition_Request --
    ---------------------------

--- a/source/server/lsp-message_loggers.ads
+++ b/source/server/lsp-message_loggers.ads
@@ -142,6 +142,10 @@ private
      (Self  : access Message_Logger;
       Value : LSP.Messages.Server_Requests.Declaration_Request);
 
+   overriding procedure On_Implementation_Request
+     (Self  : access Message_Logger;
+      Value : LSP.Messages.Server_Requests.Implementation_Request);
+
    overriding procedure On_Type_Definition_Request
      (Self   : access Message_Logger;
       Value  : LSP.Messages.Server_Requests.Type_Definition_Request);

--- a/testsuite/ada_lsp/aggregate.references_after_update/test.json
+++ b/testsuite/ada_lsp/aggregate.references_after_update/test.json
@@ -224,19 +224,6 @@
                   {
                      "range": {
                         "start": {
-                           "line": 2, 
-                           "character": 18
-                        }, 
-                        "end": {
-                           "line": 2, 
-                           "character": 21
-                        }
-                     }, 
-                     "uri": "$URI{q/main.adb}"
-                  }, 
-                  {
-                     "range": {
-                        "start": {
                            "line": 1, 
                            "character": 3
                         }, 
@@ -246,6 +233,19 @@
                         }
                      }, 
                      "uri": "$URI{common/common_pack.ads}"
+                  }, 
+                  {
+                     "range": {
+                        "start": {
+                           "line": 2, 
+                           "character": 18
+                        }, 
+                        "end": {
+                           "line": 2, 
+                           "character": 21
+                        }
+                     }, 
+                     "uri": "$URI{q/main.adb}"
                   }
                ]
             }

--- a/testsuite/ada_lsp/aggregate.simple/test.json
+++ b/testsuite/ada_lsp/aggregate.simple/test.json
@@ -139,19 +139,6 @@
                   {
                      "range": {
                         "start": {
-                           "line": 2, 
-                           "character": 18
-                        }, 
-                        "end": {
-                           "line": 2, 
-                           "character": 21
-                        }
-                     }, 
-                     "uri": "$URI{q/main.adb}"
-                  }, 
-                  {
-                     "range": {
-                        "start": {
                            "line": 1, 
                            "character": 3
                         }, 
@@ -161,6 +148,19 @@
                         }
                      }, 
                      "uri": "$URI{common/common_pack.ads}"
+                  }, 
+                  {
+                     "range": {
+                        "start": {
+                           "line": 2, 
+                           "character": 18
+                        }, 
+                        "end": {
+                           "line": 2, 
+                           "character": 21
+                        }
+                     }, 
+                     "uri": "$URI{q/main.adb}"
                   }
                ]
             }]

--- a/testsuite/ada_lsp/definition_and_overridings/lal_repro.py
+++ b/testsuite/ada_lsp/definition_and_overridings/lal_repro.py
@@ -1,0 +1,7 @@
+import libadalang as lal
+
+ctx = lal.AnalysisContext()
+
+u = ctx.get_from_file("gb.adb")
+p1_call = u.root.findall(lambda x: x.text == "P1")[0]
+print p1_call.p_defining_name.p_base_subp_declarations

--- a/testsuite/ada_lsp/implementation.aggregates/agg.gpr
+++ b/testsuite/ada_lsp/implementation.aggregates/agg.gpr
@@ -1,0 +1,3 @@
+aggregate project Agg is
+   for Project_Files use ("p/p.gpr", "q/q.gpr");
+end Agg;

--- a/testsuite/ada_lsp/implementation.aggregates/common/common.gpr
+++ b/testsuite/ada_lsp/implementation.aggregates/common/common.gpr
@@ -1,0 +1,2 @@
+project common is
+end common;

--- a/testsuite/ada_lsp/implementation.aggregates/common/common_pack.ads
+++ b/testsuite/ada_lsp/implementation.aggregates/common/common_pack.ads
@@ -1,0 +1,6 @@
+package common_pack is
+   Foo : Integer := 42;
+
+   function Common_Fun return Integer;
+
+end common_pack;

--- a/testsuite/ada_lsp/implementation.aggregates/lal_repro.py
+++ b/testsuite/ada_lsp/implementation.aggregates/lal_repro.py
@@ -1,0 +1,28 @@
+import libadalang as lal
+
+provider_p = lal.UnitProvider.for_project("agg.gpr", project="p/p.gpr")
+ctx_p = lal.AnalysisContext(unit_provider=provider_p)
+
+provider_q = lal.UnitProvider.for_project("agg.gpr", project="q/q.gpr")
+ctx_q = lal.AnalysisContext(unit_provider=provider_q)
+
+u_p = ctx_p.get_from_file("common/common_pack.ads")
+u_q = ctx_q.get_from_file("common/common_pack.ads")
+
+print u_p
+print u_q
+
+fun_p = u_p.root.findall(lambda x: x.text == "Common_Fun")[0]
+print fun_p.p_next_part.unit.filename
+
+fun_q = u_q.root.findall(lambda x: x.text == "Common_Fun")[0]
+print fun_q.p_next_part.unit.filename
+
+fun_p = u_p.root.findall(lambda x: x.text == "Common_Fun")[0]
+print fun_p.p_next_part.unit.filename
+
+fun_q = u_q.root.findall(lambda x: x.text == "Common_Fun")[0]
+print fun_q.p_next_part.unit.filename
+
+
+#print p1_call.p_defining_name.p_base_subp_declarations

--- a/testsuite/ada_lsp/implementation.aggregates/p/common_pack.adb
+++ b/testsuite/ada_lsp/implementation.aggregates/p/common_pack.adb
@@ -1,0 +1,3 @@
+package body Common_Pack is
+   function Common_Fun return Integer is (2);
+end Common_Pack;

--- a/testsuite/ada_lsp/implementation.aggregates/p/main.adb
+++ b/testsuite/ada_lsp/implementation.aggregates/p/main.adb
@@ -1,0 +1,6 @@
+with common_pack; use common_pack;
+procedure Main is
+   A : Integer := Foo;
+begin
+   null;
+end;

--- a/testsuite/ada_lsp/implementation.aggregates/p/p.gpr
+++ b/testsuite/ada_lsp/implementation.aggregates/p/p.gpr
@@ -1,0 +1,3 @@
+with "../common/common";
+project p is
+end p;

--- a/testsuite/ada_lsp/implementation.aggregates/q/common_pack.adb
+++ b/testsuite/ada_lsp/implementation.aggregates/q/common_pack.adb
@@ -1,0 +1,3 @@
+package body Common_Pack is
+   function Common_Fun return Integer is (1);
+end Common_Pack;

--- a/testsuite/ada_lsp/implementation.aggregates/q/main.adb
+++ b/testsuite/ada_lsp/implementation.aggregates/q/main.adb
@@ -1,0 +1,6 @@
+with common_pack; use common_pack;
+procedure Main is
+   A : Integer := Foo;
+begin
+   null;
+end;

--- a/testsuite/ada_lsp/implementation.aggregates/q/q.gpr
+++ b/testsuite/ada_lsp/implementation.aggregates/q/q.gpr
@@ -1,0 +1,3 @@
+with "../common/common";
+project q is
+end q;

--- a/testsuite/ada_lsp/implementation.aggregates/test.json
+++ b/testsuite/ada_lsp/implementation.aggregates/test.json
@@ -1,0 +1,522 @@
+[
+   {
+      "comment": [
+         "extensive test of the 'implementation' with aggregate projects"
+      ]
+   }, 
+   {
+      "start": {
+         "cmd": [
+            "${ALS}"
+         ]
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "capabilities": {
+                  "textDocument": {
+                     "completion": {
+                        "completionItemKind": {}
+                     }, 
+                     "documentLink": {}, 
+                     "formatting": {}, 
+                     "documentHighlight": {}, 
+                     "synchronization": {}, 
+                     "references": {}, 
+                     "rangeFormatting": {}, 
+                     "onTypeFormatting": {}, 
+                     "codeLens": {}, 
+                     "colorProvider": {}
+                  }, 
+                  "workspace": {
+                     "applyEdit": false, 
+                     "executeCommand": {}, 
+                     "didChangeWatchedFiles": {}, 
+                     "workspaceEdit": {}, 
+                     "didChangeConfiguration": {}
+                  }
+               }, 
+               "rootUri": "$URI{.}"
+            }, 
+            "jsonrpc": "2.0", 
+            "id": 1, 
+            "method": "initialize"
+         }, 
+         "wait": [
+            {
+               "id": 1, 
+               "result": {
+                  "capabilities": {
+                     "executeCommandProvider": {
+                        "commands": []
+                     }, 
+                     "typeDefinitionProvider": true, 
+                     "alsReferenceKinds": [
+                        "write", 
+                        "call", 
+                        "dispatching call", 
+                        "parent", 
+                        "child"
+                     ], 
+                     "hoverProvider": true, 
+                     "definitionProvider": true, 
+                     "renameProvider": true, 
+                     "alsCalledByProvider": true, 
+                     "referencesProvider": true, 
+                     "declarationProvider": true, 
+                     "textDocumentSync": 1, 
+                     "documentLinkProvider": {}, 
+                     "completionProvider": {
+                        "triggerCharacters": [
+                           "."
+                        ], 
+                        "resolveProvider": false
+                     }, 
+                     "documentSymbolProvider": true
+                  }
+               }
+            }
+         ]
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0", 
+            "method": "initialized"
+         }, 
+         "wait": []
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "settings": {
+                  "ada": {
+                     "scenarioVariables": {}, 
+                     "enableDiagnostics": false, 
+                     "defaultCharset": "ISO-8859-1"
+                  }
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "method": "workspace/didChangeConfiguration"
+         }, 
+         "wait": []
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "text": "package common_pack is\n   Foo : Integer := 42;\n\n   function Common_Fun return Integer;\n\nend common_pack;\n", 
+                  "version": 0, 
+                  "uri": "$URI{common/common_pack.ads}", 
+                  "languageId": "Ada"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "method": "textDocument/didOpen"
+         }, 
+         "wait": []
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "text": "package body Common_Pack is\n   function Common_Fun return Integer is (2);\nend Common_Pack;\n", 
+                  "version": 0, 
+                  "uri": "$URI{p/common_pack.adb}", 
+                  "languageId": "Ada"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "method": "textDocument/didOpen"
+         }, 
+         "wait": []
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "text": "package body Common_Pack is\n   function Common_Fun return Integer is (1);\nend Common_Pack;\n", 
+                  "version": 0, 
+                  "uri": "$URI{q/common_pack.adb}", 
+                  "languageId": "Ada"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "method": "textDocument/didOpen"
+         }, 
+         "wait": []
+      }
+   }, 
+   {"comment": "------------  check that bodies are found in both projects ---------"},
+   {
+      "send": {
+         "request": {
+            "params": {
+               "position": {
+                  "line": 3, 
+                  "character": 12
+               }, 
+               "textDocument": {
+                  "uri": "$URI{common/common_pack.ads}"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "id": 2, 
+            "method": "textDocument/implementation"
+         }, 
+         "wait": [
+            {
+               "id": 2, 
+               "result": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 1, 
+                           "character": 12
+                        }, 
+                        "end": {
+                           "line": 1, 
+                           "character": 22
+                        }
+                     }, 
+                     "uri": "$URI{p/common_pack.adb}"
+                  }, 
+                  {
+                     "range": {
+                        "start": {
+                           "line": 1, 
+                           "character": 12
+                        }, 
+                        "end": {
+                           "line": 1, 
+                           "character": 22
+                        }
+                     }, 
+                     "uri": "$URI{q/common_pack.adb}"
+                  }
+               ]
+            }
+         ]
+      }
+   }, 
+   {"comment": "------------ query hovers on targets ---------"},
+   {
+      "send": {
+         "request": {
+            "params": {
+               "position": {
+                  "line": 1, 
+                  "character": 12
+               }, 
+               "textDocument": {
+                  "uri": "$URI{p/common_pack.adb}"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "id": 3, 
+            "method": "textDocument/hover"
+         }, 
+         "wait": [
+            {
+               "id": 3, 
+               "result": {
+                  "contents": [
+                     {
+                        "value": "function Common_Fun return Integer", 
+                        "language": "ada"
+                     }, 
+                     "at common_pack.ads (4:4)"
+                  ]
+               }
+            }
+         ]
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "position": {
+                  "line": 1, 
+                  "character": 12
+               }, 
+               "textDocument": {
+                  "uri": "$URI{p/common_pack.adb}"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "id": 4, 
+            "method": "textDocument/hover"
+         }, 
+         "wait": [
+            {
+               "id": 4, 
+               "result": {
+                  "contents": [
+                     {
+                        "value": "function Common_Fun return Integer", 
+                        "language": "ada"
+                     }, 
+                     "at common_pack.ads (4:4)"
+                  ]
+               }
+            }
+         ]
+      }
+   }, 
+   {"comment": "------------  check again that bodies are found in both projects ---------"},
+   {
+      "send": {
+         "request": {
+            "params": {
+               "position": {
+                  "line": 3, 
+                  "character": 12
+               }, 
+               "textDocument": {
+                  "uri": "$URI{common/common_pack.ads}"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "id": 5, 
+            "method": "textDocument/implementation"
+         }, 
+         "wait": [
+            {
+               "id": 5, 
+               "result": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 1, 
+                           "character": 12
+                        }, 
+                        "end": {
+                           "line": 1, 
+                           "character": 22
+                        }
+                     }, 
+                     "uri": "$URI{p/common_pack.adb}"
+                  }, 
+                  {
+                     "range": {
+                        "start": {
+                           "line": 1, 
+                           "character": 12
+                        }, 
+                        "end": {
+                           "line": 1, 
+                           "character": 22
+                        }
+                     }, 
+                     "uri": "$URI{q/common_pack.adb}"
+                  }
+               ]
+            }
+         ]
+      }
+   }, 
+   {"comment": "------------  check for 'definition' calls ---------"},
+   {
+      "send": {
+         "request": {
+            "params": {
+               "position": {
+                  "line": 1, 
+                  "character": 12
+               }, 
+               "textDocument": {
+                  "uri": "$URI{q/common_pack.adb}"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "id": 9, 
+            "method": "textDocument/definition"
+         }, 
+         "wait": [
+            {
+               "id": 9, 
+               "result": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 3, 
+                           "character": 12
+                        }, 
+                        "end": {
+                           "line": 3, 
+                           "character": 22
+                        }
+                     }, 
+                     "uri": "$URI{common/common_pack.ads}"
+                  }
+               ]
+            }
+         ]
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "position": {
+                  "line": 1, 
+                  "character": 12
+               }, 
+               "textDocument": {
+                  "uri": "$URI{p/common_pack.adb}"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "id": 10, 
+            "method": "textDocument/definition"
+         }, 
+         "wait": [
+            {
+               "id": 10, 
+               "result": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 3, 
+                           "character": 12
+                        }, 
+                        "end": {
+                           "line": 3, 
+                           "character": 22
+                        }
+                     }, 
+                     "uri": "$URI{common/common_pack.ads}"
+                  }
+               ]
+            }
+         ]
+      }
+   }, 
+   {"comment": "------------  check again that bodies are found in both projects ---------"},
+   {
+      "send": {
+         "request": {
+            "params": {
+               "position": {
+                  "line": 3, 
+                  "character": 12
+               }, 
+               "textDocument": {
+                  "uri": "$URI{common/common_pack.ads}"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "id": 11, 
+            "method": "textDocument/implementation"
+         }, 
+         "wait": [
+            {
+               "id": 11, 
+               "result": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 1, 
+                           "character": 12
+                        }, 
+                        "end": {
+                           "line": 1, 
+                           "character": 22
+                        }
+                     }, 
+                     "uri": "$URI{p/common_pack.adb}"
+                  }, 
+                  {
+                     "range": {
+                        "start": {
+                           "line": 1, 
+                           "character": 12
+                        }, 
+                        "end": {
+                           "line": 1, 
+                           "character": 22
+                        }
+                     }, 
+                     "uri": "$URI{q/common_pack.adb}"
+                  }
+               ]
+            }
+         ]
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{common/common_pack.ads}"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "method": "textDocument/didClose"
+         }, 
+         "wait": []
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{q/common_pack.adb}"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "method": "textDocument/didClose"
+         }, 
+         "wait": []
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{p/common_pack.adb}"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "method": "textDocument/didClose"
+         }, 
+         "wait": []
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0", 
+            "id": 14, 
+            "method": "shutdown"
+         }, 
+         "wait": [
+            {
+               "id": 14, 
+               "result": null
+            }
+         ]
+      }
+   }, 
+   {
+      "stop": {
+         "exit_code": 0
+      }
+   }
+]

--- a/testsuite/ada_lsp/implementation.aggregates/test.yaml
+++ b/testsuite/ada_lsp/implementation.aggregates/test.yaml
@@ -1,0 +1,1 @@
+title: 'implementation.aggregates'

--- a/testsuite/ada_lsp/implementation/p.gpr
+++ b/testsuite/ada_lsp/implementation/p.gpr
@@ -1,0 +1,6 @@
+project P is
+
+   for Main use ("foo3.adb") & project'Main;
+
+end P;
+

--- a/testsuite/ada_lsp/implementation/pack-foo3.adb
+++ b/testsuite/ada_lsp/implementation/pack-foo3.adb
@@ -1,0 +1,4 @@
+separate (pack) procedure foo3 is
+begin
+   raise Constraint_Error;
+end foo3;

--- a/testsuite/ada_lsp/implementation/pack.adb
+++ b/testsuite/ada_lsp/implementation/pack.adb
@@ -1,0 +1,9 @@
+package body pack is
+
+   type R is null record;
+   
+   procedure Foo is null;
+
+   procedure Foo3 is separate;
+   
+end pack;

--- a/testsuite/ada_lsp/implementation/pack.ads
+++ b/testsuite/ada_lsp/implementation/pack.ads
@@ -1,0 +1,15 @@
+package pack is
+
+   procedure Foo;
+
+   procedure Foo2;
+   
+   procedure Foo3;
+   
+private
+   
+   procedure Foo2 is null;
+   
+   type R;
+   
+end pack;

--- a/testsuite/ada_lsp/implementation/test.json
+++ b/testsuite/ada_lsp/implementation/test.json
@@ -1,0 +1,518 @@
+[
+   {
+      "comment": [
+         "basic test for textdocument/implementation"
+      ]
+   }, 
+   {
+      "start": {
+         "cmd": [
+            "${ALS}"
+         ]
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "capabilities": {
+                  "textDocument": {
+                     "completion": {
+                        "completionItemKind": {}
+                     }, 
+                     "documentLink": {}, 
+                     "formatting": {}, 
+                     "documentHighlight": {}, 
+                     "synchronization": {}, 
+                     "references": {}, 
+                     "rangeFormatting": {}, 
+                     "onTypeFormatting": {}, 
+                     "codeLens": {}, 
+                     "colorProvider": {}
+                  }, 
+                  "workspace": {
+                     "applyEdit": false, 
+                     "executeCommand": {}, 
+                     "didChangeWatchedFiles": {}, 
+                     "workspaceEdit": {}, 
+                     "didChangeConfiguration": {}
+                  }
+               }, 
+               "rootUri": "$URI{.}"
+            }, 
+            "jsonrpc": "2.0", 
+            "id": 1, 
+            "method": "initialize"
+         }, 
+         "wait": [
+            {
+               "id": 1, 
+               "result": {
+                  "capabilities": {
+                     "executeCommandProvider": {
+                        "commands": []
+                     }, 
+                     "typeDefinitionProvider": true, 
+                     "alsReferenceKinds": [
+                        "write", 
+                        "call", 
+                        "dispatching call", 
+                        "parent", 
+                        "child"
+                     ], 
+                     "hoverProvider": true, 
+                     "definitionProvider": true, 
+                     "renameProvider": true, 
+                     "alsCalledByProvider": true, 
+                     "referencesProvider": true, 
+                     "declarationProvider": true, 
+                     "textDocumentSync": 1, 
+                     "documentLinkProvider": {}, 
+                     "completionProvider": {
+                        "triggerCharacters": [
+                           "."
+                        ], 
+                        "resolveProvider": false
+                     }, 
+                     "documentSymbolProvider": true
+                  }
+               }
+            }
+         ]
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0", 
+            "method": "initialized"
+         }, 
+         "wait": []
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "settings": {
+                  "ada": {
+                     "scenarioVariables": {}, 
+                     "enableDiagnostics": false, 
+                     "defaultCharset": "ISO-8859-1"
+                  }
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "method": "workspace/didChangeConfiguration"
+         }, 
+         "wait": []
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "text": "package pack is\n\n   procedure Foo;\n\n   procedure Foo2;\n   \n   procedure Foo3;\n   \nprivate\n   \n   procedure Foo2 is null;\n   \n   type R;\n   \nend pack;\n", 
+                  "version": 0, 
+                  "uri": "$URI{pack.ads}", 
+                  "languageId": "Ada"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "method": "textDocument/didOpen"
+         }, 
+         "wait": []
+      }
+   }, 
+   {"comment": "------------- pack.ads  Foo -> return implementation in the body --------"},
+   {
+      "send": {
+         "request": {
+            "params": {
+               "position": {
+                  "line": 2, 
+                  "character": 13
+               }, 
+               "textDocument": {
+                  "uri": "$URI{pack.ads}"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "id": 2, 
+            "method": "textDocument/implementation"
+         }, 
+         "wait": [
+            {
+               "id": 2, 
+               "result": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 4, 
+                           "character": 13
+                        }, 
+                        "end": {
+                           "line": 4, 
+                           "character": 16
+                        }
+                     }, 
+                     "uri": "$URI{pack.adb}"
+                  }
+               ]
+            }
+         ]
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "text": "package body pack is\n\n   type R is null record;\n   \n   procedure Foo is null;\n\n   procedure Foo3 is separate;\n   \nend pack;\n", 
+                  "version": 0, 
+                  "uri": "$URI{pack.adb}", 
+                  "languageId": "Ada"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "method": "textDocument/didOpen"
+         }, 
+         "wait": []
+      }
+   }, 
+   {"comment": "------------- Foo on the body -> stay on the body --------"},
+   {
+      "send": {
+         "request": {
+            "params": {
+               "position": {
+                  "line": 4, 
+                  "character": 13
+               }, 
+               "textDocument": {
+                  "uri": "$URI{pack.adb}"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "id": 3, 
+            "method": "textDocument/implementation"
+         }, 
+         "wait": [
+            {
+               "id": 3, 
+               "result": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 4, 
+                           "character": 13
+                        }, 
+                        "end": {
+                           "line": 4, 
+                           "character": 16
+                        }
+                     }, 
+                     "uri": "$URI{pack.adb}"
+                  }
+               ]
+            }
+         ]
+      }
+   }, 
+   {"comment": "------------- definition Foo on the body -> go back to the spec --------"},
+   {
+      "send": {
+         "request": {
+            "params": {
+               "position": {
+                  "line": 4, 
+                  "character": 13
+               }, 
+               "textDocument": {
+                  "uri": "$URI{pack.adb}"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "id": 4, 
+            "method": "textDocument/definition"
+         }, 
+         "wait": [
+            {
+               "id": 4, 
+               "result": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 2, 
+                           "character": 13
+                        }, 
+                        "end": {
+                           "line": 2, 
+                           "character": 16
+                        }
+                     }, 
+                     "uri": "$URI{pack.ads}"
+                  }
+               ]
+            }
+         ]
+      }
+   }, 
+   {"comment": "------------- Foo2 on the spec -> find the private implementation --------"},
+   {
+      "send": {
+         "request": {
+            "params": {
+               "position": {
+                  "line": 4, 
+                  "character": 13
+               }, 
+               "textDocument": {
+                  "uri": "$URI{pack.ads}"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "id": 5, 
+            "method": "textDocument/implementation"
+         }, 
+         "wait": [
+            {
+               "id": 5, 
+               "result": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 10, 
+                           "character": 13
+                        }, 
+                        "end": {
+                           "line": 10, 
+                           "character": 17
+                        }
+                     }, 
+                     "uri": "$URI{pack.ads}"
+                  }
+               ]
+            }
+         ]
+      }
+   }, 
+   {"comment": "------------- Foo2 on the private implementation ->  stay there --------"},
+   {
+      "send": {
+         "request": {
+            "params": {
+               "position": {
+                  "line": 10, 
+                  "character": 13
+               }, 
+               "textDocument": {
+                  "uri": "$URI{pack.ads}"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "id": 6, 
+            "method": "textDocument/implementation"
+         }, 
+         "wait": [
+            {
+               "id": 6, 
+               "result": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 10, 
+                           "character": 13
+                        }, 
+                        "end": {
+                           "line": 10, 
+                           "character": 17
+                        }
+                     }, 
+                     "uri": "$URI{pack.ads}"
+                  }
+               ]
+            }
+         ]
+      }
+   }, 
+   {"comment": "------------- Foo3 on the spec ->  list body AND separate implementation --------"},
+   {
+      "send": {
+         "request": {
+            "params": {
+               "position": {
+                  "line": 6, 
+                  "character": 13
+               }, 
+               "textDocument": {
+                  "uri": "$URI{pack.ads}"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "id": 7, 
+            "method": "textDocument/implementation"
+         }, 
+         "wait": [
+            {
+               "id": 7, 
+               "result": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 6, 
+                           "character": 13
+                        }, 
+                        "end": {
+                           "line": 6, 
+                           "character": 17
+                        }
+                     }, 
+                     "uri": "$URI{pack.adb}"
+                  }, 
+                  {
+                     "range": {
+                        "start": {
+                           "line": 0, 
+                           "character": 26
+                        }, 
+                        "end": {
+                           "line": 0, 
+                           "character": 30
+                        }
+                     }, 
+                     "uri": "$URI{pack-foo3.adb}"
+                  }
+               ]
+            }
+         ]
+      }
+   }, 
+   {"comment": "------------- R on the spec ->  find completion in body --------"},
+   {
+      "send": {
+         "request": {
+            "params": {
+               "position": {
+                  "line": 12, 
+                  "character": 8
+               }, 
+               "textDocument": {
+                  "uri": "$URI{pack.ads}"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "id": 9, 
+            "method": "textDocument/implementation"
+         }, 
+         "wait": [
+            {
+               "id": 9, 
+               "result": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 2, 
+                           "character": 8
+                        }, 
+                        "end": {
+                           "line": 2, 
+                           "character": 9
+                        }
+                     }, 
+                     "uri": "$URI{pack.adb}"
+                  }
+               ]
+            }
+         ]
+      }
+   }, 
+   {"comment": "------------- R on the body ->  stay on the body --------"},
+   {
+      "send": {
+         "request": {
+            "params": {
+               "position": {
+                  "line": 2, 
+                  "character": 8
+               }, 
+               "textDocument": {
+                  "uri": "$URI{pack.adb}"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "id": 10, 
+            "method": "textDocument/implementation"
+         }, 
+         "wait": [
+            {
+               "id": 10, 
+               "result": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 2, 
+                           "character": 8
+                        }, 
+                        "end": {
+                           "line": 2, 
+                           "character": 9
+                        }
+                     }, 
+                     "uri": "$URI{pack.adb}"
+                  }
+               ]
+            }
+         ]
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{pack.ads}"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "method": "textDocument/didClose"
+         }, 
+         "wait": []
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{pack.adb}"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "method": "textDocument/didClose"
+         }, 
+         "wait": []
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0", 
+            "id": 11, 
+            "method": "shutdown"
+         }, 
+         "wait": [
+            {
+               "id": 11, 
+               "result": null
+            }
+         ]
+      }
+   }, 
+   {
+      "stop": {
+         "exit_code": 0
+      }
+   }
+]

--- a/testsuite/ada_lsp/implementation/test.yaml
+++ b/testsuite/ada_lsp/implementation/test.yaml
@@ -1,0 +1,1 @@
+title: 'implementation'


### PR DESCRIPTION
Generate the boilerplate to support this, and implement the body.

Revisit the way we handle contexts: store the source files in an ordered
set to improve speed of lookup and memory management.