### PR TITLE
SA18-022: Rename parameters in the whole hierarchy

### DIFF
--- a/testsuite/ada_lsp/rename.primitive_parameters/default.gpr
+++ b/testsuite/ada_lsp/rename.primitive_parameters/default.gpr
@@ -1,0 +1,10 @@
+project Default is
+
+   for Source_Dirs use ("src");
+   for Main use ("main.adb");
+
+   package Compiler is
+      for Switches ("ada") use ("-gnatwa");
+   end Compiler;
+
+end Default;

--- a/testsuite/ada_lsp/rename.primitive_parameters/src/children.adb
+++ b/testsuite/ada_lsp/rename.primitive_parameters/src/children.adb
@@ -1,0 +1,12 @@
+with Ada.Text_IO;
+
+package body Children is
+
+   procedure Primitive (Self : in out Child;
+                        Id   : Integer) is
+   begin
+      Self.Id := Id;
+      Ada.Text_IO.Put_Line ("Child");
+   end Primitive;
+
+end Children;

--- a/testsuite/ada_lsp/rename.primitive_parameters/src/children.ads
+++ b/testsuite/ada_lsp/rename.primitive_parameters/src/children.ads
@@ -1,0 +1,9 @@
+with Parents; use Parents;
+package Children is
+
+   type Child is new Parent with null Record;
+
+   procedure Primitive (Self : in out Child;
+                        Id   : Integer);
+
+end Children;

--- a/testsuite/ada_lsp/rename.primitive_parameters/src/great_children.adb
+++ b/testsuite/ada_lsp/rename.primitive_parameters/src/great_children.adb
@@ -1,0 +1,13 @@
+with Ada.Text_IO;
+
+package body Great_Children is
+
+   procedure Primitive (Self : in out Great_Child;
+                        Id   : Integer) is
+   begin
+      Self.Id := Id;
+
+      Ada.Text_IO.Put_Line ("Great child");
+   end Primitive;
+
+end Great_Children;

--- a/testsuite/ada_lsp/rename.primitive_parameters/src/great_children.ads
+++ b/testsuite/ada_lsp/rename.primitive_parameters/src/great_children.ads
@@ -1,0 +1,9 @@
+with Children; use Children;
+package Great_Children is
+
+   type Great_Child is new Child with null Record;
+
+   procedure Primitive (Self : in out Great_Child;
+                        Id   : Integer);
+
+end Great_Children;

--- a/testsuite/ada_lsp/rename.primitive_parameters/src/main.adb
+++ b/testsuite/ada_lsp/rename.primitive_parameters/src/main.adb
@@ -1,0 +1,8 @@
+with Children; use Children;
+with Great_Children; use Great_Children;
+
+procedure Main is
+   Obj : Child'Class := Great_Child'(others => <>);
+begin
+   Obj.Primitive (3);
+end Main;

--- a/testsuite/ada_lsp/rename.primitive_parameters/src/parents.ads
+++ b/testsuite/ada_lsp/rename.primitive_parameters/src/parents.ads
@@ -1,0 +1,11 @@
+package Parents is
+
+   type Parent is abstract tagged record
+      Id : Integer;
+   end record;
+
+   procedure Primitive (Self : in out Parent;
+                        Id   : Integer) is abstract;
+   --  Parent procedure
+
+end Parents;

