### PR TITLE
SB25-033 Remove performance bottleneck

### DIFF
--- a/source/ada/lsp-ada_handlers.adb
+++ b/source/ada/lsp-ada_handlers.adb
@@ -651,6 +651,7 @@ package body LSP.Ada_Handlers is
             LSP.Messages.Warning);
       end if;
 
+      Sort_And_Remove_Duplicates (Response.result.Locations);
       return Response;
    end On_Declaration_Request;
 
@@ -790,6 +791,7 @@ package body LSP.Ada_Handlers is
             LSP.Messages.Warning);
       end if;
 
+      Sort_And_Remove_Duplicates (Response.result.Locations);
       return Response;
    end On_Implementation_Request;
 
@@ -914,6 +916,7 @@ package body LSP.Ada_Handlers is
             LSP.Messages.Warning);
       end if;
 
+      Sort_And_Remove_Duplicates (Response.result.Locations);
       return Response;
    end On_Definition_Request;
 
@@ -1444,6 +1447,7 @@ package body LSP.Ada_Handlers is
             LSP.Messages.Warning);
       end if;
 
+      Sort_And_Remove_Duplicates (Response.result);
       return Response;
    end On_References_Request;
 
@@ -1548,7 +1552,7 @@ package body LSP.Ada_Handlers is
                         return;
                      end if;
                   end loop;
-
+                  Sort_And_Remove_Duplicates (Subp_And_Refs.refs);
                   Response.result.Append (Subp_And_Refs);
                   Next (C);
                end;

--- a/source/ada/lsp-lal_utils.ads
+++ b/source/ada/lsp-lal_utils.ads
@@ -75,7 +75,6 @@ package LSP.Lal_Utils is
       Kind   : LSP.Messages.AlsReferenceKind_Set := LSP.Messages.Empty_Set);
    --  Append given Node location to the Result.
    --  Do nothing if the item inside of an synthetic file (like __standard).
-   --  Do not append if the location is already in Result.
    --  See description of Kind in Get_Node_Location comments.
 
    procedure Append_Location
@@ -83,6 +82,10 @@ package LSP.Lal_Utils is
       Node   : Libadalang.Analysis.Ada_Node'Class;
       Kind   : LSP.Messages.AlsReferenceKind_Set := LSP.Messages.Empty_Set);
    --  The same for Location_Vector.
+
+   procedure Sort_And_Remove_Duplicates
+     (Result : in out LSP.Messages.Location_Vector);
+   --  Sort Result and remove duplicates from it.
 
    function Get_Node_Location
      (Node : Libadalang.Analysis.Ada_Node;

--- a/testsuite/ada_lsp/D301-004.xrefs.generics/test.json
+++ b/testsuite/ada_lsp/D301-004.xrefs.generics/test.json
@@ -156,19 +156,6 @@
                   {
                      "range": {
                         "start": {
-                           "line": 1,
-                           "character": 11
-                        },
-                        "end": {
-                           "line": 1,
-                           "character": 15
-                        }
-                     },
-                     "uri": "$URI{g_g.adb}"
-                  },
-                  {
-                     "range": {
-                        "start": {
                            "line": 2,
                            "character": 12
                         },
@@ -178,6 +165,19 @@
                         }
                      },
                      "uri": "$URI{g_g.ads}"
+                  },
+                  {
+                     "range": {
+                        "start": {
+                           "line": 1,
+                           "character": 11
+                        },
+                        "end": {
+                           "line": 1,
+                           "character": 15
+                        }
+                     },
+                     "uri": "$URI{g_g.adb}"
                   }
                ]
             }

--- a/testsuite/ada_lsp/aggregate.references_after_update/test.json
+++ b/testsuite/ada_lsp/aggregate.references_after_update/test.json
@@ -207,19 +207,6 @@
                   {
                      "range": {
                         "start": {
-                           "line": 2, 
-                           "character": 18
-                        }, 
-                        "end": {
-                           "line": 2, 
-                           "character": 21
-                        }
-                     }, 
-                     "uri": "$URI{p/main.adb}"
-                  }, 
-                  {
-                     "range": {
-                        "start": {
                            "line": 1, 
                            "character": 3
                         }, 
@@ -229,6 +216,19 @@
                         }
                      }, 
                      "uri": "$URI{common/common_pack.ads}"
+                  }, 
+                  {
+                     "range": {
+                        "start": {
+                           "line": 2, 
+                           "character": 18
+                        }, 
+                        "end": {
+                           "line": 2, 
+                           "character": 21
+                        }
+                     }, 
+                     "uri": "$URI{p/main.adb}"
                   }, 
                   {
                      "range": {

--- a/testsuite/ada_lsp/aggregate.simple/test.json
+++ b/testsuite/ada_lsp/aggregate.simple/test.json
@@ -3,198 +3,198 @@
       "comment": [
          "test 'reference' in a basic aggregate project"
       ]
-   }, 
+   },
    {
       "start": {
          "cmd": [
             "${ALS}"
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
-            "jsonrpc": "2.0", 
+            "jsonrpc": "2.0",
             "params": {
                "capabilities": {
                   "workspace": {
                      "applyEdit": false
                   }
-               }, 
+               },
                "rootUri": "$URI{.}"
-            }, 
-            "id": 1, 
+            },
+            "id": 1,
             "method": "initialize"
-         }, 
+         },
          "wait": [
             {
-               "id": 1, 
+               "id": 1,
                "result": {
                   "capabilities": {
-                     "typeDefinitionProvider": true, 
+                     "typeDefinitionProvider": true,
                      "alsReferenceKinds": [
-                        "write", 
-                        "call", 
+                        "write",
+                        "call",
                         "dispatching call", "parent", "child"
-                     ], 
-                     "hoverProvider": true, 
-                     "definitionProvider": true, 
-                     "renameProvider": {}, 
-                     "alsCalledByProvider": true, 
-                     "referencesProvider": true, 
-                     "textDocumentSync": 1, 
+                     ],
+                     "hoverProvider": true,
+                     "definitionProvider": true,
+                     "renameProvider": {},
+                     "alsCalledByProvider": true,
+                     "referencesProvider": true,
+                     "textDocumentSync": 1,
                      "completionProvider": {
                         "triggerCharacters": [
                            "."
-                        ], 
+                        ],
                         "resolveProvider": false
-                     }, 
+                     },
                      "documentSymbolProvider": true
                   }
                }
             }]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
