### PR TITLE
SA18-022: Allow renaming overriding/base primitives

### DIFF
--- a/source/ada/lsp-ada_contexts.ads
+++ b/source/ada/lsp-ada_contexts.ads
@@ -97,6 +97,7 @@ package LSP.Ada_Contexts is
    --  when textDocument/definition requests happen on dispatching calls.
    --  Imprecise_Results is set to True if we don't know whether the results
    --  are precise.
+   --  Returns an empty array if Decl is null.
 
    function Find_All_Base_Declarations
      (Self              : Context;
@@ -107,6 +108,7 @@ package LSP.Ada_Contexts is
    --  that it inherits, not including self.
    --  Imprecise_Results is set to True if we don't know whether the results
    --  are precise.
+   --  Returns an empty array if Decl is null.
 
    function Find_All_Calls
      (Self              : Context;
@@ -115,6 +117,16 @@ package LSP.Ada_Contexts is
       return Libadalang.Analysis.Base_Id_Array;
    --  Return all the enclosing entities that call Definition in all sources
    --  known to this project.
+
+   function Get_References_For_Renaming
+     (Self              : Context;
+      Definition        : Libadalang.Analysis.Defining_Name;
+      Imprecise_Results : out Boolean)
+      return Libadalang.Analysis.Base_Id_Array;
+   --  Get all the references to a given defining name in all units for
+   --  renaming purposes: for instance, when called on a tagged type primitive
+   --  definition, references to the base subprograms it inherits and to the
+   --  overriding ones are also returned.
 
    function Is_Part_Of_Project
      (Self : Context;

--- a/source/ada/lsp-lal_utils.adb
+++ b/source/ada/lsp-lal_utils.adb
@@ -182,6 +182,24 @@ package body LSP.Lal_Utils is
       return Location;
    end Get_Node_Location;
 
+   ----------------------
+   -- To_Base_Id_Array --
+   ----------------------
+
+   function To_Base_Id_Array
+     (Basic_Decls : Basic_Decl_Array) return Base_Id_Array
+   is
+      Base_Ids : Base_Id_Array (Basic_Decls'Range);
+      Idx      : Positive := Base_Ids'First;
+   begin
+      for Decl of Basic_Decls loop
+         Base_Ids (Idx) := Decl.P_Defining_Name.F_Name.As_Base_Id;
+         Idx := Idx + 1;
+      end loop;
+
+      return Base_Ids;
+   end To_Base_Id_Array;
+
    ------------------
    -- Resolve_Name --
    ------------------

--- a/source/ada/lsp-lal_utils.ads
+++ b/source/ada/lsp-lal_utils.ads
@@ -85,6 +85,11 @@ package LSP.Lal_Utils is
    --  Return the location of the given node. Populate alsKind field of the
    --  result with given Kind.
 
+   function To_Base_Id_Array
+     (Basic_Decls : Basic_Decl_Array) return Base_Id_Array;
+   --  Convert the given Basic_Decl_Array into a Base_Id_Array by retrieving
+   --  the defining names of all the given declarations.
+
    ---------------
    -- Called_By --
    ---------------

--- a/testsuite/ada_lsp/rename.tagged_type_primitives/children.adb
+++ b/testsuite/ada_lsp/rename.tagged_type_primitives/children.adb
@@ -1,0 +1,10 @@
+with Ada.Text_IO;
+
+package body Children is
+
+   procedure Primitive (Self : Child) is
+   begin
+      Ada.Text_IO.Put_Line ("Child");
+   end Primitive;
+
+end Children;

--- a/testsuite/ada_lsp/rename.tagged_type_primitives/children.ads
+++ b/testsuite/ada_lsp/rename.tagged_type_primitives/children.ads
@@ -1,0 +1,8 @@
+with Parents; use Parents;
+package Children is
+
+   type Child is new Parent with null Record;
+
+   procedure Primitive (Self : Child);
+
+end Children;

--- a/testsuite/ada_lsp/rename.tagged_type_primitives/default.gpr
+++ b/testsuite/ada_lsp/rename.tagged_type_primitives/default.gpr
@@ -1,0 +1,5 @@
+project Default is
+
+   for Main use ("main.adb");
+
+end Default;

--- a/testsuite/ada_lsp/rename.tagged_type_primitives/great_children.adb
+++ b/testsuite/ada_lsp/rename.tagged_type_primitives/great_children.adb
@@ -1,0 +1,10 @@
+with Ada.Text_IO;
+
+package body Great_Children is
+
+   procedure Primitive (Self : Great_Child) is
+   begin
+      Ada.Text_IO.Put_Line ("Great child");
+   end Primitive;
+
+end Great_Children;

--- a/testsuite/ada_lsp/rename.tagged_type_primitives/great_children.ads
+++ b/testsuite/ada_lsp/rename.tagged_type_primitives/great_children.ads
@@ -1,0 +1,8 @@
+with Children; use Children;
+package Great_Children is
+
+   type Great_Child is new Child with null Record;
+
+   procedure Primitive (Self : Great_Child);
+
+end Great_Children;

--- a/testsuite/ada_lsp/rename.tagged_type_primitives/main.adb
+++ b/testsuite/ada_lsp/rename.tagged_type_primitives/main.adb
@@ -1,0 +1,8 @@
+with Children; use Children;
+with Great_Children; use Great_Children;
+
+procedure Main is
+   Obj : constant Child'Class := Great_Child'(others => <>);
+begin
+   Obj.Primitive;
+end Main;

--- a/testsuite/ada_lsp/rename.tagged_type_primitives/parents.ads
+++ b/testsuite/ada_lsp/rename.tagged_type_primitives/parents.ads
@@ -1,0 +1,10 @@
+package Parents is
+
+   type Parent is abstract tagged record
+      A : Integer;
+   end record;
+
+   procedure Primitive (Self : Parent) is abstract;
+   --  Parent procedure
+
+end Parents;

--- a/testsuite/ada_lsp/rename.tagged_type_primitives/test.json
+++ b/testsuite/ada_lsp/rename.tagged_type_primitives/test.json
@@ -1,0 +1,802 @@
+[
+   {
+      "comment": [
+          "This test checks that textDocument/rename on tagged type ",
+          "primitives renames also the suprograms it inherits and the ",
+          "overriding ones."
+      ]
+   },
+   {
+      "start": {
+         "cmd": [
+            "${ALS}"
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "processId": 26765,
+               "capabilities": {
+                  "textDocument": {
+                     "completion": {
+                        "completionItemKind": {}
+                     },
+                     "documentLink": {},
+                     "formatting": {},
+                     "documentHighlight": {},
+                     "synchronization": {},
+                     "references": {},
+                     "rangeFormatting": {},
+                     "onTypeFormatting": {},
+                     "codeLens": {},
+                     "colorProvider": {}
+                  },
+                  "workspace": {
+                     "applyEdit": false,
+                     "executeCommand": {},
+                     "didChangeWatchedFiles": {},
+                     "workspaceEdit": {},
+                     "didChangeConfiguration": {}
+                  }
+               },
+               "rootUri": "$URI{.}"
+            },
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize"
+         },
+         "wait": [
+            {
+               "id": 1,
+               "result": {
+                  "capabilities": {
+                     "executeCommandProvider": {
+                        "commands": []
+                     },
+                     "typeDefinitionProvider": true,
+                     "alsReferenceKinds": [
+                        "write",
+                        "call",
+                        "dispatching call",
+                        "parent",
+                        "child"
+                     ],
+                     "hoverProvider": true,
+                     "definitionProvider": true,
+                     "renameProvider": true,
+                     "alsCalledByProvider": true,
+                     "referencesProvider": true,
+                     "declarationProvider": true,
+                     "textDocumentSync": 1,
+                     "documentLinkProvider": {},
+                     "completionProvider": {
+                        "triggerCharacters": [
+                           "."
+                        ],
+                        "resolveProvider": false
+                     },
+                     "documentSymbolProvider": true
+                  }
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "initialized"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "settings": {
+                  "ada": {
+                     "projectFile": "$URI{default.gpr}",
+                     "scenarioVariables": {},
+                     "enableDiagnostics": false,
+                     "enableIndexing": false,
+                     "defaultCharset": "ISO-8859-1"
+                  }
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "workspace/didChangeConfiguration"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "text": "with Children; use Children;\nwith Great_Children; use Great_Children;\n\nprocedure Main is\n   Obj : constant Child'Class := Great_Child'(others => <>);\nbegin\n   Obj.Primitive;\nend Main;\n",
+                  "version": 0,
+                  "uri": "$URI{main.adb}",
+                  "languageId": "Ada"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "settings": {
+                  "ada": {
+                     "renameInComments": true
+                  }
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "workspace/didChangeConfiguration"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "newName": "New_Primitive",
+               "position": {
+                  "line": 6,
+                  "character": 7
+               },
+               "textDocument": {
+                  "uri": "$URI{main.adb}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "textDocument/rename"
+         },
+         "wait": [
+            {
+               "id": 2,
+               "result": {
+                  "changes": {
+                     "$URI{great_children.ads}": [
+                        {
+                           "newText": "New_Primitive",
+                           "range": {
+                              "start": {
+                                 "line": 5,
+                                 "character": 13
+                              },
+                              "end": {
+                                 "line": 5,
+                                 "character": 22
+                              }
+                           }
+                        }
+                     ],
+                     "$URI{children.ads}": [
+                        {
+                           "newText": "New_Primitive",
+                           "range": {
+                              "start": {
+                                 "line": 5,
+                                 "character": 13
+                              },
+                              "end": {
+                                 "line": 5,
+                                 "character": 22
+                              }
+                           }
+                        }
+                     ],
+                     "$URI{parents.ads}": [
+                        {
+                           "newText": "New_Primitive",
+                           "range": {
+                              "start": {
+                                 "line": 6,
+                                 "character": 13
+                              },
+                              "end": {
+                                 "line": 6,
+                                 "character": 22
+                              }
+                           }
+                        }
+                     ],
+                     "$URI{great_children.adb}": [
+                        {
+                           "newText": "New_Primitive",
+                           "range": {
+                              "start": {
+                                 "line": 4,
+                                 "character": 13
+                              },
+                              "end": {
+                                 "line": 4,
+                                 "character": 22
+                              }
+                           }
+                        },
+                        {
+                           "newText": "New_Primitive",
+                           "range": {
+                              "start": {
+                                 "line": 7,
+                                 "character": 7
+                              },
+                              "end": {
+                                 "line": 7,
+                                 "character": 16
+                              }
+                           }
+                        }
+                     ],
+                     "$URI{children.adb}": [
+                        {
+                           "newText": "New_Primitive",
+                           "range": {
+                              "start": {
+                                 "line": 4,
+                                 "character": 13
+                              },
+                              "end": {
+                                 "line": 4,
+                                 "character": 22
+                              }
+                           }
+                        },
+                        {
+                           "newText": "New_Primitive",
+                           "range": {
+                              "start": {
+                                 "line": 7,
+                                 "character": 7
+                              },
+                              "end": {
+                                 "line": 7,
+                                 "character": 16
+                              }
+                           }
+                        }
+                     ],
+                     "$URI{main.adb}": [
+                        {
+                           "newText": "New_Primitive",
+                           "range": {
+                              "start": {
+                                 "line": 6,
+                                 "character": 7
+                              },
+                              "end": {
+                                 "line": 6,
+                                 "character": 16
+                              }
+                           }
+                        }
+                     ]
+                  }
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "text": "with Children; use Children;\npackage Great_Children is\n\n   type Great_Child is new Child with null Record;\n\n   procedure Primitive (Self : Great_Child);\n\nend Great_Children;\n",
+                  "version": 0,
+                  "uri": "$URI{great_children.ads}",
+                  "languageId": "Ada"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "contentChanges": [
+                  {
+                     "text": "with Children; use Children;\npackage Great_Children is\n\n   type Great_Child is new Child with null Record;\n\n   procedure  (Self : Great_Child);\n\nend Great_Children;\n"
+                  }
+               ],
+               "textDocument": {
+                  "version": 1,
+                  "uri": "$URI{great_children.ads}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "contentChanges": [
+                  {
+                     "text": "with Children; use Children;\npackage Great_Children is\n\n   type Great_Child is new Child with null Record;\n\n   procedure New_Primitive (Self : Great_Child);\n\nend Great_Children;\n"
+                  }
+               ],
+               "textDocument": {
+                  "version": 2,
+                  "uri": "$URI{great_children.ads}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{great_children.ads}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didClose"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "contentChanges": [
+                  {
+                     "text": "with Children; use Children;\nwith Great_Children; use Great_Children;\n\nprocedure Main is\n   Obj : constant Child'Class := Great_Child'(others => <>);\nbegin\n   Obj.;\nend Main;\n"
+                  }
+               ],
+               "textDocument": {
+                  "version": 1,
+                  "uri": "$URI{main.adb}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "contentChanges": [
+                  {
+                     "text": "with Children; use Children;\nwith Great_Children; use Great_Children;\n\nprocedure Main is\n   Obj : constant Child'Class := Great_Child'(others => <>);\nbegin\n   Obj.New_Primitive;\nend Main;\n"
+                  }
+               ],
+               "textDocument": {
+                  "version": 2,
+                  "uri": "$URI{main.adb}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "text": "with Ada.Text_IO;\n\npackage body Children is\n\n   procedure Primitive (Self : Child) is\n   begin\n      Ada.Text_IO.Put_Line (\"Child\");\n   end Primitive;\n\nend Children;\n",
+                  "version": 0,
+                  "uri": "$URI{children.adb}",
+                  "languageId": "Ada"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "contentChanges": [
+                  {
+                     "text": "with Ada.Text_IO;\n\npackage body Children is\n\n   procedure Primitive (Self : Child) is\n   begin\n      Ada.Text_IO.Put_Line (\"Child\");\n   end ;\n\nend Children;\n"
+                  }
+               ],
+               "textDocument": {
+                  "version": 1,
+                  "uri": "$URI{children.adb}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "contentChanges": [
+                  {
+                     "text": "with Ada.Text_IO;\n\npackage body Children is\n\n   procedure Primitive (Self : Child) is\n   begin\n      Ada.Text_IO.Put_Line (\"Child\");\n   end New_Primitive;\n\nend Children;\n"
+                  }
+               ],
+               "textDocument": {
+                  "version": 2,
+                  "uri": "$URI{children.adb}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "contentChanges": [
+                  {
+                     "text": "with Ada.Text_IO;\n\npackage body Children is\n\n   procedure  (Self : Child) is\n   begin\n      Ada.Text_IO.Put_Line (\"Child\");\n   end New_Primitive;\n\nend Children;\n"
+                  }
+               ],
+               "textDocument": {
+                  "version": 3,
+                  "uri": "$URI{children.adb}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "contentChanges": [
+                  {
+                     "text": "with Ada.Text_IO;\n\npackage body Children is\n\n   procedure New_Primitive (Self : Child) is\n   begin\n      Ada.Text_IO.Put_Line (\"Child\");\n   end New_Primitive;\n\nend Children;\n"
+                  }
+               ],
+               "textDocument": {
+                  "version": 4,
+                  "uri": "$URI{children.adb}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{children.adb}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didClose"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "text": "package Parents is\n\n   type Parent is abstract tagged record\n      A : Integer;\n   end record;\n\n   procedure Primitive (Self : Parent) is abstract;\n   --  Parent procedure\n\nend Parents;\n",
+                  "version": 0,
+                  "uri": "$URI{parents.ads}",
+                  "languageId": "Ada"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "contentChanges": [
+                  {
+                     "text": "package Parents is\n\n   type Parent is abstract tagged record\n      A : Integer;\n   end record;\n\n   procedure  (Self : Parent) is abstract;\n   --  Parent procedure\n\nend Parents;\n"
+                  }
+               ],
+               "textDocument": {
+                  "version": 1,
+                  "uri": "$URI{parents.ads}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "contentChanges": [
+                  {
+                     "text": "package Parents is\n\n   type Parent is abstract tagged record\n      A : Integer;\n   end record;\n\n   procedure New_Primitive (Self : Parent) is abstract;\n   --  Parent procedure\n\nend Parents;\n"
+                  }
+               ],
+               "textDocument": {
+                  "version": 2,
+                  "uri": "$URI{parents.ads}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{parents.ads}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didClose"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "text": "with Parents; use Parents;\npackage Children is\n\n   type Child is new Parent with null Record;\n\n   procedure Primitive (Self : Child);\n\nend Children;\n",
+                  "version": 0,
+                  "uri": "$URI{children.ads}",
+                  "languageId": "Ada"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "contentChanges": [
+                  {
+                     "text": "with Parents; use Parents;\npackage Children is\n\n   type Child is new Parent with null Record;\n\n   procedure  (Self : Child);\n\nend Children;\n"
+                  }
+               ],
+               "textDocument": {
+                  "version": 1,
+                  "uri": "$URI{children.ads}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "contentChanges": [
+                  {
+                     "text": "with Parents; use Parents;\npackage Children is\n\n   type Child is new Parent with null Record;\n\n   procedure New_Primitive (Self : Child);\n\nend Children;\n"
+                  }
+               ],
+               "textDocument": {
+                  "version": 2,
+                  "uri": "$URI{children.ads}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{children.ads}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didClose"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "text": "with Ada.Text_IO;\n\npackage body Great_Children is\n\n   procedure Primitive (Self : Great_Child) is\n   begin\n      Ada.Text_IO.Put_Line (\"Great child\");\n   end Primitive;\n\nend Great_Children;\n",
+                  "version": 0,
+                  "uri": "$URI{great_children.adb}",
+                  "languageId": "Ada"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "contentChanges": [
+                  {
+                     "text": "with Ada.Text_IO;\n\npackage body Great_Children is\n\n   procedure Primitive (Self : Great_Child) is\n   begin\n      Ada.Text_IO.Put_Line (\"Great child\");\n   end ;\n\nend Great_Children;\n"
+                  }
+               ],
+               "textDocument": {
+                  "version": 1,
+                  "uri": "$URI{great_children.adb}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "contentChanges": [
+                  {
+                     "text": "with Ada.Text_IO;\n\npackage body Great_Children is\n\n   procedure Primitive (Self : Great_Child) is\n   begin\n      Ada.Text_IO.Put_Line (\"Great child\");\n   end New_Primitive;\n\nend Great_Children;\n"
+                  }
+               ],
+               "textDocument": {
+                  "version": 2,
+                  "uri": "$URI{great_children.adb}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "contentChanges": [
+                  {
+                     "text": "with Ada.Text_IO;\n\npackage body Great_Children is\n\n   procedure  (Self : Great_Child) is\n   begin\n      Ada.Text_IO.Put_Line (\"Great child\");\n   end New_Primitive;\n\nend Great_Children;\n"
+                  }
+               ],
+               "textDocument": {
+                  "version": 3,
+                  "uri": "$URI{great_children.adb}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "contentChanges": [
+                  {
+                     "text": "with Ada.Text_IO;\n\npackage body Great_Children is\n\n   procedure New_Primitive (Self : Great_Child) is\n   begin\n      Ada.Text_IO.Put_Line (\"Great child\");\n   end New_Primitive;\n\nend Great_Children;\n"
+                  }
+               ],
+               "textDocument": {
+                  "version": 4,
+                  "uri": "$URI{great_children.adb}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{great_children.adb}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didClose"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{main.adb}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didClose"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "shutdown"
+         },
+         "wait": [
+            {
+               "id": 3,
+               "result": null
+            }
+         ]
+      }
+   },
+   {
+      "stop": {
+         "exit_code": 0
+      }
+   }
+]

--- a/testsuite/ada_lsp/rename.tagged_type_primitives/test.yaml
+++ b/testsuite/ada_lsp/rename.tagged_type_primitives/test.yaml
@@ -1,0 +1,1 @@
+title: 'rename.tagged_type_primitives'


### PR DESCRIPTION
The textDocument/rename request handler now also renames the overriding
and base primitives when dealing with tagged type primitives.

An automatic test has been added.