--- a/testsuite/ada_lsp/rename.primitive_parameters/test.json
+++ b/testsuite/ada_lsp/rename.primitive_parameters/test.json
@@ -1,0 +1,716 @@
+[
+   {
+      "comment": [
+         "This test checks that textDocument/rename on tagged type ",
+         "primitive parameters renames also this parameter in the suprograms ",
+         "it inherits and in the overriding ones."
+
+      ]
+   },
+   {
+      "start": {
+         "cmd": [
+            "${ALS}"
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "processId": 21500,
+               "capabilities": {
+                  "textDocument": {
+                     "completion": {
+                        "completionItemKind": {}
+                     },
+                     "documentLink": {},
+                     "formatting": {},
+                     "documentHighlight": {},
+                     "synchronization": {},
+                     "references": {},
+                     "rangeFormatting": {},
+                     "onTypeFormatting": {},
+                     "codeLens": {},
+                     "colorProvider": {}
+                  },
+                  "workspace": {
+                     "applyEdit": false,
+                     "executeCommand": {},
+                     "didChangeWatchedFiles": {},
+                     "workspaceEdit": {},
+                     "didChangeConfiguration": {}
+                  }
+               },
+               "rootUri": "$URI{.}"
+            },
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize"
+         },
+         "wait": [
+            {
+               "id": 1,
+               "result": {
+                  "capabilities": {
+                     "executeCommandProvider": {
+                        "commands": []
+                     },
+                     "typeDefinitionProvider": true,
+                     "alsReferenceKinds": [
+                        "write",
+                        "call",
+                        "dispatching call",
+                        "parent",
+                        "child"
+                     ],
+                     "hoverProvider": true,
+                     "definitionProvider": true,
+                     "renameProvider": {},
+                     "alsCalledByProvider": true,
+                     "referencesProvider": true,
+                     "declarationProvider": true,
+                     "textDocumentSync": 1,
+                     "documentLinkProvider": {},
+                     "completionProvider": {
+                        "triggerCharacters": [
+                           "."
+                        ],
+                        "resolveProvider": false
+                     },
+                     "documentSymbolProvider": true
+                  }
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "initialized"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "settings": {
+                  "ada": {
+                     "projectFile": "$URI{default.gpr}",
+                     "scenarioVariables": {},
+                     "enableDiagnostics": false,
+                     "defaultCharset": "ISO-8859-1"
+                  }
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "workspace/didChangeConfiguration"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "text": "with Parents; use Parents;\npackage Children is\n\n   type Child is new Parent with null Record;\n\n   procedure Primitive (Self : in out Child;\n                        Id   : Integer);\n\nend Children;\n",
+                  "version": 0,
+                  "uri": "$URI{src/children.ads}",
+                  "languageId": "Ada"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "settings": {
+                  "ada": {
+                     "renameInComments": false
+                  }
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "workspace/didChangeConfiguration"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "newName": "New_Id",
+               "position": {
+                  "line": 6,
+                  "character": 25
+               },
+               "textDocument": {
+                  "uri": "$URI{src/children.ads}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "textDocument/rename"
+         },
+         "wait": [
+            {
+               "id": 2,
+               "result": {
+                  "changes": {
+                     "$URI{src/children.ads}": [
+                        {
+                           "newText": "New_Id",
+                           "range": {
+                              "start": {
+                                 "line": 6,
+                                 "character": 24
+                              },
+                              "end": {
+                                 "line": 6,
+                                 "character": 26
+                              }
+                           }
+                        }
+                     ],
+                     "$URI{src/children.adb}": [
+                        {
+                           "newText": "New_Id",
+                           "range": {
+                              "start": {
+                                 "line": 5,
+                                 "character": 24
+                              },
+                              "end": {
+                                 "line": 5,
+                                 "character": 26
+                              }
+                           }
+                        },
+                        {
+                           "newText": "New_Id",
+                           "range": {
+                              "start": {
+                                 "line": 7,
+                                 "character": 17
+                              },
+                              "end": {
+                                 "line": 7,
+                                 "character": 19
+                              }
+                           }
+                        }
+                     ],
+                     "$URI{src/great_children.adb}": [
+                        {
+                           "newText": "New_Id",
+                           "range": {
+                              "start": {
+                                 "line": 5,
+                                 "character": 24
+                              },
+                              "end": {
+                                 "line": 5,
+                                 "character": 26
+                              }
+                           }
+                        },
+                        {
+                           "newText": "New_Id",
+                           "range": {
+                              "start": {
+                                 "line": 7,
+                                 "character": 17
+                              },
+                              "end": {
+                                 "line": 7,
+                                 "character": 19
+                              }
+                           }
+                        }
+                     ],
+                     "$URI{src/great_children.ads}": [
+                        {
+                           "newText": "New_Id",
+                           "range": {
+                              "start": {
+                                 "line": 6,
+                                 "character": 24
+                              },
+                              "end": {
+                                 "line": 6,
+                                 "character": 26
+                              }
+                           }
+                        }
+                     ],
+                     "$URI{src/parents.ads}": [
+                        {
+                           "newText": "New_Id",
+                           "range": {
+                              "start": {
+                                 "line": 7,
+                                 "character": 24
+                              },
+                              "end": {
+                                 "line": 7,
+                                 "character": 26
+                              }
+                           }
+                        }
+                     ]
+                  }
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "contentChanges": [
+                  {
+                     "text": "with Parents; use Parents;\npackage Children is\n\n   type Child is new Parent with null Record;\n\n   procedure Primitive (Self : in out Child;\n                           : Integer);\n\nend Children;\n"
+                  }
+               ],
+               "textDocument": {
+                  "version": 1,
+                  "uri": "$URI{src/children.ads}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "contentChanges": [
+                  {
+                     "text": "with Parents; use Parents;\npackage Children is\n\n   type Child is new Parent with null Record;\n\n   procedure Primitive (Self : in out Child;\n                        New_Id   : Integer);\n\nend Children;\n"
+                  }
+               ],
+               "textDocument": {
+                  "version": 2,
+                  "uri": "$URI{src/children.ads}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "text": "with Ada.Text_IO;\n\npackage body Great_Children is\n\n   procedure Primitive (Self : in out Great_Child;\n                        Id   : Integer) is\n   begin\n      Self.Id := Id;\n\n      Ada.Text_IO.Put_Line (\"Great child\");\n   end Primitive;\n\nend Great_Children;\n",
+                  "version": 0,
+                  "uri": "$URI{src/great_children.adb}",
+                  "languageId": "Ada"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "contentChanges": [
+                  {
+                     "text": "with Ada.Text_IO;\n\npackage body Great_Children is\n\n   procedure Primitive (Self : in out Great_Child;\n                        Id   : Integer) is\n   begin\n      Self.Id := ;\n\n      Ada.Text_IO.Put_Line (\"Great child\");\n   end Primitive;\n\nend Great_Children;\n"
+                  }
+               ],
+               "textDocument": {
+                  "version": 1,
+                  "uri": "$URI{src/great_children.adb}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "contentChanges": [
+                  {
+                     "text": "with Ada.Text_IO;\n\npackage body Great_Children is\n\n   procedure Primitive (Self : in out Great_Child;\n                        Id   : Integer) is\n   begin\n      Self.Id := New_Id;\n\n      Ada.Text_IO.Put_Line (\"Great child\");\n   end Primitive;\n\nend Great_Children;\n"
+                  }
+               ],
+               "textDocument": {
+                  "version": 2,
+                  "uri": "$URI{src/great_children.adb}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "contentChanges": [
+                  {
+                     "text": "with Ada.Text_IO;\n\npackage body Great_Children is\n\n   procedure Primitive (Self : in out Great_Child;\n                           : Integer) is\n   begin\n      Self.Id := New_Id;\n\n      Ada.Text_IO.Put_Line (\"Great child\");\n   end Primitive;\n\nend Great_Children;\n"
+                  }
+               ],
+               "textDocument": {
+                  "version": 3,
+                  "uri": "$URI{src/great_children.adb}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "contentChanges": [
+                  {
+                     "text": "with Ada.Text_IO;\n\npackage body Great_Children is\n\n   procedure Primitive (Self : in out Great_Child;\n                        New_Id   : Integer) is\n   begin\n      Self.Id := New_Id;\n\n      Ada.Text_IO.Put_Line (\"Great child\");\n   end Primitive;\n\nend Great_Children;\n"
+                  }
+               ],
+               "textDocument": {
+                  "version": 4,
+                  "uri": "$URI{src/great_children.adb}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{src/great_children.adb}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didClose"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "text": "with Children; use Children;\npackage Great_Children is\n\n   type Great_Child is new Child with null Record;\n\n   procedure Primitive (Self : in out Great_Child;\n                        Id   : Integer);\n\nend Great_Children;\n",
+                  "version": 0,
+                  "uri": "$URI{src/great_children.ads}",
+                  "languageId": "Ada"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "contentChanges": [
+                  {
+                     "text": "with Children; use Children;\npackage Great_Children is\n\n   type Great_Child is new Child with null Record;\n\n   procedure Primitive (Self : in out Great_Child;\n                           : Integer);\n\nend Great_Children;\n"
+                  }
+               ],
+               "textDocument": {
+                  "version": 1,
+                  "uri": "$URI{src/great_children.ads}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "contentChanges": [
+                  {
+                     "text": "with Children; use Children;\npackage Great_Children is\n\n   type Great_Child is new Child with null Record;\n\n   procedure Primitive (Self : in out Great_Child;\n                        New_Id   : Integer);\n\nend Great_Children;\n"
+                  }
+               ],
+               "textDocument": {
+                  "version": 2,
+                  "uri": "$URI{src/great_children.ads}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{src/great_children.ads}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didClose"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "text": "package Parents is\n\n   type Parent is abstract tagged record\n      Id : Integer;\n   end record;\n\n   procedure Primitive (Self : in out Parent;\n                        Id   : Integer) is abstract;\n   --  Parent procedure\n\nend Parents;\n",
+                  "version": 0,
+                  "uri": "$URI{src/parents.ads}",
+                  "languageId": "Ada"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "contentChanges": [
+                  {
+                     "text": "package Parents is\n\n   type Parent is abstract tagged record\n      Id : Integer;\n   end record;\n\n   procedure Primitive (Self : in out Parent;\n                           : Integer) is abstract;\n   --  Parent procedure\n\nend Parents;\n"
+                  }
+               ],
+               "textDocument": {
+                  "version": 1,
+                  "uri": "$URI{src/parents.ads}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "contentChanges": [
+                  {
+                     "text": "package Parents is\n\n   type Parent is abstract tagged record\n      Id : Integer;\n   end record;\n\n   procedure Primitive (Self : in out Parent;\n                        New_Id   : Integer) is abstract;\n   --  Parent procedure\n\nend Parents;\n"
+                  }
+               ],
+               "textDocument": {
+                  "version": 2,
+                  "uri": "$URI{src/parents.ads}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{src/parents.ads}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didClose"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "text": "with Ada.Text_IO;\n\npackage body Children is\n\n   procedure Primitive (Self : in out Child;\n                        Id   : Integer) is\n   begin\n      Self.Id := Id;\n      Ada.Text_IO.Put_Line (\"Child\");\n   end Primitive;\n\nend Children;\n",
+                  "version": 0,
+                  "uri": "$URI{src/children.adb}",
+                  "languageId": "Ada"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "contentChanges": [
+                  {
+                     "text": "with Ada.Text_IO;\n\npackage body Children is\n\n   procedure Primitive (Self : in out Child;\n                        Id   : Integer) is\n   begin\n      Self.Id := ;\n      Ada.Text_IO.Put_Line (\"Child\");\n   end Primitive;\n\nend Children;\n"
+                  }
+               ],
+               "textDocument": {
+                  "version": 1,
+                  "uri": "$URI{src/children.adb}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "contentChanges": [
+                  {
+                     "text": "with Ada.Text_IO;\n\npackage body Children is\n\n   procedure Primitive (Self : in out Child;\n                        Id   : Integer) is\n   begin\n      Self.Id := New_Id;\n      Ada.Text_IO.Put_Line (\"Child\");\n   end Primitive;\n\nend Children;\n"
+                  }
+               ],
+               "textDocument": {
+                  "version": 2,
+                  "uri": "$URI{src/children.adb}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "contentChanges": [
+                  {
+                     "text": "with Ada.Text_IO;\n\npackage body Children is\n\n   procedure Primitive (Self : in out Child;\n                           : Integer) is\n   begin\n      Self.Id := New_Id;\n      Ada.Text_IO.Put_Line (\"Child\");\n   end Primitive;\n\nend Children;\n"
+                  }
+               ],
+               "textDocument": {
+                  "version": 3,
+                  "uri": "$URI{src/children.adb}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "contentChanges": [
+                  {
+                     "text": "with Ada.Text_IO;\n\npackage body Children is\n\n   procedure Primitive (Self : in out Child;\n                        New_Id   : Integer) is\n   begin\n      Self.Id := New_Id;\n      Ada.Text_IO.Put_Line (\"Child\");\n   end Primitive;\n\nend Children;\n"
+                  }
+               ],
+               "textDocument": {
+                  "version": 4,
+                  "uri": "$URI{src/children.adb}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{src/children.adb}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didClose"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{src/children.ads}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didClose"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "shutdown"
+         },
+         "wait": [
+            {
+               "id": 3,
+               "result": null
+            }
+         ]
+      }
+   },
+   {
+      "stop": {
+         "exit_code": 0
+      }
+   }
+]

--- a/testsuite/ada_lsp/rename.primitive_parameters/test.yaml
+++ b/testsuite/ada_lsp/rename.primitive_parameters/test.yaml
@@ -1,0 +1,1 @@
+title: 'rename.primitive_parameters'


### PR DESCRIPTION
When renaming a parameter of a tagged type primitive, we now
also rename this parameter in all the base and overriding
subprograms.