-            "jsonrpc": "2.0", 
+            "jsonrpc": "2.0",
             "method": "initialized"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
-            "jsonrpc": "2.0", 
+            "jsonrpc": "2.0",
             "params": {
                "settings": {
                   "ada": {
-                     "projectFile": "agg.gpr", 
-                     "scenarioVariables": {}, 
-                     "enableDiagnostics": false, 
+                     "projectFile": "agg.gpr",
+                     "scenarioVariables": {},
+                     "enableDiagnostics": false,
                      "defaultCharset": "UTF-8"
                   }
                }
-            }, 
+            },
             "method": "workspace/didChangeConfiguration"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
-            "jsonrpc": "2.0", 
+            "jsonrpc": "2.0",
             "params": {
                "textDocument": {
-                  "text": "package common_pack is\n   Foo : Integer := 42;\nend common_pack;\n", 
-                  "version": 0, 
-                  "uri": "$URI{common/common_pack.ads}", 
+                  "text": "package common_pack is\n   Foo : Integer := 42;\nend common_pack;\n",
+                  "version": 0,
+                  "uri": "$URI{common/common_pack.ads}",
                   "languageId": "Ada"
                }
-            }, 
+            },
             "method": "textDocument/didOpen"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
-            "jsonrpc": "2.0", 
+            "jsonrpc": "2.0",
             "params": {
                "position": {
-                  "line": 1, 
+                  "line": 1,
                   "character": 5
-               }, 
+               },
                "textDocument": {
                   "uri": "$URI{common/common_pack.ads}"
-               }, 
+               },
                "context": {
                   "includeDeclaration": true
                }
-            }, 
-            "id": 2, 
+            },
+            "id": 2,
             "method": "textDocument/references"
-         }, 
+         },
          "wait": [
             {
-               "id": 2, 
+               "id": 2,
                "result": [
                   {
                      "range": {
                         "start": {
-                           "line": 2, 
-                           "character": 18
-                        }, 
-                        "end": {
-                           "line": 2, 
-                           "character": 21
-                        }
-                     }, 
-                     "uri": "$URI{p/main.adb}"
-                  }, 
-                  {
-                     "range": {
-                        "start": {
-                           "line": 1, 
+                           "line": 1,
                            "character": 3
-                        }, 
+                        },
                         "end": {
-                           "line": 1, 
+                           "line": 1,
                            "character": 6
                         }
-                     }, 
+                     },
                      "uri": "$URI{common/common_pack.ads}"
-                  }, 
+                  },
                   {
                      "range": {
                         "start": {
-                           "line": 2, 
+                           "line": 2,
                            "character": 18
-                        }, 
+                        },
                         "end": {
-                           "line": 2, 
+                           "line": 2,
                            "character": 21
                         }
-                     }, 
+                     },
+                     "uri": "$URI{p/main.adb}"
+                  },
+                  {
+                     "range": {
+                        "start": {
+                           "line": 2,
+                           "character": 18
+                        },
+                        "end": {
+                           "line": 2,
+                           "character": 21
+                        }
+                     },
                      "uri": "$URI{q/main.adb}"
                   }
                ]
             }]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
-            "jsonrpc": "2.0", 
+            "jsonrpc": "2.0",
             "params": {
                "textDocument": {
                   "uri": "$URI{common/common_pack.ads}"
                }
-            }, 
+            },
             "method": "textDocument/didClose"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
-            "jsonrpc": "2.0", 
-            "id": 3, 
+            "jsonrpc": "2.0",
+            "id": 3,
             "method": "shutdown"
-         }, 
+         },
          "wait": [
             {
-               "id": 3, 
+               "id": 3,
                "result": null
             }
          ]
       }
-   }, 
+   },
    {
       "stop": {
          "exit_code": 0

--- a/testsuite/ada_lsp/definition_parents/test.json
+++ b/testsuite/ada_lsp/definition_parents/test.json
@@ -3,14 +3,14 @@
       "comment": [
          "check the listing of parents and children in 'definition' on methods"
       ]
-   }, 
+   },
    {
       "start": {
          "cmd": [
             "${ALS}"
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
@@ -19,502 +19,502 @@
                   "textDocument": {
                      "completion": {
                         "completionItemKind": {}
-                     }, 
-                     "documentLink": {}, 
-                     "formatting": {}, 
-                     "documentHighlight": {}, 
-                     "synchronization": {}, 
-                     "references": {}, 
-                     "rangeFormatting": {}, 
-                     "onTypeFormatting": {}, 
-                     "codeLens": {}, 
+                     },
+                     "documentLink": {},
+                     "formatting": {},
+                     "documentHighlight": {},
+                     "synchronization": {},
+                     "references": {},
+                     "rangeFormatting": {},
+                     "onTypeFormatting": {},
+                     "codeLens": {},
                      "colorProvider": {}
-                  }, 
+                  },
                   "workspace": {
-                     "applyEdit": false, 
-                     "executeCommand": {}, 
-                     "didChangeWatchedFiles": {}, 
-                     "workspaceEdit": {}, 
+                     "applyEdit": false,
+                     "executeCommand": {},
+                     "didChangeWatchedFiles": {},
+                     "workspaceEdit": {},
                      "didChangeConfiguration": {}
                   }
-               }, 
+               },
                "rootUri": "$URI{.}"
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 1, 
+            },
+            "jsonrpc": "2.0",
+            "id": 1,
             "method": "initialize"
