### PR TITLE
SC19-050 Fix textDocument/typeDefinition

### DIFF
--- a/testsuite/ada_lsp/type_definition.aggregate/agg.gpr
+++ b/testsuite/ada_lsp/type_definition.aggregate/agg.gpr
@@ -1,0 +1,3 @@
+aggregate project Agg is
+   for Project_Files use ("p/p.gpr", "q/q.gpr");
+end Agg;

--- a/testsuite/ada_lsp/type_definition.aggregate/common/common_pack.ads
+++ b/testsuite/ada_lsp/type_definition.aggregate/common/common_pack.ads
@@ -1,0 +1,6 @@
+with truc; use truc;
+
+package common_pack is
+   X   : My_Definition;
+   Foo : Integer := X.F;
+end common_pack;

--- a/testsuite/ada_lsp/type_definition.aggregate/p-loc.xml
+++ b/testsuite/ada_lsp/type_definition.aggregate/p-loc.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<Locations >
+  <Project>
+    <vfs_file>/export/work/setton/src/ancr/src/gnatstudio/ada_language_server/testsuite/ada_lsp/type_definition.complex/p.gpr</vfs_file>
+    <file_marker column=" 1" line=" 11" >
+      <vfs_project>/export/work/setton/src/ancr/src/gnatstudio/ada_language_server/testsuite/ada_lsp/type_definition.complex/p.gpr</vfs_project>
+      <vfs_file>/export/work/setton/src/ancr/src/gnatstudio/ada_language_server/testsuite/ada_lsp/type_definition.complex/pack.adb</vfs_file>
+    </file_marker>
+    <file_marker column=" 8" line=" 7" >
+      <vfs_project>/export/work/setton/src/ancr/src/gnatstudio/ada_language_server/testsuite/ada_lsp/type_definition.complex/p.gpr</vfs_project>
+      <vfs_file>/export/work/setton/src/ancr/src/gnatstudio/ada_language_server/testsuite/ada_lsp/type_definition.complex/pack.adb</vfs_file>
+    </file_marker>
+    <file_marker column=" 4" line=" 3" >
+      <vfs_project>/export/work/setton/src/ancr/src/gnatstudio/ada_language_server/testsuite/ada_lsp/type_definition.complex/p.gpr</vfs_project>
+      <vfs_file>/export/work/setton/src/ancr/src/gnatstudio/ada_language_server/testsuite/ada_lsp/type_definition.complex/pack.ads</vfs_file>
+    </file_marker>
+    <file_marker column=" 19" line=" 7" >
+      <vfs_project>/export/work/setton/src/ancr/src/gnatstudio/ada_language_server/testsuite/ada_lsp/type_definition.complex/p.gpr</vfs_project>
+      <vfs_file>/export/work/setton/src/ancr/src/gnatstudio/ada_language_server/testsuite/ada_lsp/type_definition.complex/pack.adb</vfs_file>
+    </file_marker>
+    <file_marker current="true" column=" 4" line=" 3" >
+      <vfs_project>/export/work/setton/src/ancr/src/gnatstudio/ada_language_server/testsuite/ada_lsp/type_definition.complex/p.gpr</vfs_project>
+      <vfs_file>/export/work/setton/src/ancr/src/gnatstudio/ada_language_server/testsuite/ada_lsp/type_definition.complex/pack.ads</vfs_file>
+    </file_marker>
+  </Project>
+</Locations>

--- a/testsuite/ada_lsp/type_definition.aggregate/p/main.adb
+++ b/testsuite/ada_lsp/type_definition.aggregate/p/main.adb
@@ -1,0 +1,6 @@
+with common_pack; use common_pack;
+procedure Main is
+   A : Integer := Foo;
+begin
+   null;
+end;

--- a/testsuite/ada_lsp/type_definition.aggregate/p/p.gpr
+++ b/testsuite/ada_lsp/type_definition.aggregate/p/p.gpr
@@ -1,0 +1,3 @@
+project p is
+   for Source_Dirs use (".", "../common");
+end p;

