### PR TITLE
Generate CHANGELOG.md on deploy vscode extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,10 @@ files from disk by specifying an `"ada.defaultCharset"` key. The default is
 You can explicitly deactivate the emission of diagnostics, via the
 `"ada.enableDiagnostics"` key. By default, diagnostics are enabled.
 
+The language server is able to edit Ada comments while executing
+`textDocument/rename` request. To enable this just set
+`ada.renameInComments` setting to `true`.
+
 By default, the server indexes the source files after loading a project,
 to speed up subsequent requests. This behavior can be controlled
 via the `"ada.enableIndexing"` flag in this request.
@@ -157,6 +161,7 @@ Here is an example config file from the gnatcov project:
     },
    "ada.defaultCharset": "utf-8",
    "ada.enableDiagnostics": false,
+   "ada.renameInComments": false
 }
 ```
 

--- a/integration/travis/deploy.sh
+++ b/integration/travis/deploy.sh
@@ -70,6 +70,19 @@ function darwin_deploy()
     tar czvf upload/$PLATFORM-$TAG.tar.gz -C integration/vscode/ada/ $PLATFORM
 }
 
+function make_change_log()
+{
+    echo "# Release notes"
+    echo ""
+    for TAG_ID in `git tag --list '2*' | tac` ; do
+        DATE=`git show --no-patch --format=Date:%ad --date=short $TAG_ID |\
+ grep Date: | sed -e s/Date://`
+        echo "## $TAG_ID ($DATE)"
+
+        git show --no-patch --format=%n $TAG_ID | sed -e '1,/Release notes/d'
+    done
+}
+
 function vsix_deploy()
 {
     sed -e 's/:white_check_mark:/Yes               /g' README.md > \
@@ -94,6 +107,7 @@ function vsix_deploy()
 
     npm install
     npm install -g vsce
+    make_change_log > CHANGELOG.md
     [ -z "$TRAVIS_TAG" ] || vsce publish -p $VSCE_TOKEN
     vsce package || true
     popd

--- a/integration/vscode/ada/package.json
+++ b/integration/vscode/ada/package.json
@@ -2,7 +2,7 @@
     "name": "ada",
     "displayName": "Language Support for Ada",
     "description": "A Language Server providing Ada and SPARK support in Visual Studio Code",
-    "version": "20.0.999",
+    "version": "21.0.999",
     "publisher": "MaximReznik",
     "license": "GPL-3.0",
     "engines": {
@@ -89,30 +89,36 @@
                         ],
                         "default": "off",
                         "description": "Traces the communication between VSCode and the language server."
-                    }
-                }
-            },
-            {
-                "type": "object",
-                "title": "Project file",
-                "properties": {
+                    }, {
                     "ada.projectFile": {
                         "scope": "resource",
                         "type": "string",
                         "default": "",
                         "description": "Project file (*.gpr) for given workspace."
-                    }
-                }
-            },
-            {
-                "type": "object",
-                "title": "Scenario variables",
-                "properties": {
+                    }, {
                     "ada.scenarioVariables": {
                         "scope": "resource",
                         "type": "object",
                         "default": {},
                         "description": "Scenario variables."
+                    }, {
+                    "ada.defaultCharset": {
+                        "scope": "resource",
+                        "type": "string",
+                        "default": "iso-8859-1",
+                        "description": "The character set to use while reading files from disk."
+                    }, {
+                    "ada.enableDiagnostics": {
+                        "scope": "resource",
+                        "type": "boolean",
+                        "default": true,
+                        "description": "The emission of diagnostics."
+                    }, {
+                    "ada.renameInComments": {
+                        "scope": "resource",
+                        "type": "boolean",
+                        "default": false,
+                        "description": "Enable editing Ada comments while executing `textDocument/rename` reques."
                     }
                 }
             }


### PR DESCRIPTION
Populate CHANGELOG.md with commit messages of release tags.

Minor fixes in README.md and package.json.