-         }, 
+         },
          "wait": [
             {
-               "id": 1, 
+               "id": 1,
                "result": {
                   "capabilities": {
-                     "typeDefinitionProvider": true, 
+                     "typeDefinitionProvider": true,
                      "alsReferenceKinds": [
-                        "write", 
-                        "call", 
-                        "dispatching call", 
-                        "parent", 
+                        "write",
+                        "call",
+                        "dispatching call",
+                        "parent",
                         "child"
-                     ], 
-                     "hoverProvider": true, 
-                     "definitionProvider": true, 
-                     "renameProvider": {}, 
-                     "alsCalledByProvider": true, 
-                     "referencesProvider": true, 
-                     "declarationProvider": true, 
-                     "textDocumentSync": 1, 
+                     ],
+                     "hoverProvider": true,
+                     "definitionProvider": true,
+                     "renameProvider": {},
+                     "alsCalledByProvider": true,
+                     "referencesProvider": true,
+                     "declarationProvider": true,
+                     "textDocumentSync": 1,
                      "completionProvider": {
                         "triggerCharacters": [
                            "."
-                        ], 
+                        ],
                         "resolveProvider": false
-                     }, 
+                     },
                      "documentSymbolProvider": true
                   }
                }
             }
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
-            "jsonrpc": "2.0", 
+            "jsonrpc": "2.0",
             "method": "initialized"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "settings": {
                   "ada": {
-                     "scenarioVariables": {}, 
-                     "enableDiagnostics": false, 
+                     "scenarioVariables": {},
+                     "enableDiagnostics": false,
                      "defaultCharset": "ISO-8859-1"
                   }
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "workspace/didChangeConfiguration"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "textDocument": {
-                  "text": "package pack is\n\n   type Root is abstract tagged null record;\n   \n   procedure Method (X : Root) is abstract;\n   \n   type Child is new Root with null record;\n   \n   overriding procedure Method (X : Child);\n   \n   type Grandchild is new Child with null record;\n   \n   overriding procedure Method (X: Grandchild) is null;\n   \n   type Other_Grandchild is new Child with null record;\n   \n   overriding procedure Method (X : Other_Grandchild);\n\nend pack;\n", 
-                  "version": 0, 
-                  "uri": "$URI{pack.ads}", 
+                  "text": "package pack is\n\n   type Root is abstract tagged null record;\n   \n   procedure Method (X : Root) is abstract;\n   \n   type Child is new Root with null record;\n   \n   overriding procedure Method (X : Child);\n   \n   type Grandchild is new Child with null record;\n   \n   overriding procedure Method (X: Grandchild) is null;\n   \n   type Other_Grandchild is new Child with null record;\n   \n   overriding procedure Method (X : Other_Grandchild);\n\nend pack;\n",
+                  "version": 0,
+                  "uri": "$URI{pack.ads}",
                   "languageId": "Ada"
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "textDocument/didOpen"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "textDocument": {
-                  "text": "package body pack is\n   \n   overriding procedure Method (X : Child) is null;\n   \n   overriding procedure Method (X : Other_Grandchild) is\n      C : Child;\n   begin\n      C.Method;\n   end Method;\n   \nend pack;\n", 
-                  "version": 0, 
-                  "uri": "$URI{pack.adb}", 
+                  "text": "package body pack is\n   \n   overriding procedure Method (X : Child) is null;\n   \n   overriding procedure Method (X : Other_Grandchild) is\n      C : Child;\n   begin\n      C.Method;\n   end Method;\n   \nend pack;\n",
+                  "version": 0,
+                  "uri": "$URI{pack.adb}",
                   "languageId": "Ada"
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "textDocument/didOpen"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {"comment":   "--------------- check 'definition' on the root class, verify that child and 2 grandchildren are listed -------------"},
    {
       "send": {
          "request": {
             "params": {
                "position": {
-                  "line": 4, 
+                  "line": 4,
                   "character": 13
-               }, 
+               },
                "textDocument": {
                   "uri": "$URI{pack.ads}"
                }
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 2, 
+            },
+            "jsonrpc": "2.0",
+            "id": 2,
             "method": "textDocument/definition"
          },
          "wait": [
             {
-               "id": 2, 
+               "id": 2,
                "result": [
                   {
                      "range": {
                         "start": {
-                           "line": 8, 
+                           "line": 8,
                            "character": 24
-                        }, 
+                        },
                         "end": {
-                           "line": 8, 
+                           "line": 8,
                            "character": 30
                         }
-                     }, 
+                     },
                      "alsKind": [
                         "child"
-                     ], 
+                     ],
                      "uri": "$URI{pack.ads}"
-                  }, 
+                  },
                   {
                      "range": {
                         "start": {
-                           "line": 12, 
+                           "line": 12,
                            "character": 24
-                        }, 
+                        },
                         "end": {
-                           "line": 12, 
+                           "line": 12,
                            "character": 30
                         }
-                     }, 
+                     },
                      "alsKind": [
                         "child"
-                     ], 
+                     ],
                      "uri": "$URI{pack.ads}"
-                  }, 
+                  },
                   {
                      "range": {
                         "start": {
-                           "line": 16, 
+                           "line": 16,
                            "character": 24
-                        }, 
+                        },
                         "end": {
-                           "line": 16, 
+                           "line": 16,
                            "character": 30
                         }
-                     }, 
+                     },
                      "alsKind": [
                         "child"
-                     ], 
+                     ],
                      "uri": "$URI{pack.ads}"
                   }
                ]
             }
          ]
       }