--- a/testsuite/ada_lsp/type_definition.aggregate/p/truc.ads
+++ b/testsuite/ada_lsp/type_definition.aggregate/p/truc.ads
@@ -1,0 +1,7 @@
+package truc is
+
+   type my_definition is record
+      f : integer := 1;
+   end record;
+
+end truc;

--- a/testsuite/ada_lsp/type_definition.aggregate/pack.adb
+++ b/testsuite/ada_lsp/type_definition.aggregate/pack.adb
@@ -1,0 +1,10 @@
+package body pack is
+
+   procedure foo is
+      bla : my_type;
+      comment : my_type;
+   begin
+      bla := comment;
+   end foo;
+
+end pack;

--- a/testsuite/ada_lsp/type_definition.aggregate/pack.ads
+++ b/testsuite/ada_lsp/type_definition.aggregate/pack.ads
@@ -1,0 +1,6 @@
+package pack is
+
+   type my_type is null record;
+   --  bla bla comment
+
+end pack;

--- a/testsuite/ada_lsp/type_definition.aggregate/q/main.adb
+++ b/testsuite/ada_lsp/type_definition.aggregate/q/main.adb
@@ -1,0 +1,6 @@
+with common_pack; use common_pack;
+procedure Main is
+   A : Integer := Foo;
+begin
+   null;
+end;

--- a/testsuite/ada_lsp/type_definition.aggregate/q/q.gpr
+++ b/testsuite/ada_lsp/type_definition.aggregate/q/q.gpr
@@ -1,0 +1,3 @@
+project q is
+   for Source_Dirs use (".", "../common");
+end q;

--- a/testsuite/ada_lsp/type_definition.aggregate/q/truc.ads
+++ b/testsuite/ada_lsp/type_definition.aggregate/q/truc.ads
@@ -1,0 +1,10 @@
+package truc is
+
+   
+   type my_definition is record
+      a : Boolean := False;
+      f : integer := 42;
+   end record;
+
+
+end truc;

