### PR TITLE
SC20-022 'implementation' now returns bodies for parent/child methods

### DIFF
--- a/source/ada/lsp-lal_utils.ads
+++ b/source/ada/lsp-lal_utils.ads
@@ -90,6 +90,12 @@ package LSP.Lal_Utils is
    --  Convert the given Basic_Decl_Array into a Base_Id_Array by retrieving
    --  the defining names of all the given declarations.
 
+   function Is_Definition_Without_Separate_Implementation
+     (Definition : Defining_Name) return Boolean;
+   --  Return True if the definition given is a subprogram that does not call
+   --  for a body, ie a "is null" procedure, an expression function, or an
+   --  abstract subprogram.
+
    ---------------
    -- Called_By --
    ---------------

--- a/testsuite/ada_lsp/implementation.overridings/p.gpr
+++ b/testsuite/ada_lsp/implementation.overridings/p.gpr
@@ -1,0 +1,2 @@
+project p is
+end p;

--- a/testsuite/ada_lsp/implementation.overridings/pack.adb
+++ b/testsuite/ada_lsp/implementation.overridings/pack.adb
@@ -1,0 +1,29 @@
+pragma Ada_2012;
+package body pack is
+
+
+   procedure Method (X : Child) is
+   begin
+      null;
+   end Method;
+
+   ------------
+   -- Method --
+   ------------
+
+   procedure Method (X : Grandchild) is
+      X : Child;
+   begin
+      X.Method;
+   end Method;
+
+   ------------
+   -- Method --
+   ------------
+
+   procedure Method (X : Great_Grandchild) is
+   begin
+      null;
+   end Method;
+
+end pack;

--- a/testsuite/ada_lsp/implementation.overridings/pack.ads
+++ b/testsuite/ada_lsp/implementation.overridings/pack.ads
@@ -1,0 +1,15 @@
+package pack is
+
+   type Root is tagged null record;
+   procedure Method (X : Root) is abstract;
+   
+   type Child is new Root with null record;
+   procedure Method (X : Child);
+   
+   type Grandchild is new Child with null record;
+   procedure Method (X : Grandchild);
+
+   type Great_Grandchild is new Grandchild with null record;
+   procedure Method (X : Great_Grandchild);
+   
+end pack;