-   }, 
+   },
    {"comment":   "--------------- check 'definition' on the child class, verify that parent and 2 grandchildren are listed -------------"},
    {
       "send": {
          "request": {
             "params": {
                "position": {
-                  "line": 8, 
+                  "line": 8,
                   "character": 24
-               }, 
+               },
                "textDocument": {
                   "uri": "$URI{pack.ads}"
                }
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 4, 
+            },
+            "jsonrpc": "2.0",
+            "id": 4,
             "method": "textDocument/definition"
-         }, 
+         },
          "wait": [
             {
-               "id": 4, 
+               "id": 4,
                "result": [
                   {
                      "range": {
                         "start": {
-                           "line": 2, 
-                           "character": 24
-                        }, 
-                        "end": {
-                           "line": 2, 
-                           "character": 30
-                        }
-                     }, 
-                     "uri": "$URI{pack.adb}"
-                  }, 
-                  {
-                     "range": {
-                        "start": {
-                           "line": 4, 
+                           "line": 4,
                            "character": 13
-                        }, 
+                        },
                         "end": {
-                           "line": 4, 
+                           "line": 4,
                            "character": 19
                         }
-                     }, 
+                     },
                      "alsKind": [
                         "parent"
-                     ], 
+                     ],
                      "uri": "$URI{pack.ads}"
-                  }, 
+                  },
                   {
                      "range": {
                         "start": {
-                           "line": 12, 
+                           "line": 12,
                            "character": 24
-                        }, 
+                        },
                         "end": {
-                           "line": 12, 
+                           "line": 12,
                            "character": 30
                         }
-                     }, 
+                     },
                      "alsKind": [
                         "child"
-                     ], 
+                     ],
                      "uri": "$URI{pack.ads}"
-                  }, 
+                  },
                   {
                      "range": {
                         "start": {
-                           "line": 16, 
+                           "line": 16,
                            "character": 24
-                        }, 
+                        },
                         "end": {
-                           "line": 16, 
+                           "line": 16,
                            "character": 30
                         }
-                     }, 
+                     },
                      "alsKind": [
                         "child"
-                     ], 
+                     ],
                      "uri": "$URI{pack.ads}"
+                  },
+                  {
+                     "range": {
+                        "start": {
+                           "line": 2,
+                           "character": 24
+                        },
+                        "end": {
+                           "line": 2,
+                           "character": 30
+                        }
+                     },
+                     "uri": "$URI{pack.adb}"
                   }
                ]
             }
          ]
       }
-   }, 
+   },
    {"comment":   "--------------- check 'definition' on the grandchild class, verify that child and root are listed as parent -------------"},
    {
       "send": {
          "request": {
             "params": {
                "position": {
-                  "line": 12, 
+                  "line": 12,
                   "character": 24
-               }, 
+               },
                "textDocument": {
                   "uri": "$URI{pack.ads}"
                }
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 7, 
+            },
+            "jsonrpc": "2.0",
+            "id": 7,
             "method": "textDocument/definition"
-         }, 
+         },
          "wait": [
             {
-               "id": 7, 
+               "id": 7,
                "result": [
                   {
                      "range": {
                         "start": {
-                           "line": 8, 
-                           "character": 24
-                        }, 
+                           "line": 4,
+                           "character": 13
+                        },
                         "end": {
-                           "line": 8, 
-                           "character": 30
+                           "line": 4,
+                           "character": 19
                         }
-                     }, 
+                     },
                      "alsKind": [
                         "parent"
-                     ], 
+                     ],
                      "uri": "$URI{pack.ads}"
-                  }, 
+                  },
                   {
                      "range": {
                         "start": {
-                           "line": 4, 
-                           "character": 13
-                        }, 
+                           "line": 8,
+                           "character": 24
+                        },
                         "end": {
-                           "line": 4, 
-                           "character": 19
+                           "line": 8,
+                           "character": 30
                         }
-                     }, 
+                     },
                      "alsKind": [
                         "parent"
-                     ], 
+                     ],
                      "uri": "$URI{pack.ads}"
                   }
                ]
             }
          ]
       }
-   }, 
+   },
    {"comment":   "--------------- check 'definition' on the other_grandchild class, verify that child and root are listed as parent -------------"},
    {
       "send": {
          "request": {
             "params": {
                "position": {
-                  "line": 16, 
+                  "line": 16,
                   "character": 24
-               }, 
+               },
                "textDocument": {
                   "uri": "$URI{pack.ads}"
                }
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 10, 
+            },
+            "jsonrpc": "2.0",
+            "id": 10,
             "method": "textDocument/definition"
-         }, 
+         },
          "wait": [
             {
-               "id": 10, 
+               "id": 10,
                "result": [
                   {
                      "range": {
                         "start": {
-                           "line": 4, 
-                           "character": 24
-                        }, 
-                        "end": {
-                           "line": 4, 
-                           "character": 30
-                        }
-                     }, 
-                     "uri": "$URI{pack.adb}"
-                  }, 
-                  {
-                     "range": {
-                        "start": {
-                           "line": 8, 
-                           "character": 24
-                        }, 
-                        "end": {
-                           "line": 8, 
-                           "character": 30
-                        }
-                     }, 
-                     "alsKind": [
-                        "parent"
-                     ], 
-                     "uri": "$URI{pack.ads}"
-                  }, 
-                  {
-                     "range": {
-                        "start": {
-                           "line": 4, 
+                           "line": 4,
                            "character": 13
-                        }, 
+                        },
                         "end": {
-                           "line": 4, 
+                           "line": 4,
                            "character": 19
                         }
-                     }, 
+                     },
                      "alsKind": [
                         "parent"
-                     ], 
+                     ],
                      "uri": "$URI{pack.ads}"
+                  },
+                  {
+                     "range": {
+                        "start": {
+                           "line": 8,
+                           "character": 24
+                        },
+                        "end": {
+                           "line": 8,
+                           "character": 30
+                        }
+                     },
+                     "alsKind": [
+                        "parent"
+                     ],
+                     "uri": "$URI{pack.ads}"
+                  },
+                  {
+                     "range": {
+                        "start": {
+                           "line": 4,
+                           "character": 24
+                        },
+                        "end": {
+                           "line": 4,
+                           "character": 30
+                        }
+                     },
+                     "uri": "$URI{pack.adb}"
                   }
                ]
             }
          ]
       }
