### PR TITLE
SA21-029: fix textDocument/symbols response type

### DIFF
--- a/source/ada/lsp-ada_documents.adb
+++ b/source/ada/lsp-ada_documents.adb
@@ -134,7 +134,7 @@ package body LSP.Ada_Documents is
    procedure Get_Symbols
      (Self    : Document;
       Context : LSP.Ada_Contexts.Context;
-      Result  : out LSP.Messages.SymbolInformation_Vector)
+      Result  : out LSP.Messages.Symbol_Vector)
    is
       Element : Libadalang.Analysis.Ada_Node;
       Item    : LSP.Messages.SymbolInformation;
@@ -148,7 +148,9 @@ package body LSP.Ada_Documents is
           (Self.Unit (Context).Root, Is_Defining_Name);
 
    begin
-      Result.Clear;
+      Result := LSP.Messages.Symbol_Vector'
+        (Is_Tree => False,
+         Vector  => <>);
 
       while Cursor.Next (Element) loop
          Item.name := To_LSP_String (Element.Text);
@@ -158,7 +160,7 @@ package body LSP.Ada_Documents is
             span    => To_Span (Element.Sloc_Range),
             alsKind => LSP.Messages.Empty_Set);
 
-         Result.Append (Item);
+         Result.Vector.Append (Item);
       end loop;
    end Get_Symbols;
 

--- a/source/ada/lsp-ada_documents.ads
+++ b/source/ada/lsp-ada_documents.ads
@@ -72,7 +72,7 @@ package LSP.Ada_Documents is
    procedure Get_Symbols
      (Self    : Document;
       Context : LSP.Ada_Contexts.Context;
-      Result  : out LSP.Messages.SymbolInformation_Vector);
+      Result  : out LSP.Messages.Symbol_Vector);
    --  Populate Result with symbols from the document.
 
    function Get_Node_At

--- a/source/protocol/lsp-messages-server_responses.ads
+++ b/source/protocol/lsp-messages-server_responses.ads
@@ -82,7 +82,7 @@ package LSP.Messages.Server_Responses is
 
    package Symbol_Responses is new LSP.Generic_Responses
      (ResponseMessage => Server_Response,
-      T               => SymbolInformation_Vector);
+      T               => Symbol_Vector);
 
    type Symbol_Response is new Symbol_Responses.Response with null record;
 

--- a/source/server/lsp-message_loggers.adb
+++ b/source/server/lsp-message_loggers.adb
@@ -929,7 +929,12 @@ package body LSP.Message_Loggers is
       Self.Trace.Trace
         ("Symbol_Response: "
          & Image (Value)
-         & Ada.Containers.Count_Type'Image (Value.result.Length));
+         & (if not Value.result.Is_Tree then
+              Ada.Containers.Count_Type'Image
+                 (Value.result.Vector.Length)
+           else
+              Ada.Containers.Count_Type'Image
+                 (Value.result.Tree.Node_Count)));
    end On_Symbol_Response;
 
    --------------------------------


### PR DESCRIPTION
In the newest version of the protocol we now have the possibility
to return either a flat list of symbols or a tree of symbols.