--- a/testsuite/ada_lsp/type_definition.aggregate/test.json
+++ b/testsuite/ada_lsp/type_definition.aggregate/test.json
@@ -1,0 +1,266 @@
+[
+   {
+      "comment": [
+         "test typeDefinition in aggregate projects, and test querying it on the actual definition"
+      ]
+   }, 
+   {
+      "start": {
+         "cmd": [
+            "${ALS}"
+         ]
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "capabilities": {
+                  "textDocument": {
+                     "completion": {
+                        "completionItemKind": {}
+                     }, 
+                     "documentLink": {}, 
+                     "formatting": {}, 
+                     "documentHighlight": {}, 
+                     "synchronization": {}, 
+                     "references": {}, 
+                     "rangeFormatting": {}, 
+                     "onTypeFormatting": {}, 
+                     "codeLens": {}, 
+                     "colorProvider": {}
+                  }, 
+                  "workspace": {
+                     "applyEdit": false, 
+                     "executeCommand": {}, 
+                     "didChangeWatchedFiles": {}, 
+                     "workspaceEdit": {}, 
+                     "didChangeConfiguration": {}
+                  }
+               }, 
+               "rootUri": "$URI{.}"
+            }, 
+            "jsonrpc": "2.0", 
+            "id": 1, 
+            "method": "initialize"
+         }, 
+         "wait": [
+            {
+               "id": 1, 
+               "result": {
+                  "capabilities": {
+                     "executeCommandProvider": {
+                        "commands": []
+                     }, 
+                     "typeDefinitionProvider": true, 
+                     "alsReferenceKinds": [
+                        "write", 
+                        "call", 
+                        "dispatching call", 
+                        "parent", 
+                        "child"
+                     ], 
+                     "hoverProvider": true, 
+                     "definitionProvider": true, 
+                     "renameProvider": true, 
+                     "alsCalledByProvider": true, 
+                     "referencesProvider": true, 
+                     "declarationProvider": true, 
+                     "textDocumentSync": 1, 
+                     "documentLinkProvider": {}, 
+                     "completionProvider": {
+                        "triggerCharacters": [
+                           "."
+                        ], 
+                        "resolveProvider": false
+                     }, 
+                     "documentSymbolProvider": true
+                  }
+               }
+            }
+         ]
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0", 
+            "method": "initialized"
+         }, 
+         "wait": []
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "settings": {
+                  "ada": {
+                     "scenarioVariables": {}, 
+                     "enableDiagnostics": false, 
+                     "defaultCharset": "ISO-8859-1"
+                  }
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "method": "workspace/didChangeConfiguration"
+         }, 
+         "wait": []
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "text": "with truc; use truc;\n\npackage common_pack is\n   X   : My_Definition;\n   Foo : Integer := X.F;\nend common_pack;\n", 
+                  "version": 0, 
+                  "uri": "$URI{common/common_pack.ads}", 
+                  "languageId": "Ada"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "method": "textDocument/didOpen"
+         }, 
+         "wait": []
+      }
+   }, 
+   {"comment": "---------------------------  typeDefinition on the location of the definition, make sure there are two replies ----------"},
+   {
+      "send": {
+         "request": {
+            "params": {
+               "position": {
+                  "line": 3, 
+                  "character": 3
+               }, 
+               "textDocument": {
+                  "uri": "$URI{common/common_pack.ads}"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "id": 2, 
+            "method": "textDocument/typeDefinition"
+         }, 
+         "wait": [
+            {
+               "id": 2, 
+               "result": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 2, 
+                           "character": 8
+                        }, 
+                        "end": {
+                           "line": 2, 
+                           "character": 21
+                        }
+                     }, 
+                     "uri": "$URI{p/truc.ads}"
+                  }, 
+                  {
+                     "range": {
+                        "start": {
+                           "line": 3, 
+                           "character": 8
+                        }, 
+                        "end": {
+                           "line": 3, 
+                           "character": 21
+                        }
+                     }, 
+                     "uri": "$URI{q/truc.ads}"
+                  }
+               ]
+            }
+         ]
+      }
+   },
+   {"comment": "---------------------------  typeDefinition on an use of the type, make sure there are two replies ----------"},
+   {
+      "send": {
+         "request": {
+            "params": {
+               "position": {
+                  "line": 4, 
+                  "character": 20
+               }, 
+               "textDocument": {
+                  "uri": "$URI{common/common_pack.ads}"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "id": 6, 
+            "method": "textDocument/typeDefinition"
+         }, 
+         "wait": [
+            {
+               "id": 6, 
+               "result": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 2, 
+                           "character": 8
+                        }, 
+                        "end": {
+                           "line": 2, 
+                           "character": 21
+                        }
+                     }, 
+                     "uri": "$URI{p/truc.ads}"
+                  }, 
+                  {
+                     "range": {
+                        "start": {
+                           "line": 3, 
+                           "character": 8
+                        }, 
+                        "end": {
+                           "line": 3, 
+                           "character": 21
+                        }
+                     }, 
+                     "uri": "$URI{q/truc.ads}"
+                  }
+               ]
+            }
+         ]
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{common/common_pack.ads}"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "method": "textDocument/didClose"
+         }, 
+         "wait": []
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0", 
+            "id": 8, 
+            "method": "shutdown"
+         }, 
+         "wait": [
+            {
+               "id": 8, 
+               "result": null
+            }
+         ]
+      }
+   }, 
+   {
+      "stop": {
+         "exit_code": 0
+      }
+   }
+]

--- a/testsuite/ada_lsp/type_definition.aggregate/test.yaml
+++ b/testsuite/ada_lsp/type_definition.aggregate/test.yaml
@@ -1,0 +1,1 @@
+title: 'type_definition.aggregate'

--- a/testsuite/ada_lsp/type_definition/type_definition.json
+++ b/testsuite/ada_lsp/type_definition/type_definition.json
@@ -76,11 +76,11 @@
                     "range": {
                         "start": {
                             "line": 1,
-                            "character": 3
+                            "character": 8
                         },
                         "end": {
                             "line": 1,
-                            "character": 31
+                            "character": 15
                         }
                     }
                 }]


### PR DESCRIPTION
This was not working in the context of aggregate projects,
and was not working when requested on the definition of the
type itself, only on an use of the type.

Add a test that covers both cases.