-   }, 
+   },
    {"comment":   "--------------- check 'definition' on the call to Method in p.adb -------------"},
    {
       "send": {
          "request": {
             "params": {
                "position": {
-                  "line": 7, 
+                  "line": 7,
                   "character": 8
-               }, 
+               },
                "textDocument": {
                   "uri": "$URI{pack.adb}"
                }
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 13, 
+            },
+            "jsonrpc": "2.0",
+            "id": 13,
             "method": "textDocument/definition"
-         }, 
+         },
          "wait": [
             {
-               "id": 13, 
+               "id": 13,
                "result": [
                   {
                      "range": {
                         "start": {
-                           "line": 8, 
-                           "character": 24
-                        }, 
-                        "end": {
-                           "line": 8, 
-                           "character": 30
-                        }
-                     }, 
-                     "uri": "$URI{pack.ads}"
-                  }, 
-                  {
-                     "range": {
-                        "start": {
-                           "line": 4, 
+                           "line": 4,
                            "character": 13
-                        }, 
+                        },
                         "end": {
-                           "line": 4, 
+                           "line": 4,
                            "character": 19
                         }
-                     }, 
+                     },
                      "alsKind": [
                         "parent"
-                     ], 
+                     ],
                      "uri": "$URI{pack.ads}"
-                  }, 
+                  },
                   {
                      "range": {
                         "start": {
-                           "line": 12, 
+                           "line": 8,
                            "character": 24
-                        }, 
+                        },
                         "end": {
-                           "line": 12, 
+                           "line": 8,
                            "character": 30
                         }
-                     }, 
-                     "alsKind": [
-                        "child"
-                     ], 
+                     },
                      "uri": "$URI{pack.ads}"
-                  }, 
+                  },
                   {
                      "range": {
                         "start": {
-                           "line": 16, 
+                           "line": 12,
                            "character": 24
-                        }, 
+                        },
                         "end": {
-                           "line": 16, 
+                           "line": 12,
                            "character": 30
                         }
-                     }, 
+                     },
                      "alsKind": [
                         "child"
-                     ], 
+                     ],
+                     "uri": "$URI{pack.ads}"
+                  },
+                  {
+                     "range": {
+                        "start": {
+                           "line": 16,
+                           "character": 24
+                        },
+                        "end": {
+                           "line": 16,
+                           "character": 30
+                        }
+                     },
+                     "alsKind": [
+                        "child"
+                     ],
                      "uri": "$URI{pack.ads}"
                   }
                ]
             }
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
@@ -522,13 +522,13 @@
                "textDocument": {
                   "uri": "$URI{pack.ads}"
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "textDocument/didClose"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
@@ -536,28 +536,28 @@
                "textDocument": {
                   "uri": "$URI{pack.adb}"
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "textDocument/didClose"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
-            "jsonrpc": "2.0", 
-            "id": 16, 
+            "jsonrpc": "2.0",
+            "id": 16,
             "method": "shutdown"
-         }, 
+         },
          "wait": [
             {
-               "id": 16, 
+               "id": 16,
                "result": null
             }
          ]
       }
-   }, 
+   },
    {
       "stop": {
          "exit_code": 0

--- a/testsuite/ada_lsp/implementation.overridings/test.json
+++ b/testsuite/ada_lsp/implementation.overridings/test.json
@@ -3,14 +3,14 @@
       "comment": [
          "test automatically generated"
       ]
-   }, 
+   },
    {
       "start": {
          "cmd": [
             "${ALS}"
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
@@ -19,548 +19,548 @@
                   "textDocument": {
                      "completion": {
                         "completionItemKind": {}
-                     }, 
-                     "documentLink": {}, 
-                     "formatting": {}, 
-                     "documentHighlight": {}, 
-                     "synchronization": {}, 
-                     "references": {}, 
-                     "rangeFormatting": {}, 
-                     "onTypeFormatting": {}, 
-                     "codeLens": {}, 
+                     },
+                     "documentLink": {},
+                     "formatting": {},
+                     "documentHighlight": {},
+                     "synchronization": {},
+                     "references": {},
+                     "rangeFormatting": {},
+                     "onTypeFormatting": {},
+                     "codeLens": {},
                      "colorProvider": {}
-                  }, 
+                  },
                   "workspace": {
-                     "applyEdit": false, 
-                     "executeCommand": {}, 
-                     "didChangeWatchedFiles": {}, 
-                     "workspaceEdit": {}, 
+                     "applyEdit": false,
+                     "executeCommand": {},
+                     "didChangeWatchedFiles": {},
+                     "workspaceEdit": {},
                      "didChangeConfiguration": {}
                   }
-               }, 
+               },
                "rootUri": "$URI{.}"
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 1, 
+            },
+            "jsonrpc": "2.0",
+            "id": 1,
             "method": "initialize"