--- a/testsuite/ada_lsp/implementation.overridings/test.json
+++ b/testsuite/ada_lsp/implementation.overridings/test.json
@@ -1,0 +1,1125 @@
+[
+   {
+      "comment": [
+         "test automatically generated"
+      ]
+   }, 
+   {
+      "start": {
+         "cmd": [
+            "${ALS}"
+         ]
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "capabilities": {
+                  "textDocument": {
+                     "completion": {
+                        "completionItemKind": {}
+                     }, 
+                     "documentLink": {}, 
+                     "formatting": {}, 
+                     "documentHighlight": {}, 
+                     "synchronization": {}, 
+                     "references": {}, 
+                     "rangeFormatting": {}, 
+                     "onTypeFormatting": {}, 
+                     "codeLens": {}, 
+                     "colorProvider": {}
+                  }, 
+                  "workspace": {
+                     "applyEdit": false, 
+                     "executeCommand": {}, 
+                     "didChangeWatchedFiles": {}, 
+                     "workspaceEdit": {}, 
+                     "didChangeConfiguration": {}
+                  }
+               }, 
+               "rootUri": "$URI{.}"
+            }, 
+            "jsonrpc": "2.0", 
+            "id": 1, 
+            "method": "initialize"
+         }, 
+         "wait": [
+            {
+               "id": 1, 
+               "result": {
+                  "capabilities": {
+                     "executeCommandProvider": {
+                        "commands": []
+                     }, 
+                     "typeDefinitionProvider": true, 
+                     "alsReferenceKinds": [
+                        "write", 
+                        "call", 
+                        "dispatching call", 
+                        "parent", 
+                        "child"
+                     ], 
+                     "hoverProvider": true, 
+                     "definitionProvider": true, 
+                     "renameProvider": true, 
+                     "alsCalledByProvider": true, 
+                     "referencesProvider": true, 
+                     "declarationProvider": true, 
+                     "textDocumentSync": 1, 
+                     "documentLinkProvider": {}, 
+                     "completionProvider": {
+                        "triggerCharacters": [
+                           "."
+                        ], 
+                        "resolveProvider": false
+                     }, 
+                     "documentSymbolProvider": true
+                  }
+               }
+            }
+         ]
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0", 
+            "method": "initialized"
+         }, 
+         "wait": []
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "settings": {
+                  "ada": {
+                     "scenarioVariables": {}, 
+                     "enableDiagnostics": false, 
+                     "defaultCharset": "ISO-8859-1"
+                  }
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "method": "workspace/didChangeConfiguration"
+         }, 
+         "wait": []
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "text": "pragma Ada_2012;\npackage body pack is\n\n\n   procedure Method (X : Child) is\n   begin\n      null;\n   end Method;\n\n   ------------\n   -- Method --\n   ------------\n\n   procedure Method (X : Grandchild) is\n      X : Child;\n   begin\n      X.Method;\n   end Method;\n\n   ------------\n   -- Method --\n   ------------\n\n   procedure Method (X : Great_Grandchild) is\n   begin\n      null;\n   end Method;\n\nend pack;\n", 
+                  "version": 0, 
+                  "uri": "$URI{pack.adb}", 
+                  "languageId": "Ada"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "method": "textDocument/didOpen"
+         }, 
+         "wait": []
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "text": "package pack is\n\n   type Root is tagged null record;\n   procedure Method (X : Root) is abstract;\n   \n   type Child is new Root with null record;\n   procedure Method (X : Child);\n   \n   type Grandchild is new Child with null record;\n   procedure Method (X : Grandchild);\n\n   type Great_Grandchild is new Grandchild with null record;\n   procedure Method (X : Great_Grandchild);\n   \nend pack;\n", 
+                  "version": 0, 
+                  "uri": "$URI{pack.ads}", 
+                  "languageId": "Ada"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "method": "textDocument/didOpen"
+         }, 
+         "wait": []
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "position": {
+                  "line": 3, 
+                  "character": 13
+               }, 
+               "textDocument": {
+                  "uri": "$URI{pack.ads}"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "id": 2, 
+            "method": "textDocument/implementation"
+         }, 
+         "wait": [
+            {
+               "id": 2, 
+               "result": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 3, 
+                           "character": 13
+                        }, 
+                        "end": {
+                           "line": 3, 
+                           "character": 19
+                        }
+                     }, 
+                     "uri": "$URI{pack.ads}"
+                  }, 
+                  {
+                     "range": {
+                        "start": {
+                           "line": 4, 
+                           "character": 13
+                        }, 
+                        "end": {
+                           "line": 4, 
+                           "character": 19
+                        }
+                     }, 
+                     "alsKind": [
+                        "child"
+                     ], 
+                     "uri": "$URI{pack.adb}"
+                  }, 
+                  {
+                     "range": {
+                        "start": {
+                           "line": 13, 
+                           "character": 13
+                        }, 
+                        "end": {
+                           "line": 13, 
+                           "character": 19
+                        }
+                     }, 
+                     "alsKind": [
+                        "child"
+                     ], 
+                     "uri": "$URI{pack.adb}"
+                  }, 
+                  {
+                     "range": {
+                        "start": {
+                           "line": 23, 
+                           "character": 13
+                        }, 
+                        "end": {
+                           "line": 23, 
+                           "character": 19
+                        }
+                     }, 
+                     "alsKind": [
+                        "child"
+                     ], 
+                     "uri": "$URI{pack.adb}"
+                  }
+               ]
+            }
+         ]
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "position": {
+                  "line": 3, 
+                  "character": 13
+               }, 
+               "textDocument": {
+                  "uri": "$URI{pack.ads}"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "id": 3, 
+            "method": "textDocument/hover"
+         }, 
+         "wait": [
+            {
+               "id": 3, 
+               "result": {
+                  "contents": [
+                     {
+                        "value": "procedure Method (X : Root)", 
+                        "language": "ada"
+                     }, 
+                     "at pack.ads (4:4)"
+                  ]
+               }
+            }
+         ]
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "position": {
+                  "line": 3, 
+                  "character": 13
+               }, 
+               "textDocument": {
+                  "uri": "$URI{pack.ads}"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "id": 4, 
+            "method": "textDocument/hover"
+         }, 
+         "wait": [
+            {
+               "id": 4, 
+               "result": {
+                  "contents": [
+                     {
+                        "value": "procedure Method (X : Root)", 
+                        "language": "ada"
+                     }, 
+                     "at pack.ads (4:4)"
+                  ]
+               }
+            }
+         ]
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "position": {
+                  "line": 6, 
+                  "character": 13
+               }, 
+               "textDocument": {
+                  "uri": "$URI{pack.ads}"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "id": 5, 
+            "method": "textDocument/implementation"
+         }, 
+         "wait": [
+            {
+               "id": 5, 
+               "result": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 4, 
+                           "character": 13
+                        }, 
+                        "end": {
+                           "line": 4, 
+                           "character": 19
+                        }
+                     }, 
+                     "uri": "$URI{pack.adb}"
+                  }, 
+                  {
+                     "range": {
+                        "start": {
+                           "line": 3, 
+                           "character": 13
+                        }, 
+                        "end": {
+                           "line": 3, 
+                           "character": 19
+                        }
+                     }, 
+                     "alsKind": [
+                        "parent"
+                     ], 
+                     "uri": "$URI{pack.ads}"
+                  }, 
+                  {
+                     "range": {
+                        "start": {
+                           "line": 13, 
+                           "character": 13
+                        }, 
+                        "end": {
+                           "line": 13, 
+                           "character": 19
+                        }
+                     }, 
+                     "alsKind": [
+                        "child"
+                     ], 
+                     "uri": "$URI{pack.adb}"
+                  }, 
+                  {
+                     "range": {
+                        "start": {
+                           "line": 23, 
+                           "character": 13
+                        }, 
+                        "end": {
+                           "line": 23, 
+                           "character": 19
+                        }
+                     }, 
+                     "alsKind": [
+                        "child"
+                     ], 
+                     "uri": "$URI{pack.adb}"
+                  }
+               ]
+            }
+         ]
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "position": {
+                  "line": 4, 
+                  "character": 13
+               }, 
+               "textDocument": {
+                  "uri": "$URI{pack.adb}"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "id": 6, 
+            "method": "textDocument/hover"
+         }, 
+         "wait": [
+            {
+               "id": 6, 
+               "result": {
+                  "contents": [
+                     {
+                        "value": "procedure Method (X : Child)", 
+                        "language": "ada"
+                     }, 
+                     "at pack.ads (7:4)"
+                  ]
+               }
+            }
+         ]
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "position": {
+                  "line": 4, 
+                  "character": 13
+               }, 
+               "textDocument": {
+                  "uri": "$URI{pack.adb}"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "id": 7, 
+            "method": "textDocument/hover"
+         }, 
+         "wait": [
+            {
+               "id": 7, 
+               "result": {
+                  "contents": [
+                     {
+                        "value": "procedure Method (X : Child)", 
+                        "language": "ada"
+                     }, 
+                     "at pack.ads (7:4)"
+                  ]
+               }
+            }
+         ]
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "position": {
+                  "line": 9, 
+                  "character": 13
+               }, 
+               "textDocument": {
+                  "uri": "$URI{pack.ads}"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "id": 8, 
+            "method": "textDocument/implementation"
+         }, 
+         "wait": [
+            {
+               "id": 8, 
+               "result": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 13, 
+                           "character": 13
+                        }, 
+                        "end": {
+                           "line": 13, 
+                           "character": 19
+                        }
+                     }, 
+                     "uri": "$URI{pack.adb}"
+                  }, 
+                  {
+                     "range": {
+                        "start": {
+                           "line": 4, 
+                           "character": 13
+                        }, 
+                        "end": {
+                           "line": 4, 
+                           "character": 19
+                        }
+                     }, 
+                     "alsKind": [
+                        "parent"
+                     ], 
+                     "uri": "$URI{pack.adb}"
+                  }, 
+                  {
+                     "range": {
+                        "start": {
+                           "line": 3, 
+                           "character": 13
+                        }, 
+                        "end": {
+                           "line": 3, 
+                           "character": 19
+                        }
+                     }, 
+                     "alsKind": [
+                        "parent"
+                     ], 
+                     "uri": "$URI{pack.ads}"
+                  }, 
+                  {
+                     "range": {
+                        "start": {
+                           "line": 23, 
+                           "character": 13
+                        }, 
+                        "end": {
+                           "line": 23, 
+                           "character": 19
+                        }
+                     }, 
+                     "alsKind": [
+                        "child"
+                     ], 
+                     "uri": "$URI{pack.adb}"
+                  }
+               ]
+            }
+         ]
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "position": {
+                  "line": 13, 
+                  "character": 13
+               }, 
+               "textDocument": {
+                  "uri": "$URI{pack.adb}"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "id": 9, 
+            "method": "textDocument/hover"
+         }, 
+         "wait": [
+            {
+               "id": 9, 
+               "result": {
+                  "contents": [
+                     {
+                        "value": "procedure Method (X : Grandchild)", 
+                        "language": "ada"
+                     }, 
+                     "at pack.ads (10:4)"
+                  ]
+               }
+            }
+         ]
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "position": {
+                  "line": 13, 
+                  "character": 13
+               }, 
+               "textDocument": {
+                  "uri": "$URI{pack.adb}"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "id": 10, 
+            "method": "textDocument/hover"
+         }, 
+         "wait": [
+            {
+               "id": 10, 
+               "result": {
+                  "contents": [
+                     {
+                        "value": "procedure Method (X : Grandchild)", 
+                        "language": "ada"
+                     }, 
+                     "at pack.ads (10:4)"
+                  ]
+               }
+            }
+         ]
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "position": {
+                  "line": 13, 
+                  "character": 13
+               }, 
+               "textDocument": {
+                  "uri": "$URI{pack.adb}"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "id": 11, 
+            "method": "textDocument/hover"
+         }, 
+         "wait": [
+            {
+               "id": 11, 
+               "result": {
+                  "contents": [
+                     {
+                        "value": "procedure Method (X : Grandchild)", 
+                        "language": "ada"
+                     }, 
+                     "at pack.ads (10:4)"
+                  ]
+               }
+            }
+         ]
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "position": {
+                  "line": 12, 
+                  "character": 13
+               }, 
+               "textDocument": {
+                  "uri": "$URI{pack.ads}"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "id": 12, 
+            "method": "textDocument/implementation"
+         }, 
+         "wait": [
+            {
+               "id": 12, 
+               "result": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 23, 
+                           "character": 13
+                        }, 
+                        "end": {
+                           "line": 23, 
+                           "character": 19
+                        }
+                     }, 
+                     "uri": "$URI{pack.adb}"
+                  }, 
+                  {
+                     "range": {
+                        "start": {
+                           "line": 13, 
+                           "character": 13
+                        }, 
+                        "end": {
+                           "line": 13, 
+                           "character": 19
+                        }
+                     }, 
+                     "alsKind": [
+                        "parent"
+                     ], 
+                     "uri": "$URI{pack.adb}"
+                  }, 
+                  {
+                     "range": {
+                        "start": {
+                           "line": 4, 
+                           "character": 13
+                        }, 
+                        "end": {
+                           "line": 4, 
+                           "character": 19
+                        }
+                     }, 
+                     "alsKind": [
+                        "parent"
+                     ], 
+                     "uri": "$URI{pack.adb}"
+                  }, 
+                  {
+                     "range": {
+                        "start": {
+                           "line": 3, 
+                           "character": 13
+                        }, 
+                        "end": {
+                           "line": 3, 
+                           "character": 19
+                        }
+                     }, 
+                     "alsKind": [
+                        "parent"
+                     ], 
+                     "uri": "$URI{pack.ads}"
+                  }
+               ]
+            }
+         ]
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "position": {
+                  "line": 23, 
+                  "character": 13
+               }, 
+               "textDocument": {
+                  "uri": "$URI{pack.adb}"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "id": 13, 
+            "method": "textDocument/hover"
+         }, 
+         "wait": [
+            {
+               "id": 13, 
+               "result": {
+                  "contents": [
+                     {
+                        "value": "procedure Method (X : Great_Grandchild)", 
+                        "language": "ada"
+                     }, 
+                     "at pack.ads (13:4)"
+                  ]
+               }
+            }
+         ]
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "position": {
+                  "line": 23, 
+                  "character": 13
+               }, 
+               "textDocument": {
+                  "uri": "$URI{pack.adb}"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "id": 14, 
+            "method": "textDocument/hover"
+         }, 
+         "wait": [
+            {
+               "id": 14, 
+               "result": {
+                  "contents": [
+                     {
+                        "value": "procedure Method (X : Great_Grandchild)", 
+                        "language": "ada"
+                     }, 
+                     "at pack.ads (13:4)"
+                  ]
+               }
+            }
+         ]
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "position": {
+                  "line": 13, 
+                  "character": 13
+               }, 
+               "textDocument": {
+                  "uri": "$URI{pack.adb}"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "id": 15, 
+            "method": "textDocument/implementation"
+         }, 
+         "wait": [
+            {
+               "id": 15, 
+               "result": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 13, 
+                           "character": 13
+                        }, 
+                        "end": {
+                           "line": 13, 
+                           "character": 19
+                        }
+                     }, 
+                     "uri": "$URI{pack.adb}"
+                  }, 
+                  {
+                     "range": {
+                        "start": {
+                           "line": 4, 
+                           "character": 13
+                        }, 
+                        "end": {
+                           "line": 4, 
+                           "character": 19
+                        }
+                     }, 
+                     "alsKind": [
+                        "parent"
+                     ], 
+                     "uri": "$URI{pack.adb}"
+                  }, 
+                  {
+                     "range": {
+                        "start": {
+                           "line": 3, 
+                           "character": 13
+                        }, 
+                        "end": {
+                           "line": 3, 
+                           "character": 19
+                        }
+                     }, 
+                     "alsKind": [
+                        "parent"
+                     ], 
+                     "uri": "$URI{pack.ads}"
+                  }, 
+                  {
+                     "range": {
+                        "start": {
+                           "line": 23, 
+                           "character": 13
+                        }, 
+                        "end": {
+                           "line": 23, 
+                           "character": 19
+                        }
+                     }, 
+                     "alsKind": [
+                        "child"
+                     ], 
+                     "uri": "$URI{pack.adb}"
+                  }
+               ]
+            }
+         ]
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "position": {
+                  "line": 13, 
+                  "character": 13
+               }, 
+               "textDocument": {
+                  "uri": "$URI{pack.adb}"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "id": 16, 
+            "method": "textDocument/hover"
+         }, 
+         "wait": [
+            {
+               "id": 16, 
+               "result": {
+                  "contents": [
+                     {
+                        "value": "procedure Method (X : Grandchild)", 
+                        "language": "ada"
+                     }, 
+                     "at pack.ads (10:4)"
+                  ]
+               }
+            }
+         ]
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "position": {
+                  "line": 13, 
+                  "character": 13
+               }, 
+               "textDocument": {
+                  "uri": "$URI{pack.adb}"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "id": 17, 
+            "method": "textDocument/hover"
+         }, 
+         "wait": [
+            {
+               "id": 17, 
+               "result": {
+                  "contents": [
+                     {
+                        "value": "procedure Method (X : Grandchild)", 
+                        "language": "ada"
+                     }, 
+                     "at pack.ads (10:4)"
+                  ]
+               }
+            }
+         ]
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "position": {
+                  "line": 16, 
+                  "character": 8
+               }, 
+               "textDocument": {
+                  "uri": "$URI{pack.adb}"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "id": 18, 
+            "method": "textDocument/implementation"
+         }, 
+         "wait": [
+            {
+               "id": 18, 
+               "result": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 4, 
+                           "character": 13
+                        }, 
+                        "end": {
+                           "line": 4, 
+                           "character": 19
+                        }
+                     }, 
+                     "uri": "$URI{pack.adb}"
+                  }, 
+                  {
+                     "range": {
+                        "start": {
+                           "line": 3, 
+                           "character": 13
+                        }, 
+                        "end": {
+                           "line": 3, 
+                           "character": 19
+                        }
+                     }, 
+                     "alsKind": [
+                        "parent"
+                     ], 
+                     "uri": "$URI{pack.ads}"
+                  }, 
+                  {
+                     "range": {
+                        "start": {
+                           "line": 13, 
+                           "character": 13
+                        }, 
+                        "end": {
+                           "line": 13, 
+                           "character": 19
+                        }
+                     }, 
+                     "alsKind": [
+                        "child"
+                     ], 
+                     "uri": "$URI{pack.adb}"
+                  }, 
+                  {
+                     "range": {
+                        "start": {
+                           "line": 23, 
+                           "character": 13
+                        }, 
+                        "end": {
+                           "line": 23, 
+                           "character": 19
+                        }
+                     }, 
+                     "alsKind": [
+                        "child"
+                     ], 
+                     "uri": "$URI{pack.adb}"
+                  }
+               ]
+            }
+         ]
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "position": {
+                  "line": 4, 
+                  "character": 13
+               }, 
+               "textDocument": {
+                  "uri": "$URI{pack.adb}"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "id": 19, 
+            "method": "textDocument/hover"
+         }, 
+         "wait": [
+            {
+               "id": 19, 
+               "result": {
+                  "contents": [
+                     {
+                        "value": "procedure Method (X : Child)", 
+                        "language": "ada"
+                     }, 
+                     "at pack.ads (7:4)"
+                  ]
+               }
+            }
+         ]
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "position": {
+                  "line": 4, 
+                  "character": 13
+               }, 
+               "textDocument": {
+                  "uri": "$URI{pack.adb}"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "id": 20, 
+            "method": "textDocument/hover"
+         }, 
+         "wait": [
+            {
+               "id": 20, 
+               "result": {
+                  "contents": [
+                     {
+                        "value": "procedure Method (X : Child)", 
+                        "language": "ada"
+                     }, 
+                     "at pack.ads (7:4)"
+                  ]
+               }
+            }
+         ]
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{pack.ads}"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "method": "textDocument/didClose"
+         }, 
+         "wait": []
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{pack.adb}"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "method": "textDocument/didClose"
+         }, 
+         "wait": []
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0", 
+            "id": 21, 
+            "method": "shutdown"
+         }, 
+         "wait": [
+            {
+               "id": 21, 
+               "result": null
+            }
+         ]
+      }
+   }, 
+   {
+      "stop": {
+         "exit_code": 0
+      }
+   }
+]

--- a/testsuite/ada_lsp/implementation.overridings/test.yaml
+++ b/testsuite/ada_lsp/implementation.overridings/test.yaml
@@ -1,0 +1,1 @@
+title: 'implementation.overridings'


### PR DESCRIPTION
Similarly to 'declaration', this requests now lists the implementations
of parent and child definitions of the subprogram.

Also slightly improve the behavior of 'implementation': return the
declaration if it's an "is null" procedure or an expression function.

Fix a bug that returned no results for subprograms that didn't have
a declaration.

Add a test.