-         }, 
+         },
          "wait": [
             {
-               "id": 1, 
+               "id": 1,
                "result": {
                   "capabilities": {
-                     "typeDefinitionProvider": true, 
+                     "typeDefinitionProvider": true,
                      "alsReferenceKinds": [
-                        "write", 
-                        "call", 
-                        "dispatching call", 
-                        "parent", 
+                        "write",
+                        "call",
+                        "dispatching call",
+                        "parent",
                         "child"
-                     ], 
-                     "hoverProvider": true, 
-                     "definitionProvider": true, 
-                     "renameProvider": {}, 
-                     "alsCalledByProvider": true, 
-                     "referencesProvider": true, 
-                     "declarationProvider": true, 
-                     "textDocumentSync": 1, 
+                     ],
+                     "hoverProvider": true,
+                     "definitionProvider": true,
+                     "renameProvider": {},
+                     "alsCalledByProvider": true,
+                     "referencesProvider": true,
+                     "declarationProvider": true,
+                     "textDocumentSync": 1,
                      "completionProvider": {
                         "triggerCharacters": [
                            "."
-                        ], 
+                        ],
                         "resolveProvider": false
-                     }, 
+                     },
                      "documentSymbolProvider": true
                   }
                }
             }
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
-            "jsonrpc": "2.0", 
+            "jsonrpc": "2.0",
             "method": "initialized"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "settings": {
                   "ada": {
-                     "scenarioVariables": {}, 
-                     "enableDiagnostics": false, 
+                     "scenarioVariables": {},
+                     "enableDiagnostics": false,
                      "defaultCharset": "ISO-8859-1"
                   }
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "workspace/didChangeConfiguration"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "textDocument": {
-                  "text": "pragma Ada_2012;\npackage body pack is\n\n\n   procedure Method (X : Child) is\n   begin\n      null;\n   end Method;\n\n   ------------\n   -- Method --\n   ------------\n\n   procedure Method (X : Grandchild) is\n      X : Child;\n   begin\n      X.Method;\n   end Method;\n\n   ------------\n   -- Method --\n   ------------\n\n   procedure Method (X : Great_Grandchild) is\n   begin\n      null;\n   end Method;\n\nend pack;\n", 
-                  "version": 0, 
-                  "uri": "$URI{pack.adb}", 
+                  "text": "pragma Ada_2012;\npackage body pack is\n\n\n   procedure Method (X : Child) is\n   begin\n      null;\n   end Method;\n\n   ------------\n   -- Method --\n   ------------\n\n   procedure Method (X : Grandchild) is\n      X : Child;\n   begin\n      X.Method;\n   end Method;\n\n   ------------\n   -- Method --\n   ------------\n\n   procedure Method (X : Great_Grandchild) is\n   begin\n      null;\n   end Method;\n\nend pack;\n",
+                  "version": 0,
+                  "uri": "$URI{pack.adb}",
                   "languageId": "Ada"
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "textDocument/didOpen"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "textDocument": {
-                  "text": "package pack is\n\n   type Root is tagged null record;\n   procedure Method (X : Root) is abstract;\n   \n   type Child is new Root with null record;\n   procedure Method (X : Child);\n   \n   type Grandchild is new Child with null record;\n   procedure Method (X : Grandchild);\n\n   type Great_Grandchild is new Grandchild with null record;\n   procedure Method (X : Great_Grandchild);\n   \nend pack;\n", 
-                  "version": 0, 
-                  "uri": "$URI{pack.ads}", 
+                  "text": "package pack is\n\n   type Root is tagged null record;\n   procedure Method (X : Root) is abstract;\n   \n   type Child is new Root with null record;\n   procedure Method (X : Child);\n   \n   type Grandchild is new Child with null record;\n   procedure Method (X : Grandchild);\n\n   type Great_Grandchild is new Grandchild with null record;\n   procedure Method (X : Great_Grandchild);\n   \nend pack;\n",
+                  "version": 0,
+                  "uri": "$URI{pack.ads}",
                   "languageId": "Ada"
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "textDocument/didOpen"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "position": {
-                  "line": 3, 
+                  "line": 3,
                   "character": 13
-               }, 
+               },
                "textDocument": {
                   "uri": "$URI{pack.ads}"
                }
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 2, 
+            },
+            "jsonrpc": "2.0",
+            "id": 2,
             "method": "textDocument/implementation"
-         }, 
+         },
          "wait": [
             {
-               "id": 2, 
+               "id": 2,
                "result": [
                   {
                      "range": {
                         "start": {
-                           "line": 4, 
+                           "line": 4,
                            "character": 13
-                        }, 
+                        },
                         "end": {
-                           "line": 4, 
+                           "line": 4,
                            "character": 19
                         }
-                     }, 
+                     },
                      "alsKind": [
                         "child"
-                     ], 
-                     "uri": "$URI{pack.adb}"
-                  }, 
-                  {
-                     "range": {
-                        "start": {
-                           "line": 13, 
-                           "character": 13
-                        }, 
-                        "end": {
-                           "line": 13, 
-                           "character": 19
-                        }
-                     }, 
-                     "alsKind": [
-                        "child"
-                     ], 
-                     "uri": "$URI{pack.adb}"
-                  }, 
-                  {
-                     "range": {
-                        "start": {
-                           "line": 23, 
-                           "character": 13
-                        }, 
-                        "end": {
-                           "line": 23, 
-                           "character": 19
-                        }
-                     }, 
-                     "alsKind": [
-                        "child"
-                     ], 
-                     "uri": "$URI{pack.adb}"
-                  }
-               ]
-            }
-         ]
-      }
-   }, 
-   {
-      "send": {
-         "request": {
-            "params": {
-               "position": {
-                  "line": 6, 
-                  "character": 13
-               }, 
-               "textDocument": {
-                  "uri": "$URI{pack.ads}"
-               }
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 5, 
-            "method": "textDocument/implementation"
-         }, 
-         "wait": [
-            {
-               "id": 5, 
-               "result": [
-                  {
-                     "range": {
-                        "start": {
-                           "line": 4, 
-                           "character": 13
-                        }, 
-                        "end": {
-                           "line": 4, 
-                           "character": 19
-                        }
-                     }, 
-                     "uri": "$URI{pack.adb}"
-                  }, 
-                  {
-                     "range": {
-                        "start": {
-                           "line": 13, 
-                           "character": 13
-                        }, 
-                        "end": {
-                           "line": 13, 
-                           "character": 19
-                        }
-                     }, 
-                     "alsKind": [
-                        "child"
-                     ], 
-                     "uri": "$URI{pack.adb}"
-                  }, 
-                  {
-                     "range": {
-                        "start": {
-                           "line": 23, 
-                           "character": 13
-                        }, 
-                        "end": {
-                           "line": 23, 
-                           "character": 19
-                        }
-                     }, 
-                     "alsKind": [
-                        "child"
-                     ], 
-                     "uri": "$URI{pack.adb}"
-                  }
-               ]
-            }
-         ]
-      }
-   }, 
-   {
-      "send": {
-         "request": {
-            "params": {
-               "position": {
-                  "line": 9, 
-                  "character": 13
-               }, 
-               "textDocument": {
-                  "uri": "$URI{pack.ads}"
-               }
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 8, 
-            "method": "textDocument/implementation"
-         }, 
-         "wait": [
-            {
-               "id": 8, 
-               "result": [
-                  {
-                     "range": {
-                        "start": {
-                           "line": 13, 
-                           "character": 13
-                        }, 
-                        "end": {
-                           "line": 13, 
-                           "character": 19
-                        }
-                     }, 
-                     "uri": "$URI{pack.adb}"
-                  }, 
-                  {
-                     "range": {
-                        "start": {
-                           "line": 4, 
-                           "character": 13
-                        }, 
-                        "end": {
-                           "line": 4, 
-                           "character": 19
-                        }
-                     }, 
-                     "alsKind": [
-                        "parent"
-                     ], 
-                     "uri": "$URI{pack.adb}"
-                  }, 
-                  {
-                     "range": {
-                        "start": {
-                           "line": 23, 
-                           "character": 13
-                        }, 
-                        "end": {
-                           "line": 23, 
-                           "character": 19
-                        }
-                     }, 
-                     "alsKind": [
-                        "child"
-                     ], 
-                     "uri": "$URI{pack.adb}"
-                  }
-               ]
-            }
-         ]
-      }
-   }, 
-   {
-      "send": {
-         "request": {
-            "params": {
-               "position": {
-                  "line": 12, 
-                  "character": 13
-               }, 
-               "textDocument": {
-                  "uri": "$URI{pack.ads}"
-               }
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 12, 
-            "method": "textDocument/implementation"
-         }, 
-         "wait": [
-            {
-               "id": 12, 
-               "result": [
-                  {
-                     "range": {
-                        "start": {
-                           "line": 23, 
-                           "character": 13
-                        }, 
-                        "end": {
-                           "line": 23, 
-                           "character": 19
-                        }
-                     }, 
-                     "uri": "$URI{pack.adb}"
-                  }, 
-                  {
-                     "range": {
-                        "start": {
-                           "line": 13, 
-                           "character": 13
-                        }, 
-                        "end": {
-                           "line": 13, 
-                           "character": 19
-                        }
-                     }, 
-                     "alsKind": [
-                        "parent"
-                     ], 
-                     "uri": "$URI{pack.adb}"
-                  }, 
-                  {
-                     "range": {
-                        "start": {
-                           "line": 4, 
-                           "character": 13
-                        }, 
-                        "end": {
-                           "line": 4, 
-                           "character": 19
-                        }
-                     }, 
-                     "alsKind": [
-                        "parent"
-                     ], 
-                     "uri": "$URI{pack.adb}"
-                  }
-               ]
-            }
-         ]
-      }
-   },  
-   {
-      "send": {
-         "request": {
-            "params": {
-               "position": {
-                  "line": 13, 
-                  "character": 13
-               }, 
-               "textDocument": {
-                  "uri": "$URI{pack.adb}"
-               }
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 15, 
-            "method": "textDocument/implementation"
-         }, 
-         "wait": [
-            {
-               "id": 15, 
-               "result": [
-                  {
-                     "range": {
-                        "start": {
-                           "line": 13, 
-                           "character": 13
-                        }, 
-                        "end": {
-                           "line": 13, 
-                           "character": 19
-                        }
-                     }, 
-                     "uri": "$URI{pack.adb}"
-                  }, 
-                  {
-                     "range": {
-                        "start": {
-                           "line": 4, 
-                           "character": 13
-                        }, 
-                        "end": {
-                           "line": 4, 
-                           "character": 19
-                        }
-                     }, 
-                     "alsKind": [
-                        "parent"
-                     ], 
-                     "uri": "$URI{pack.adb}"
-                  }, 
-                  {
-                     "range": {
-                        "start": {
-                           "line": 23, 
-                           "character": 13
-                        }, 
-                        "end": {
-                           "line": 23, 
-                           "character": 19
-                        }
-                     }, 
-                     "alsKind": [
-                        "child"
-                     ], 
-                     "uri": "$URI{pack.adb}"
-                  }
-               ]
-            }
-         ]
-      }
-   }, 
-   {
-      "send": {
-         "request": {
-            "params": {
-               "position": {
-                  "line": 16, 
-                  "character": 8
-               }, 
-               "textDocument": {
-                  "uri": "$URI{pack.adb}"
-               }
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 18, 
-            "method": "textDocument/implementation"
-         }, 
-         "wait": [
-            {
-               "id": 18, 
-               "result": [
-                  {
-                     "range": {
-                        "start": {
-                           "line": 4, 
-                           "character": 13
-                        }, 
-                        "end": {
-                           "line": 4, 
-                           "character": 19
-                        }
-                     }, 
+                     ],
                      "uri": "$URI{pack.adb}"
                   },
                   {
                      "range": {
                         "start": {
-                           "line": 13, 
+                           "line": 13,
                            "character": 13
-                        }, 
+                        },
                         "end": {
-                           "line": 13, 
+                           "line": 13,
                            "character": 19
                         }
-                     }, 
+                     },
                      "alsKind": [
                         "child"
-                     ], 
+                     ],
                      "uri": "$URI{pack.adb}"
-                  }, 
+                  },
                   {
                      "range": {
                         "start": {
-                           "line": 23, 
+                           "line": 23,
                            "character": 13
-                        }, 
+                        },
                         "end": {
-                           "line": 23, 
+                           "line": 23,
                            "character": 19
                         }
-                     }, 
+                     },
                      "alsKind": [
                         "child"
-                     ], 
+                     ],
                      "uri": "$URI{pack.adb}"
                   }
                ]
             }
          ]
       }
-   }, 
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "position": {
+                  "line": 6,
+                  "character": 13
+               },
+               "textDocument": {
+                  "uri": "$URI{pack.ads}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "id": 5,
+            "method": "textDocument/implementation"
+         },
+         "wait": [
+            {
+               "id": 5,
+               "result": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 4,
+                           "character": 13
+                        },
+                        "end": {
+                           "line": 4,
+                           "character": 19
+                        }
+                     },
+                     "uri": "$URI{pack.adb}"
+                  },
+                  {
+                     "range": {
+                        "start": {
+                           "line": 13,
+                           "character": 13
+                        },
+                        "end": {
+                           "line": 13,
+                           "character": 19
+                        }
+                     },
+                     "alsKind": [
+                        "child"
+                     ],
+                     "uri": "$URI{pack.adb}"
+                  },
+                  {
+                     "range": {
+                        "start": {
+                           "line": 23,
+                           "character": 13
+                        },
+                        "end": {
+                           "line": 23,
+                           "character": 19
+                        }
+                     },
+                     "alsKind": [
+                        "child"
+                     ],
+                     "uri": "$URI{pack.adb}"
+                  }
+               ]
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "position": {
+                  "line": 9,
+                  "character": 13
+               },
+               "textDocument": {
+                  "uri": "$URI{pack.ads}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "id": 8,
+            "method": "textDocument/implementation"
+         },
+         "wait": [
+            {
+               "id": 8,
+               "result": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 4,
+                           "character": 13
+                        },
+                        "end": {
+                           "line": 4,
+                           "character": 19
+                        }
+                     },
+                     "alsKind": [
+                        "parent"
+                     ],
+                     "uri": "$URI{pack.adb}"
+                  },
+                  {
+                     "range": {
+                        "start": {
+                           "line": 13,
+                           "character": 13
+                        },
+                        "end": {
+                           "line": 13,
+                           "character": 19
+                        }
+                     },
+                     "uri": "$URI{pack.adb}"
+                  },
+                  {
+                     "range": {
+                        "start": {
+                           "line": 23,
+                           "character": 13
+                        },
+                        "end": {
+                           "line": 23,
+                           "character": 19
+                        }
+                     },
+                     "alsKind": [
+                        "child"
+                     ],
+                     "uri": "$URI{pack.adb}"
+                  }
+               ]
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "position": {
+                  "line": 12,
+                  "character": 13
+               },
+               "textDocument": {
+                  "uri": "$URI{pack.ads}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "id": 12,
+            "method": "textDocument/implementation"
+         },
+         "wait": [
+            {
+               "id": 12,
+               "result": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 4,
+                           "character": 13
+                        },
+                        "end": {
+                           "line": 4,
+                           "character": 19
+                        }
+                     },
+                     "alsKind": [
+                        "parent"
+                     ],
+                     "uri": "$URI{pack.adb}"
+                  },
+                  {
+                     "range": {
+                        "start": {
+                           "line": 13,
+                           "character": 13
+                        },
+                        "end": {
+                           "line": 13,
+                           "character": 19
+                        }
+                     },
+                     "alsKind": [
+                        "parent"
+                     ],
+                     "uri": "$URI{pack.adb}"
+                  },
+                  {
+                     "range": {
+                        "start": {
+                           "line": 23,
+                           "character": 13
+                        },
+                        "end": {
+                           "line": 23,
+                           "character": 19
+                        }
+                     },
+                     "uri": "$URI{pack.adb}"
+                  }
+               ]
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "position": {
+                  "line": 13,
+                  "character": 13
+               },
+               "textDocument": {
+                  "uri": "$URI{pack.adb}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "id": 15,
+            "method": "textDocument/implementation"
+         },
+         "wait": [
+            {
+               "id": 15,
+               "result": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 4,
+                           "character": 13
+                        },
+                        "end": {
+                           "line": 4,
+                           "character": 19
+                        }
+                     },
+                     "alsKind": [
+                        "parent"
+                     ],
+                     "uri": "$URI{pack.adb}"
+                  },
+                  {
+                     "range": {
+                        "start": {
+                           "line": 13,
+                           "character": 13
+                        },
+                        "end": {
+                           "line": 13,
+                           "character": 19
+                        }
+                     },
+                     "uri": "$URI{pack.adb}"
+                  },
+                  {
+                     "range": {
+                        "start": {
+                           "line": 23,
+                           "character": 13
+                        },
+                        "end": {
+                           "line": 23,
+                           "character": 19
+                        }
+                     },
+                     "alsKind": [
+                        "child"
+                     ],
+                     "uri": "$URI{pack.adb}"
+                  }
+               ]
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "position": {
+                  "line": 16,
+                  "character": 8
+               },
+               "textDocument": {
+                  "uri": "$URI{pack.adb}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "id": 18,
+            "method": "textDocument/implementation"
+         },
+         "wait": [
+            {
+               "id": 18,
+               "result": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 4,
+                           "character": 13
+                        },
+                        "end": {
+                           "line": 4,
+                           "character": 19
+                        }
+                     },
+                     "uri": "$URI{pack.adb}"
+                  },
+                  {
+                     "range": {
+                        "start": {
+                           "line": 13,
+                           "character": 13
+                        },
+                        "end": {
+                           "line": 13,
+                           "character": 19
+                        }
+                     },
+                     "alsKind": [
+                        "child"
+                     ],
+                     "uri": "$URI{pack.adb}"
+                  },
+                  {
+                     "range": {
+                        "start": {
+                           "line": 23,
+                           "character": 13
+                        },
+                        "end": {
+                           "line": 23,
+                           "character": 19
+                        }
+                     },
+                     "alsKind": [
+                        "child"
+                     ],
+                     "uri": "$URI{pack.adb}"
+                  }
+               ]
+            }
+         ]
+      }
+   },
    {
       "send": {
          "request": {
@@ -568,13 +568,13 @@
                "textDocument": {
                   "uri": "$URI{pack.ads}"
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "textDocument/didClose"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
@@ -582,28 +582,28 @@
                "textDocument": {
                   "uri": "$URI{pack.adb}"
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "textDocument/didClose"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
-            "jsonrpc": "2.0", 
-            "id": 21, 
+            "jsonrpc": "2.0",
+            "id": 21,
             "method": "shutdown"
-         }, 
+         },
          "wait": [
             {
-               "id": 21, 
+               "id": 21,
                "result": null
             }
          ]
       }
-   }, 
+   },
    {
       "stop": {
          "exit_code": 0


### PR DESCRIPTION
When returning a list of locations, we were checking at each insertion
whether the location was already present in the results. This has
a cost of O(n^2)

Instead, append the locations, and sort/remove duplicates only at
the end, changing the cost to O(n*log(n)).

Sort the results by file then location; when sorting files in the
same directory, use a slightly more logical sort than an alphabetic
sort, returning locations in the .ads before the .adb, and the parent
package before the child packages.