### PR TITLE
SA22-030: Add more reference kinds

### DIFF
--- a/source/protocol/lsp-messages.adb
+++ b/source/protocol/lsp-messages.adb
@@ -115,6 +115,8 @@ package body LSP.Messages is
       RequestCancelled     => -32800,
       ContentModified      => -32801);
 
+   Simple_Reference_Image           : aliased constant Standard.String :=
+                                        "reference";
    Write_Reference_Image            : aliased constant Standard.String :=
                                         "write";
    Static_Call_Reference_Image      : aliased constant Standard.String :=
@@ -130,7 +132,8 @@ package body LSP.Messages is
 
    AlsReferenceKind_Map : constant array
      (AlsReferenceKind) of not null String_Constant_Access :=
-     (Write            => Write_Reference_Image'Access,
+     (Simple           => Simple_Reference_Image'Access,
+      Write            => Write_Reference_Image'Access,
       Static_Call      => Static_Call_Reference_Image'Access,
       Dispatching_Call => Dispatching_Call_Reference_Image'Access,
       Parent           => Parent_Reference_Image'Access,

--- a/source/protocol/lsp-messages.ads
+++ b/source/protocol/lsp-messages.ads
@@ -367,7 +367,7 @@ package LSP.Messages is
    --  }
 
    type AlsReferenceKind is
-     (Write, Static_Call, Dispatching_Call, Parent, Child);
+     (Simple, Write, Static_Call, Dispatching_Call, Parent, Child);
    type AlsReferenceKind_Array is array (AlsReferenceKind) of Boolean;
    type AlsReferenceKind_Set (Is_Server_Side : Boolean := True) is record
       case Is_Server_Side is

--- a/testsuite/ada_lsp/F131-024.xrefs.separate_body/test.json
+++ b/testsuite/ada_lsp/F131-024.xrefs.separate_body/test.json
@@ -34,6 +34,7 @@
                   "capabilities": {
                      "typeDefinitionProvider": true,
                      "alsReferenceKinds": [
+                        "reference",
                         "write",
                         "call",
                         "dispatching call", "parent", "child"

--- a/testsuite/ada_lsp/G323-009.tooltips.function_prototype/test.json
+++ b/testsuite/ada_lsp/G323-009.tooltips.function_prototype/test.json
@@ -34,6 +34,7 @@
                   "capabilities": {
                      "typeDefinitionProvider": true,
                      "alsReferenceKinds": [
+                        "reference",
                         "write",
                         "call",
                         "dispatching call", "parent", "child"

--- a/testsuite/ada_lsp/S510-020.exceptions_reporting/test.json
+++ b/testsuite/ada_lsp/S510-020.exceptions_reporting/test.json
@@ -44,7 +44,6 @@
             "wait":[{
                 "jsonrpc": "2.0",
                 "id": "references-1",
-                "result": "<ABSENT>",
                 "error": {
                     "code":-32603,
                     "message":"<ANY>"

--- a/testsuite/ada_lsp/S820-016.called_by.entry/test.json
+++ b/testsuite/ada_lsp/S820-016.called_by.entry/test.json
@@ -3,14 +3,14 @@
       "comment": [
          "testing 'called by' on a task entry"
       ]
-   }, 
+   },
    {
       "start": {
          "cmd": [
             "${ALS}"
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
@@ -19,181 +19,182 @@
                   "workspace": {
                      "applyEdit": false
                   }
-               }, 
+               },
                "rootUri": "$URI{.}"
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 1, 
+            },
+            "jsonrpc": "2.0",
+            "id": 1,
             "method": "initialize"
-         }, 
+         },
          "wait": [
             {
-               "id": 1, 
+               "id": 1,
                "result": {
                   "capabilities": {
-                     "typeDefinitionProvider": true, 
+                     "typeDefinitionProvider": true,
                      "alsReferenceKinds": [
-                        "write", 
-                        "call", 
+                        "reference",
+                        "write",
+                        "call",
                         "dispatching call", "parent", "child"
-                     ], 
-                     "hoverProvider": true, 
-                     "definitionProvider": true, 
-                     "renameProvider": {}, 
-                     "alsCalledByProvider": true, 
-                     "referencesProvider": true, 
-                     "textDocumentSync": 1, 
+                     ],
+                     "hoverProvider": true,
+                     "definitionProvider": true,
+                     "renameProvider": {},
+                     "alsCalledByProvider": true,
+                     "referencesProvider": true,
+                     "textDocumentSync": 1,
                      "completionProvider": {
                         "triggerCharacters": [
                            "."
-                        ], 
+                        ],
                         "resolveProvider": false
-                     }, 
+                     },
                      "documentSymbolProvider": true
                   }
                }
             }
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
-            "jsonrpc": "2.0", 
+            "jsonrpc": "2.0",
             "method": "initialized"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "settings": {
                   "ada": {
-                     "projectFile": "default.gpr", 
-                     "scenarioVariables": {}, 
-                     "enableDiagnostics": false, 
+                     "projectFile": "default.gpr",
+                     "scenarioVariables": {},
+                     "enableDiagnostics": false,
                      "defaultCharset": "UTF-8"
                   }
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "workspace/didChangeConfiguration"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "textDocument": {
-                  "text": "package phil is\n   task type philosopher is\n      entry Start_Eating (Chopstick1 : in Positive;\n                        Chopstick2 : in Positive);\n   end philosopher;\nend Phil;\n", 
-                  "version": 0, 
-                  "uri": "$URI{phil.ads}", 
+                  "text": "package phil is\n   task type philosopher is\n      entry Start_Eating (Chopstick1 : in Positive;\n                        Chopstick2 : in Positive);\n   end philosopher;\nend Phil;\n",
+                  "version": 0,
+                  "uri": "$URI{phil.ads}",
                   "languageId": "Ada"
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "textDocument/didOpen"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "position": {
-                  "line": 2, 
+                  "line": 2,
                   "character": 12
-               }, 
+               },
                "textDocument": {
                   "uri": "$URI{phil.ads}"
                }
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 2, 
+            },
+            "jsonrpc": "2.0",
+            "id": 2,
             "method": "textDocument/alsCalledBy"
-         }, 
+         },
          "wait": [
             {
-               "id": 2, 
+               "id": 2,
                "result": [
                   {
                      "refs": [
                         {
                            "range": {
                               "start": {
-                                 "line": 8, 
+                                 "line": 8,
                                  "character": 5
-                              }, 
+                              },
                               "end": {
-                                 "line": 8, 
+                                 "line": 8,
                                  "character": 17
                               }
-                           }, 
+                           },
                            "uri": "$URI{room.adb}"
-                        }, 
+                        },
                         {
                            "range": {
                               "start": {
-                                 "line": 9, 
+                                 "line": 9,
                                  "character": 5
-                              }, 
+                              },
                               "end": {
-                                 "line": 9, 
+                                 "line": 9,
                                  "character": 17
                               }
-                           }, 
+                           },
                            "uri": "$URI{room.adb}"
                         }
-                     ], 
+                     ],
                      "location": {
                         "range": {
                            "start": {
-                              "line": 2, 
+                              "line": 2,
                               "character": 10
-                           }, 
+                           },
                            "end": {
-                              "line": 2, 
+                              "line": 2,
                               "character": 14
                            }
-                        }, 
+                        },
                         "uri": "$URI{room.adb}"
-                     }, 
+                     },
                      "name": "room"
                   }
                ]
             }
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "position": {
-                  "line": 2, 
+                  "line": 2,
                   "character": 10
-               }, 
+               },
                "textDocument": {
                   "uri": "$URI{room.adb}"
                }
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 3, 
+            },
+            "jsonrpc": "2.0",
+            "id": 3,
             "method": "textDocument/alsCalledBy"
-         }, 
+         },
          "wait": [
             {
-               "id": 3, 
+               "id": 3,
                "result": []
             }
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
@@ -201,28 +202,28 @@
                "textDocument": {
                   "uri": "$URI{phil.ads}"
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "textDocument/didClose"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
-            "jsonrpc": "2.0", 
-            "id": 4, 
+            "jsonrpc": "2.0",
+            "id": 4,
             "method": "shutdown"
-         }, 
+         },
          "wait": [
             {
-               "id": 4, 
+               "id": 4,
                "result": null
             }
          ]
       }
-   }, 
+   },
    {
       "stop": {
          "exit_code": 0

--- a/testsuite/ada_lsp/SA11-040.definition.fallback/test.json
+++ b/testsuite/ada_lsp/SA11-040.definition.fallback/test.json
@@ -3,14 +3,14 @@
       "comment": [
          "test the fallback navigation to subprograms that don't have an exact profile"
       ]
-   }, 
+   },
    {
       "start": {
          "cmd": [
             "${ALS}"
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
@@ -19,174 +19,175 @@
                   "workspace": {
                      "applyEdit": false
                   }
-               }, 
+               },
                "rootUri": "$URI{.}"
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 1, 
+            },
+            "jsonrpc": "2.0",
+            "id": 1,
             "method": "initialize"
-         }, 
+         },
          "wait": [
             {
-               "id": 1, 
+               "id": 1,
                "result": {
                   "capabilities": {
-                     "typeDefinitionProvider": true, 
+                     "typeDefinitionProvider": true,
                      "alsReferenceKinds": [
-                        "write", 
-                        "call", 
+                        "reference",
+                        "write",
+                        "call",
                         "dispatching call", "parent", "child"
-                     ], 
-                     "hoverProvider": true, 
-                     "definitionProvider": true, 
-                     "renameProvider": {}, 
-                     "alsCalledByProvider": true, 
-                     "referencesProvider": true, 
-                     "textDocumentSync": 1, 
+                     ],
+                     "hoverProvider": true,
+                     "definitionProvider": true,
+                     "renameProvider": {},
+                     "alsCalledByProvider": true,
+                     "referencesProvider": true,
+                     "textDocumentSync": 1,
                      "completionProvider": {
                         "triggerCharacters": [
                            "."
-                        ], 
+                        ],
                         "resolveProvider": false
-                     }, 
+                     },
                      "documentSymbolProvider": true
                   }
                }
             }
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
-            "jsonrpc": "2.0", 
+            "jsonrpc": "2.0",
             "method": "initialized"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "settings": {
                   "ada": {
-                     "scenarioVariables": {}, 
-                     "enableDiagnostics": false, 
+                     "scenarioVariables": {},
+                     "enableDiagnostics": false,
                      "defaultCharset": "ISO-8859-1"
                   }
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "workspace/didChangeConfiguration"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "textDocument": {
-                  "text": "package P is\n\n   procedure Foo (A : Integer; Other_Param : Boolean);\n\n   package Nested is\n      procedure Foo (A : Integer);\n\n      procedure Bla (A : Integer);\n   end Nested;\n\n   procedure Bla (A : Integer);\n\nend P;\n", 
-                  "version": 0, 
-                  "uri": "$URI{p.ads}", 
+                  "text": "package P is\n\n   procedure Foo (A : Integer; Other_Param : Boolean);\n\n   package Nested is\n      procedure Foo (A : Integer);\n\n      procedure Bla (A : Integer);\n   end Nested;\n\n   procedure Bla (A : Integer);\n\nend P;\n",
+                  "version": 0,
+                  "uri": "$URI{p.ads}",
                   "languageId": "Ada"
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "textDocument/didOpen"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "position": {
-                  "line": 2, 
+                  "line": 2,
                   "character": 13
-               }, 
+               },
                "textDocument": {
                   "uri": "$URI{p.ads}"
                }
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 2, 
+            },
+            "jsonrpc": "2.0",
+            "id": 2,
             "method": "textDocument/definition"
-         }, 
+         },
          "wait": [
             {
                "params": {
-                  "message": "The result of 'definition' is approximate.", 
+                  "message": "The result of 'definition' is approximate.",
                   "type": 2
-               }, 
+               },
                "method": "window/showMessage"
-            }, 
+            },
             {
-               "id": 2, 
+               "id": 2,
                "result": [
                   {
                      "range": {
                         "start": {
-                           "line": 6, 
+                           "line": 6,
                            "character": 13
-                        }, 
+                        },
                         "end": {
-                           "line": 6, 
+                           "line": 6,
                            "character": 16
                         }
-                     }, 
+                     },
                      "uri": "$URI{p.adb}"
                   }
                ]
             }
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "textDocument": {
-                  "text": "package body P is\n\n   ---------\n   -- Foo --\n   ---------\n\n   procedure Foo (A : Integer) is\n   begin\n      null;\n   end Foo;\n\n   ------------\n   -- Nested --\n   ------------\n\n   package body Nested is\n\n      procedure Foo (A : Integer) is\n      begin\n         null;\n      end Foo;\n\n      procedure Bla (A : Integer; Other_Param : Boolean) is null;\n\n   end Nested;\n\n   procedure Bla is null;\n\nend P;\n", 
-                  "version": 0, 
-                  "uri": "$URI{p.adb}", 
+                  "text": "package body P is\n\n   ---------\n   -- Foo --\n   ---------\n\n   procedure Foo (A : Integer) is\n   begin\n      null;\n   end Foo;\n\n   ------------\n   -- Nested --\n   ------------\n\n   package body Nested is\n\n      procedure Foo (A : Integer) is\n      begin\n         null;\n      end Foo;\n\n      procedure Bla (A : Integer; Other_Param : Boolean) is null;\n\n   end Nested;\n\n   procedure Bla is null;\n\nend P;\n",
+                  "version": 0,
+                  "uri": "$URI{p.adb}",
                   "languageId": "Ada"
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "textDocument/didOpen"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {"comment": "--------- expecting an empty result for the definition of a procedure which 'is null' -------"},
    {
       "send": {
          "request": {
             "params": {
                "position": {
-                  "line": 22, 
+                  "line": 22,
                   "character": 16
-               }, 
+               },
                "textDocument": {
                   "uri": "$URI{p.adb}"
                }
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 3, 
+            },
+            "jsonrpc": "2.0",
+            "id": 3,
             "method": "textDocument/definition"
-         }, 
+         },
          "wait": [
             {
-               "id": 3, 
+               "id": 3,
                "result": []
             }
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
@@ -194,13 +195,13 @@
                "textDocument": {
                   "uri": "$URI{p.ads}"
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "textDocument/didClose"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
@@ -208,28 +209,28 @@
                "textDocument": {
                   "uri": "$URI{p.adb}"
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "textDocument/didClose"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
-            "jsonrpc": "2.0", 
-            "id": 4, 
+            "jsonrpc": "2.0",
+            "id": 4,
             "method": "shutdown"
-         }, 
+         },
          "wait": [
             {
-               "id": 4, 
+               "id": 4,
                "result": null
             }
          ]
       }
-   }, 
+   },
    {
       "stop": {
          "exit_code": 0

--- a/testsuite/ada_lsp/SA22-029.rename_in_comments/test.json
+++ b/testsuite/ada_lsp/SA22-029.rename_in_comments/test.json
@@ -3,14 +3,14 @@
       "comment": [
          "test automatically generated"
       ]
-   }, 
+   },
    {
       "start": {
          "cmd": [
             "${ALS}"
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
@@ -19,87 +19,88 @@
                   "workspace": {
                      "applyEdit": false
                   }
-               }, 
+               },
                "rootUri": "$URI{.}"
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 1, 
+            },
+            "jsonrpc": "2.0",
+            "id": 1,
             "method": "initialize"
-         }, 
+         },
          "wait": [
             {
-               "id": 1, 
+               "id": 1,
                "result": {
                   "capabilities": {
-                     "typeDefinitionProvider": true, 
+                     "typeDefinitionProvider": true,
                      "alsReferenceKinds": [
-                        "write", 
-                        "call", 
+                        "reference",
+                        "write",
+                        "call",
                         "dispatching call", "parent", "child"
-                     ], 
-                     "hoverProvider": true, 
-                     "definitionProvider": true, 
-                     "renameProvider": {}, 
-                     "alsCalledByProvider": true, 
-                     "referencesProvider": true, 
-                     "textDocumentSync": 1, 
+                     ],
+                     "hoverProvider": true,
+                     "definitionProvider": true,
+                     "renameProvider": {},
+                     "alsCalledByProvider": true,
+                     "referencesProvider": true,
+                     "textDocumentSync": 1,
                      "completionProvider": {
                         "triggerCharacters": [
                            "."
-                        ], 
+                        ],
                         "resolveProvider": false
-                     }, 
+                     },
                      "documentSymbolProvider": true
                   }
                }
             }
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
-            "jsonrpc": "2.0", 
+            "jsonrpc": "2.0",
             "method": "initialized"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "settings": {
                   "ada": {
-                     "scenarioVariables": {}, 
-                     "enableDiagnostics": false, 
+                     "scenarioVariables": {},
+                     "enableDiagnostics": false,
                      "defaultCharset": "ISO-8859-1"
                   }
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "workspace/didChangeConfiguration"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "textDocument": {
-                  "text": "\npackage P is\n\n   type T is tagged null record;\n\n   ------------\n   --  Print --\n   ------------\n\n   procedure Print (S : T);\n\n   ------------\n   --  Print --\n   ------------\n\nend P;\n", 
-                  "version": 0, 
-                  "uri": "$URI{p.ads}", 
+                  "text": "\npackage P is\n\n   type T is tagged null record;\n\n   ------------\n   --  Print --\n   ------------\n\n   procedure Print (S : T);\n\n   ------------\n   --  Print --\n   ------------\n\nend P;\n",
+                  "version": 0,
+                  "uri": "$URI{p.ads}",
                   "languageId": "Ada"
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "textDocument/didOpen"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
@@ -109,114 +110,114 @@
                      "renameInComments": true
                   }
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "workspace/didChangeConfiguration"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
-               "newName": "Print1", 
+               "newName": "Print1",
                "position": {
-                  "line": 9, 
+                  "line": 9,
                   "character": 16
-               }, 
+               },
                "textDocument": {
                   "uri": "$URI{p.ads}"
                }
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 2, 
+            },
+            "jsonrpc": "2.0",
+            "id": 2,
             "method": "textDocument/rename"
-         }, 
+         },
          "wait": [
             {
-               "id": 2, 
+               "id": 2,
                "result": {
                   "changes": {
                      "$URI{p.adb}": [
                         {
-                           "newText": "Print1", 
+                           "newText": "Print1",
                            "range": {
                               "start": {
-                                 "line": 5, 
+                                 "line": 5,
                                  "character": 13
-                              }, 
+                              },
                               "end": {
-                                 "line": 5, 
+                                 "line": 5,
                                  "character": 18
                               }
                            }
-                        }, 
+                        },
                         {
-                           "newText": "Print1", 
+                           "newText": "Print1",
                            "range": {
                               "start": {
-                                 "line": 8, 
+                                 "line": 8,
                                  "character": 7
-                              }, 
+                              },
                               "end": {
-                                 "line": 8, 
+                                 "line": 8,
                                  "character": 12
                               }
                            }
                         }
-                     ], 
+                     ],
                      "$URI{p.ads}": [
                         {
-                           "newText": "Print1", 
+                           "newText": "Print1",
                            "range": {
                               "start": {
-                                 "line": 6, 
+                                 "line": 6,
                                  "character": 7
-                              }, 
+                              },
                               "end": {
-                                 "line": 6, 
+                                 "line": 6,
                                  "character": 18
                               }
                            }
-                        }, 
+                        },
                         {
-                           "newText": "Print1", 
+                           "newText": "Print1",
                            "range": {
                               "start": {
-                                 "line": 12, 
+                                 "line": 12,
                                  "character": 7
-                              }, 
+                              },
                               "end": {
-                                 "line": 12, 
+                                 "line": 12,
                                  "character": 18
                               }
                            }
-                        }, 
+                        },
                         {
-                           "newText": "Print1", 
+                           "newText": "Print1",
                            "range": {
                               "start": {
-                                 "line": 9, 
+                                 "line": 9,
                                  "character": 13
-                              }, 
+                              },
                               "end": {
-                                 "line": 9, 
+                                 "line": 9,
                                  "character": 18
                               }
                            }
                         }
-                     ], 
+                     ],
                      "$URI{p1.adb}": [
                         {
-                           "newText": "Print1", 
+                           "newText": "Print1",
                            "range": {
                               "start": {
-                                 "line": 7, 
+                                 "line": 7,
                                  "character": 8
-                              }, 
+                              },
                               "end": {
-                                 "line": 7, 
+                                 "line": 7,
                                  "character": 13
                               }
                            }
@@ -227,22 +228,22 @@
             }
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
-            "jsonrpc": "2.0", 
-            "id": 3, 
+            "jsonrpc": "2.0",
+            "id": 3,
             "method": "shutdown"
-         }, 
+         },
          "wait": [
             {
-               "id": 3, 
+               "id": 3,
                "result": null
             }
          ]
       }
-   }, 
+   },
    {
       "stop": {
          "exit_code": 0

--- a/testsuite/ada_lsp/SA24-055.called_by_on_abstract/test.json
+++ b/testsuite/ada_lsp/SA24-055.called_by_on_abstract/test.json
@@ -3,14 +3,14 @@
       "comment": [
          "test automatically generated"
       ]
-   }, 
+   },
    {
       "start": {
          "cmd": [
             "${ALS}"
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
@@ -19,146 +19,147 @@
                   "workspace": {
                      "applyEdit": false
                   }
-               }, 
+               },
                "rootUri": "$URI{.}"
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 1, 
+            },
+            "jsonrpc": "2.0",
+            "id": 1,
             "method": "initialize"
-         }, 
+         },
          "wait": [
             {
-               "id": 1, 
+               "id": 1,
                "result": {
                   "capabilities": {
-                     "typeDefinitionProvider": true, 
+                     "typeDefinitionProvider": true,
                      "alsReferenceKinds": [
-                        "write", 
-                        "call", 
+                        "reference",
+                        "write",
+                        "call",
                         "dispatching call", "parent", "child"
-                     ], 
-                     "hoverProvider": true, 
-                     "definitionProvider": true, 
-                     "renameProvider": {}, 
-                     "alsCalledByProvider": true, 
-                     "referencesProvider": true, 
-                     "textDocumentSync": 1, 
+                     ],
+                     "hoverProvider": true,
+                     "definitionProvider": true,
+                     "renameProvider": {},
+                     "alsCalledByProvider": true,
+                     "referencesProvider": true,
+                     "textDocumentSync": 1,
                      "completionProvider": {
                         "triggerCharacters": [
                            "."
-                        ], 
+                        ],
                         "resolveProvider": false
-                     }, 
+                     },
                      "documentSymbolProvider": true
                   }
                }
             }
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
-            "jsonrpc": "2.0", 
+            "jsonrpc": "2.0",
             "method": "initialized"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "settings": {
                   "ada": {
-                     "scenarioVariables": {}, 
-                     "enableDiagnostics": false, 
+                     "scenarioVariables": {},
+                     "enableDiagnostics": false,
                      "defaultCharset": "ISO-8859-1"
                   }
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "workspace/didChangeConfiguration"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "textDocument": {
-                  "text": "package P is\n   type Root is abstract tagged null record;\n\n   procedure Foo (R : Root) is abstract;\nend P;\n", 
-                  "version": 0, 
-                  "uri": "$URI{p.ads}", 
+                  "text": "package P is\n   type Root is abstract tagged null record;\n\n   procedure Foo (R : Root) is abstract;\nend P;\n",
+                  "version": 0,
+                  "uri": "$URI{p.ads}",
                   "languageId": "Ada"
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "textDocument/didOpen"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "position": {
-                  "line": 3, 
+                  "line": 3,
                   "character": 13
-               }, 
+               },
                "textDocument": {
                   "uri": "$URI{p.ads}"
                }
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 2, 
+            },
+            "jsonrpc": "2.0",
+            "id": 2,
             "method": "textDocument/alsCalledBy"
-         }, 
+         },
          "wait": [
             {
-               "id": 2, 
+               "id": 2,
                "result": [
                   {
                      "refs": [
                         {
                            "range": {
                               "start": {
-                                 "line": 6, 
+                                 "line": 6,
                                  "character": 3
-                              }, 
+                              },
                               "end": {
-                                 "line": 6, 
+                                 "line": 6,
                                  "character": 6
                               }
-                           }, 
+                           },
                            "alsKind": [
                               "dispatching call"
-                           ], 
+                           ],
                            "uri": "$URI{main.adb}"
                         }
-                     ], 
+                     ],
                      "location": {
                         "range": {
                            "start": {
-                              "line": 3, 
+                              "line": 3,
                               "character": 10
-                           }, 
+                           },
                            "end": {
-                              "line": 3, 
+                              "line": 3,
                               "character": 14
                            }
-                        }, 
+                        },
                         "uri": "$URI{main.adb}"
-                     }, 
+                     },
                      "name": "Main"
                   }
                ]
             }
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
@@ -166,28 +167,28 @@
                "textDocument": {
                   "uri": "$URI{p.ads}"
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "textDocument/didClose"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
-            "jsonrpc": "2.0", 
-            "id": 3, 
+            "jsonrpc": "2.0",
+            "id": 3,
             "method": "shutdown"
-         }, 
+         },
          "wait": [
             {
-               "id": 3, 
+               "id": 3,
                "result": null
             }
          ]
       }
-   }, 
+   },
    {
       "stop": {
          "exit_code": 0

--- a/testsuite/ada_lsp/SB21-042.tooltips.aspects/test.json
+++ b/testsuite/ada_lsp/SB21-042.tooltips.aspects/test.json
@@ -3,14 +3,14 @@
       "comment": [
          "test automatically generated"
       ]
-   }, 
+   },
    {
       "start": {
          "cmd": [
             "${ALS}"
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
@@ -19,440 +19,441 @@
                   "workspace": {
                      "applyEdit": false
                   }
-               }, 
+               },
                "rootUri": "$URI{.}"
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 1, 
+            },
+            "jsonrpc": "2.0",
+            "id": 1,
             "method": "initialize"
-         }, 
+         },
          "wait": [
             {
-               "id": 1, 
+               "id": 1,
                "result": {
                   "capabilities": {
-                     "typeDefinitionProvider": true, 
+                     "typeDefinitionProvider": true,
                      "alsReferenceKinds": [
-                        "write", 
-                        "call", 
+                        "reference",
+                        "write",
+                        "call",
                         "dispatching call", "parent", "child"
-                     ], 
-                     "hoverProvider": true, 
-                     "definitionProvider": true, 
-                     "renameProvider": {}, 
-                     "alsCalledByProvider": true, 
-                     "referencesProvider": true, 
-                     "textDocumentSync": 1, 
+                     ],
+                     "hoverProvider": true,
+                     "definitionProvider": true,
+                     "renameProvider": {},
+                     "alsCalledByProvider": true,
+                     "referencesProvider": true,
+                     "textDocumentSync": 1,
                      "completionProvider": {
                         "triggerCharacters": [
                            "."
-                        ], 
+                        ],
                         "resolveProvider": false
-                     }, 
+                     },
                      "documentSymbolProvider": true
                   }
                }
             }
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
-            "jsonrpc": "2.0", 
+            "jsonrpc": "2.0",
             "method": "initialized"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "settings": {
                   "ada": {
-                     "projectFile": "$URI{default.gpr}", 
-                     "scenarioVariables": {}, 
-                     "enableDiagnostics": true, 
+                     "projectFile": "$URI{default.gpr}",
+                     "scenarioVariables": {},
+                     "enableDiagnostics": true,
                      "defaultCharset": "ISO-8859-1"
                   }
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "workspace/didChangeConfiguration"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "textDocument": {
-                  "text": "procedure Foo\nis\n   type My_Record is tagged record\n      I : Integer := 1;\n   end record\n     with Alignment => (8);\n\n   type My_New_Record is new My_Record with\n     Record\n       J : Integer := 2;\n       K : Integer := 3;\n    end record with Alignment => (8);\n\n   My_Int : Integer := 42 with Atomic;\n   My_Var : My_Record := (I => My_Int);\n\n   procedure Bar (V : in out My_Record)\n     with\n       Pre  => V.I > 0,\n       Post => V.I > 0;\n\n   procedure FooBar (V : in out My_New_Record) with\n     Pre =>\n       V.I > 0\n       and then (V.J > V.K\n                 and then V.K > V.I),\n     Post => V.I = 0;\n\n   procedure Bar (V : in out My_Record) is null;\n   procedure FooBar (V : in out My_New_Record) is null;\n\nbegin\n   null;\nend Foo;\n", 
-                  "version": 0, 
-                  "uri": "$URI{foo.adb}", 
+                  "text": "procedure Foo\nis\n   type My_Record is tagged record\n      I : Integer := 1;\n   end record\n     with Alignment => (8);\n\n   type My_New_Record is new My_Record with\n     Record\n       J : Integer := 2;\n       K : Integer := 3;\n    end record with Alignment => (8);\n\n   My_Int : Integer := 42 with Atomic;\n   My_Var : My_Record := (I => My_Int);\n\n   procedure Bar (V : in out My_Record)\n     with\n       Pre  => V.I > 0,\n       Post => V.I > 0;\n\n   procedure FooBar (V : in out My_New_Record) with\n     Pre =>\n       V.I > 0\n       and then (V.J > V.K\n                 and then V.K > V.I),\n     Post => V.I = 0;\n\n   procedure Bar (V : in out My_Record) is null;\n   procedure FooBar (V : in out My_New_Record) is null;\n\nbegin\n   null;\nend Foo;\n",
+                  "version": 0,
+                  "uri": "$URI{foo.adb}",
                   "languageId": "Ada"
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "textDocument/didOpen"
-         }, 
+         },
          "wait": []
       }
-   },  
+   },
    {
       "send": {
          "request": {
             "params": {
                "position": {
-                  "line": 2, 
+                  "line": 2,
                   "character": 8
-               }, 
+               },
                "textDocument": {
                   "uri": "$URI{foo.adb}"
                }
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 2, 
+            },
+            "jsonrpc": "2.0",
+            "id": 2,
             "method": "textDocument/hover"
-         }, 
+         },
          "wait": [
             {
-               "id": 2, 
+               "id": 2,
                "result": {
                   "contents": [
                      {
-                        "value": "type My_Record is tagged record\n   I : Integer := 1;\nend record\n  with Alignment => (8);", 
+                        "value": "type My_Record is tagged record\n   I : Integer := 1;\nend record\n  with Alignment => (8);",
                         "language": "ada"
-                     }, 
+                     },
                      "at foo.adb (3:4)"
                   ]
                }
             }
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "position": {
-                  "line": 7, 
+                  "line": 7,
                   "character": 8
-               }, 
+               },
                "textDocument": {
                   "uri": "$URI{foo.adb}"
                }
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 3, 
+            },
+            "jsonrpc": "2.0",
+            "id": 3,
             "method": "textDocument/hover"
-         }, 
+         },
          "wait": [
             {
-               "id": 3, 
+               "id": 3,
                "result": {
                   "contents": [
                      {
-                        "value": "type My_New_Record is new My_Record with\n Record\n   J : Integer := 2;\n   K : Integer := 3;\nend record with Alignment => (8);", 
+                        "value": "type My_New_Record is new My_Record with\n Record\n   J : Integer := 2;\n   K : Integer := 3;\nend record with Alignment => (8);",
                         "language": "ada"
-                     }, 
+                     },
                      "at foo.adb (8:4)"
                   ]
                }
             }
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "position": {
-                  "line": 13, 
+                  "line": 13,
                   "character": 12
-               }, 
+               },
                "textDocument": {
                   "uri": "$URI{foo.adb}"
                }
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 4, 
+            },
+            "jsonrpc": "2.0",
+            "id": 4,
             "method": "textDocument/hover"
-         }, 
+         },
          "wait": [
             {
-               "id": 4, 
+               "id": 4,
                "result": {
                   "contents": [
                      {
-                        "value": "type Integer is range -(2 ** 31) .. +(2 ** 31 - 1);", 
+                        "value": "type Integer is range -(2 ** 31) .. +(2 ** 31 - 1);",
                         "language": "ada"
-                     }, 
+                     },
                      "at __standard (4:3)"
                   ]
                }
             }
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "position": {
-                  "line": 13, 
+                  "line": 13,
                   "character": 3
-               }, 
+               },
                "textDocument": {
                   "uri": "$URI{foo.adb}"
                }
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 5, 
+            },
+            "jsonrpc": "2.0",
+            "id": 5,
             "method": "textDocument/hover"
-         }, 
+         },
          "wait": [
             {
-               "id": 5, 
+               "id": 5,
                "result": {
                   "contents": [
                      {
-                        "value": "My_Int : Integer := 42 with Atomic;", 
+                        "value": "My_Int : Integer := 42 with Atomic;",
                         "language": "ada"
-                     }, 
+                     },
                      "at foo.adb (14:4)"
                   ]
                }
             }
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "position": {
-                  "line": 14, 
+                  "line": 14,
                   "character": 3
-               }, 
+               },
                "textDocument": {
                   "uri": "$URI{foo.adb}"
                }
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 6, 
+            },
+            "jsonrpc": "2.0",
+            "id": 6,
             "method": "textDocument/hover"
-         }, 
+         },
          "wait": [
             {
-               "id": 6, 
+               "id": 6,
                "result": {
                   "contents": [
                      {
-                        "value": "My_Var : My_Record := (I => My_Int);", 
+                        "value": "My_Var : My_Record := (I => My_Int);",
                         "language": "ada"
-                     }, 
+                     },
                      "at foo.adb (15:4)"
                   ]
                }
             }
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "position": {
-                  "line": 16, 
+                  "line": 16,
                   "character": 13
-               }, 
+               },
                "textDocument": {
                   "uri": "$URI{foo.adb}"
                }
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 7, 
+            },
+            "jsonrpc": "2.0",
+            "id": 7,
             "method": "textDocument/hover"
-         }, 
+         },
          "wait": [
             {
-               "id": 7, 
+               "id": 7,
                "result": {
                   "contents": [
                      {
-                        "value": "procedure Bar (V : in out My_Record)\nwith\n  Pre  => V.I > 0,\n  Post => V.I > 0", 
+                        "value": "procedure Bar (V : in out My_Record)\nwith\n  Pre  => V.I > 0,\n  Post => V.I > 0",
                         "language": "ada"
-                     }, 
+                     },
                      "at foo.adb (17:4)"
                   ]
                }
             }
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "position": {
-                  "line": 21, 
+                  "line": 21,
                   "character": 13
-               }, 
+               },
                "textDocument": {
                   "uri": "$URI{foo.adb}"
                }
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 8, 
+            },
+            "jsonrpc": "2.0",
+            "id": 8,
             "method": "textDocument/hover"
-         }, 
+         },
          "wait": [
             {
-               "id": 8, 
+               "id": 8,
                "result": {
                   "contents": [
                      {
-                        "value": "procedure FooBar (V : in out My_New_Record)\nwith\n  Pre =>\n    V.I > 0\n    and then (V.J > V.K\n              and then V.K > V.I),\n  Post => V.I = 0", 
+                        "value": "procedure FooBar (V : in out My_New_Record)\nwith\n  Pre =>\n    V.I > 0\n    and then (V.J > V.K\n              and then V.K > V.I),\n  Post => V.I = 0",
                         "language": "ada"
-                     }, 
+                     },
                      "at foo.adb (22:4)"
                   ]
                }
             }
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "position": {
-                  "line": 28, 
+                  "line": 28,
                   "character": 13
-               }, 
+               },
                "textDocument": {
                   "uri": "$URI{foo.adb}"
                }
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 9, 
+            },
+            "jsonrpc": "2.0",
+            "id": 9,
             "method": "textDocument/hover"
-         }, 
+         },
          "wait": [
             {
-               "id": 9, 
+               "id": 9,
                "result": {
                   "contents": [
                      {
-                        "value": "procedure Bar (V : in out My_Record)\nwith\n  Pre  => V.I > 0,\n  Post => V.I > 0", 
+                        "value": "procedure Bar (V : in out My_Record)\nwith\n  Pre  => V.I > 0,\n  Post => V.I > 0",
                         "language": "ada"
-                     }, 
+                     },
                      "at foo.adb (17:4)"
                   ]
                }
             }
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "position": {
-                  "line": 29, 
+                  "line": 29,
                   "character": 13
-               }, 
+               },
                "textDocument": {
                   "uri": "$URI{foo.adb}"
                }
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 10, 
+            },
+            "jsonrpc": "2.0",
+            "id": 10,
             "method": "textDocument/hover"
-         }, 
+         },
          "wait": [
             {
-               "id": 10, 
+               "id": 10,
                "result": {
                   "contents": [
                      {
-                        "value": "procedure FooBar (V : in out My_New_Record)\nwith\n  Pre =>\n    V.I > 0\n    and then (V.J > V.K\n              and then V.K > V.I),\n  Post => V.I = 0", 
+                        "value": "procedure FooBar (V : in out My_New_Record)\nwith\n  Pre =>\n    V.I > 0\n    and then (V.J > V.K\n              and then V.K > V.I),\n  Post => V.I = 0",
                         "language": "ada"
-                     }, 
+                     },
                      "at foo.adb (22:4)"
                   ]
                }
             }
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "position": {
-                  "line": 28, 
+                  "line": 28,
                   "character": 29
-               }, 
+               },
                "textDocument": {
                   "uri": "$URI{foo.adb}"
                }
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 11, 
+            },
+            "jsonrpc": "2.0",
+            "id": 11,
             "method": "textDocument/hover"
-         }, 
+         },
          "wait": [
             {
-               "id": 11, 
+               "id": 11,
                "result": {
                   "contents": [
                      {
-                        "value": "type My_Record is tagged record\n   I : Integer := 1;\nend record\n  with Alignment => (8);", 
+                        "value": "type My_Record is tagged record\n   I : Integer := 1;\nend record\n  with Alignment => (8);",
                         "language": "ada"
-                     }, 
+                     },
                      "at foo.adb (3:4)"
                   ]
                }
             }
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "position": {
-                  "line": 29, 
+                  "line": 29,
                   "character": 32
-               }, 
+               },
                "textDocument": {
                   "uri": "$URI{foo.adb}"
                }
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 12, 
+            },
+            "jsonrpc": "2.0",
+            "id": 12,
             "method": "textDocument/hover"
-         }, 
+         },
          "wait": [
             {
-               "id": 12, 
+               "id": 12,
                "result": {
                   "contents": [
                      {
-                        "value": "type My_New_Record is new My_Record with\n Record\n   J : Integer := 2;\n   K : Integer := 3;\nend record with Alignment => (8);", 
+                        "value": "type My_New_Record is new My_Record with\n Record\n   J : Integer := 2;\n   K : Integer := 3;\nend record with Alignment => (8);",
                         "language": "ada"
-                     }, 
+                     },
                      "at foo.adb (8:4)"
                   ]
                }
             }
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
@@ -460,28 +461,28 @@
                "textDocument": {
                   "uri": "$URI{foo.adb}"
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "textDocument/didClose"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
-            "jsonrpc": "2.0", 
-            "id": 13, 
+            "jsonrpc": "2.0",
+            "id": 13,
             "method": "shutdown"
-         }, 
+         },
          "wait": [
             {
-               "id": 13, 
+               "id": 13,
                "result": null
             }
          ]
       }
-   }, 
+   },
    {
       "stop": {
          "exit_code": 0

--- a/testsuite/ada_lsp/SC16-095.fallback_when_no_body/test.json
+++ b/testsuite/ada_lsp/SC16-095.fallback_when_no_body/test.json
@@ -3,14 +3,14 @@
       "comment": [
          "test that we're not using navigation fallback on specs that should have no body"
       ]
-   }, 
+   },
    {
       "start": {
          "cmd": [
             "${ALS}"
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
@@ -19,233 +19,234 @@
                   "textDocument": {
                      "completion": {
                         "completionItemKind": {}
-                     }, 
-                     "documentLink": {}, 
-                     "formatting": {}, 
-                     "documentHighlight": {}, 
-                     "synchronization": {}, 
-                     "references": {}, 
-                     "rangeFormatting": {}, 
-                     "onTypeFormatting": {}, 
-                     "codeLens": {}, 
+                     },
+                     "documentLink": {},
+                     "formatting": {},
+                     "documentHighlight": {},
+                     "synchronization": {},
+                     "references": {},
+                     "rangeFormatting": {},
+                     "onTypeFormatting": {},
+                     "codeLens": {},
                      "colorProvider": {}
-                  }, 
+                  },
                   "workspace": {
-                     "applyEdit": false, 
-                     "executeCommand": {}, 
-                     "didChangeWatchedFiles": {}, 
-                     "workspaceEdit": {}, 
+                     "applyEdit": false,
+                     "executeCommand": {},
+                     "didChangeWatchedFiles": {},
+                     "workspaceEdit": {},
                      "didChangeConfiguration": {}
                   }
-               }, 
+               },
                "rootUri": "$URI{.}"
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 1, 
+            },
+            "jsonrpc": "2.0",
+            "id": 1,
             "method": "initialize"
-         }, 
+         },
          "wait": [
             {
-               "id": 1, 
+               "id": 1,
                "result": {
                   "capabilities": {
-                     "typeDefinitionProvider": true, 
-                     "alsReferenceKinds": [
-                        "write", 
-                        "call", 
+                     "typeDefinitionProvider": true,
+                      "alsReferenceKinds": [
+                        "reference",
+                        "write",
+                        "call",
                         "dispatching call", "parent", "child"
-                     ], 
-                     "hoverProvider": true, 
-                     "definitionProvider": true, 
-                     "renameProvider": {}, 
-                     "alsCalledByProvider": true, 
-                     "referencesProvider": true, 
-                     "declarationProvider": true, 
-                     "textDocumentSync": 1, 
+                     ],
+                     "hoverProvider": true,
+                     "definitionProvider": true,
+                     "renameProvider": {},
+                     "alsCalledByProvider": true,
+                     "referencesProvider": true,
+                     "declarationProvider": true,
+                     "textDocumentSync": 1,
                      "completionProvider": {
                         "triggerCharacters": [
                            "."
-                        ], 
+                        ],
                         "resolveProvider": false
-                     }, 
+                     },
                      "documentSymbolProvider": true
                   }
                }
             }
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
-            "jsonrpc": "2.0", 
+            "jsonrpc": "2.0",
             "method": "initialized"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "settings": {
                   "ada": {
-                     "scenarioVariables": {}, 
-                     "enableDiagnostics": false, 
+                     "scenarioVariables": {},
+                     "enableDiagnostics": false,
                      "defaultCharset": "ISO-8859-1"
                   }
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "workspace/didChangeConfiguration"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "textDocument": {
-                  "text": "package pack is\n\n   procedure Foo is null;\n   function Bla return Integer is (42);\n   \n   type X is abstract tagged null record;\n   procedure Nobody (Arg : X) is abstract;\n\n   procedure Allow_A_Body;\nend pack;\n", 
-                  "version": 0, 
-                  "uri": "$URI{pack.ads}", 
+                  "text": "package pack is\n\n   procedure Foo is null;\n   function Bla return Integer is (42);\n   \n   type X is abstract tagged null record;\n   procedure Nobody (Arg : X) is abstract;\n\n   procedure Allow_A_Body;\nend pack;\n",
+                  "version": 0,
+                  "uri": "$URI{pack.ads}",
                   "languageId": "Ada"
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "textDocument/didOpen"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "textDocument": {
-                  "text": "package body pack is\n\n   procedure Foo (Y : Integer);\n   \n   function Bla (Y : Integer) return Integer is\n   begin\n      return 2;\n   end Bla;\n   \n   type Y is null record;\n   \n   procedure Nobody (Arg : Y) is\n   begin\n      null;\n   end;\n   \n   procedure Allow_A_Body is null;\n\n   procedure Foo (Y : Integer) is\n   begin\n      null;\n   end;\n   \nend pack;\n", 
-                  "version": 0, 
-                  "uri": "$URI{pack.adb}", 
+                  "text": "package body pack is\n\n   procedure Foo (Y : Integer);\n   \n   function Bla (Y : Integer) return Integer is\n   begin\n      return 2;\n   end Bla;\n   \n   type Y is null record;\n   \n   procedure Nobody (Arg : Y) is\n   begin\n      null;\n   end;\n   \n   procedure Allow_A_Body is null;\n\n   procedure Foo (Y : Integer) is\n   begin\n      null;\n   end;\n   \nend pack;\n",
+                  "version": 0,
+                  "uri": "$URI{pack.adb}",
                   "languageId": "Ada"
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "textDocument/didOpen"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "position": {
-                  "line": 2, 
+                  "line": 2,
                   "character": 13
-               }, 
+               },
                "textDocument": {
                   "uri": "$URI{pack.ads}"
                }
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 2, 
+            },
+            "jsonrpc": "2.0",
+            "id": 2,
             "method": "textDocument/definition"
-         }, 
+         },
          "wait": [
             {
-               "id": 2, 
+               "id": 2,
                "result": []
             }
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "position": {
-                  "line": 3, 
+                  "line": 3,
                   "character": 12
-               }, 
+               },
                "textDocument": {
                   "uri": "$URI{pack.ads}"
                }
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 3, 
+            },
+            "jsonrpc": "2.0",
+            "id": 3,
             "method": "textDocument/definition"
-         }, 
+         },
          "wait": [
             {
-               "id": 3, 
+               "id": 3,
                "result": []
             }
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "position": {
-                  "line": 6, 
+                  "line": 6,
                   "character": 13
-               }, 
+               },
                "textDocument": {
                   "uri": "$URI{pack.ads}"
                }
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 4, 
+            },
+            "jsonrpc": "2.0",
+            "id": 4,
             "method": "textDocument/definition"
-         }, 
+         },
          "wait": [
             {
-               "id": 4, 
+               "id": 4,
                "result": []
             }
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "position": {
-                  "line": 8, 
+                  "line": 8,
                   "character": 13
-               }, 
+               },
                "textDocument": {
                   "uri": "$URI{pack.ads}"
                }
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 5, 
+            },
+            "jsonrpc": "2.0",
+            "id": 5,
             "method": "textDocument/definition"
-         }, 
+         },
          "wait": [
             {
-               "id": 5, 
+               "id": 5,
                "result": [
                   {
                      "range": {
                         "start": {
-                           "line": 16, 
+                           "line": 16,
                            "character": 13
-                        }, 
+                        },
                         "end": {
-                           "line": 16, 
+                           "line": 16,
                            "character": 25
                         }
-                     }, 
+                     },
                      "uri": "$URI{pack.adb}"
                   }
                ]
             }
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
@@ -253,13 +254,13 @@
                "textDocument": {
                   "uri": "$URI{pack.ads}"
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "textDocument/didClose"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
@@ -267,28 +268,28 @@
                "textDocument": {
                   "uri": "$URI{pack.adb}"
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "textDocument/didClose"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
-            "jsonrpc": "2.0", 
-            "id": 6, 
+            "jsonrpc": "2.0",
+            "id": 6,
             "method": "shutdown"
-         }, 
+         },
          "wait": [
             {
-               "id": 6, 
+               "id": 6,
                "result": null
             }
          ]
       }
-   }, 
+   },
    {
       "stop": {
          "exit_code": 0

--- a/testsuite/ada_lsp/aggregate.references_after_update/test.json
+++ b/testsuite/ada_lsp/aggregate.references_after_update/test.json
@@ -3,14 +3,14 @@
       "comment": [
          "test finding all references accross aggregates after editing a document"
       ]
-   }, 
+   },
    {
       "start": {
          "cmd": [
             "${ALS}"
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
@@ -19,148 +19,149 @@
                   "textDocument": {
                      "completion": {
                         "completionItemKind": {}
-                     }, 
-                     "documentLink": {}, 
-                     "formatting": {}, 
-                     "documentHighlight": {}, 
-                     "synchronization": {}, 
-                     "references": {}, 
-                     "rangeFormatting": {}, 
-                     "onTypeFormatting": {}, 
-                     "codeLens": {}, 
+                     },
+                     "documentLink": {},
+                     "formatting": {},
+                     "documentHighlight": {},
+                     "synchronization": {},
+                     "references": {},
+                     "rangeFormatting": {},
+                     "onTypeFormatting": {},
+                     "codeLens": {},
                      "colorProvider": {}
-                  }, 
+                  },
                   "workspace": {
-                     "applyEdit": false, 
-                     "executeCommand": {}, 
-                     "didChangeWatchedFiles": {}, 
-                     "workspaceEdit": {}, 
+                     "applyEdit": false,
+                     "executeCommand": {},
+                     "didChangeWatchedFiles": {},
+                     "workspaceEdit": {},
                      "didChangeConfiguration": {}
                   }
-               }, 
+               },
                "rootUri": "$URI{.}"
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 1, 
+            },
+            "jsonrpc": "2.0",
+            "id": 1,
             "method": "initialize"
-         }, 
+         },
          "wait": [
             {
-               "id": 1, 
+               "id": 1,
                "result": {
                   "capabilities": {
-                     "typeDefinitionProvider": true, 
+                     "typeDefinitionProvider": true,
                      "alsReferenceKinds": [
-                        "write", 
-                        "call", 
+                        "reference",
+                        "write",
+                        "call",
                         "dispatching call", "parent", "child"
-                     ], 
-                     "hoverProvider": true, 
-                     "definitionProvider": true, 
-                     "renameProvider": {}, 
-                     "alsCalledByProvider": true, 
-                     "referencesProvider": true, 
-                     "declarationProvider": true, 
-                     "textDocumentSync": 1, 
+                     ],
+                     "hoverProvider": true,
+                     "definitionProvider": true,
+                     "renameProvider": {},
+                     "alsCalledByProvider": true,
+                     "referencesProvider": true,
+                     "declarationProvider": true,
+                     "textDocumentSync": 1,
                      "completionProvider": {
                         "triggerCharacters": [
                            "."
-                        ], 
+                        ],
                         "resolveProvider": false
-                     }, 
+                     },
                      "documentSymbolProvider": true
                   }
                }
             }
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
-            "jsonrpc": "2.0", 
+            "jsonrpc": "2.0",
             "method": "initialized"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "settings": {
                   "ada": {
-                     "projectFile": "agg.gpr", 
-                     "scenarioVariables": {}, 
-                     "enableDiagnostics": false, 
+                     "projectFile": "agg.gpr",
+                     "scenarioVariables": {},
+                     "enableDiagnostics": false,
                      "defaultCharset": "UTF-8"
                   }
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "workspace/didChangeConfiguration"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "textDocument": {
-                  "text": "package common_pack is\n   Fo : Integer := 42;\nend common_pack;\n", 
-                  "version": 0, 
-                  "uri": "$URI{common/common_pack.ads}", 
+                  "text": "package common_pack is\n   Fo : Integer := 42;\nend common_pack;\n",
+                  "version": 0,
+                  "uri": "$URI{common/common_pack.ads}",
                   "languageId": "Ada"
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "textDocument/didOpen"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "position": {
-                  "line": 1, 
+                  "line": 1,
                   "character": 4
-               }, 
+               },
                "textDocument": {
                   "uri": "$URI{common/common_pack.ads}"
-               }, 
+               },
                "context": {
                   "includeDeclaration": true
                }
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 2, 
+            },
+            "jsonrpc": "2.0",
+            "id": 2,
             "method": "textDocument/references"
-         }, 
+         },
          "wait": [
             {
-               "id": 2, 
+               "id": 2,
                "result": [
                   {
                      "range": {
                         "start": {
-                           "line": 1, 
+                           "line": 1,
                            "character": 3
-                        }, 
+                        },
                         "end": {
-                           "line": 1, 
+                           "line": 1,
                            "character": 5
                         }
-                     }, 
+                     },
                      "uri": "$URI{common/common_pack.ads}"
                   }
                ]
             }
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
@@ -169,85 +170,85 @@
                   {
                      "text": "package common_pack is\n   Foo : Integer := 42;\nend common_pack;\n"
                   }
-               ], 
+               ],
                "textDocument": {
-                  "version": 1, 
+                  "version": 1,
                   "uri": "$URI{common/common_pack.ads}"
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "textDocument/didChange"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "position": {
-                  "line": 1, 
+                  "line": 1,
                   "character": 4
-               }, 
+               },
                "textDocument": {
                   "uri": "$URI{common/common_pack.ads}"
-               }, 
+               },
                "context": {
                   "includeDeclaration": true
                }
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 3, 
+            },
+            "jsonrpc": "2.0",
+            "id": 3,
             "method": "textDocument/references"
-         }, 
+         },
          "wait": [
             {
-               "id": 3, 
+               "id": 3,
                "result": [
                   {
                      "range": {
                         "start": {
-                           "line": 1, 
+                           "line": 1,
                            "character": 3
-                        }, 
+                        },
                         "end": {
-                           "line": 1, 
+                           "line": 1,
                            "character": 6
                         }
-                     }, 
+                     },
                      "uri": "$URI{common/common_pack.ads}"
-                  }, 
+                  },
                   {
                      "range": {
                         "start": {
-                           "line": 2, 
+                           "line": 2,
                            "character": 18
-                        }, 
+                        },
                         "end": {
-                           "line": 2, 
+                           "line": 2,
                            "character": 21
                         }
-                     }, 
+                     },
                      "uri": "$URI{p/main.adb}"
-                  }, 
+                  },
                   {
                      "range": {
                         "start": {
-                           "line": 2, 
+                           "line": 2,
                            "character": 18
-                        }, 
+                        },
                         "end": {
-                           "line": 2, 
+                           "line": 2,
                            "character": 21
                         }
-                     }, 
+                     },
                      "uri": "$URI{q/main.adb}"
                   }
                ]
             }
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
@@ -255,28 +256,28 @@
                "textDocument": {
                   "uri": "$URI{common/common_pack.ads}"
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "textDocument/didClose"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
-            "jsonrpc": "2.0", 
-            "id": 4, 
+            "jsonrpc": "2.0",
+            "id": 4,
             "method": "shutdown"
-         }, 
+         },
          "wait": [
             {
-               "id": 4, 
+               "id": 4,
                "result": null
             }
          ]
       }
-   }, 
+   },
    {
       "stop": {
          "exit_code": 0

--- a/testsuite/ada_lsp/aggregate.simple/test.json
+++ b/testsuite/ada_lsp/aggregate.simple/test.json
@@ -33,6 +33,7 @@
                   "capabilities": {
                      "typeDefinitionProvider": true,
                      "alsReferenceKinds": [
+                        "reference",
                         "write",
                         "call",
                         "dispatching call", "parent", "child"

--- a/testsuite/ada_lsp/called_by_dispatching/test.json
+++ b/testsuite/ada_lsp/called_by_dispatching/test.json
@@ -3,164 +3,165 @@
       "comment": [
          "test of the presence of the 'dispatching call' in alsReferenceKind"
       ]
-   }, 
+   },
    {
       "start": {
          "cmd": [
             "${ALS}"
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
-               "processId": 10247, 
+               "processId": 10247,
                "capabilities": {
                   "workspace": {
                      "applyEdit": false
                   }
-               }, 
+               },
                "rootUri": "$URI{.}"
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 1, 
+            },
+            "jsonrpc": "2.0",
+            "id": 1,
             "method": "initialize"
-         }, 
+         },
          "wait": [
             {
-               "id": 1, 
+               "id": 1,
                "result": {
                   "capabilities": {
-                     "typeDefinitionProvider": true, 
-                     "alsReferenceKinds": [
-                        "write", 
-                        "call", 
+                     "typeDefinitionProvider": true,
+                      "alsReferenceKinds": [
+                        "reference",
+                        "write",
+                        "call",
                         "dispatching call", "parent", "child"
-                     ], 
-                     "hoverProvider": true, 
-                     "definitionProvider": true, 
-                     "renameProvider": {}, 
-                     "alsCalledByProvider": true, 
-                     "referencesProvider": true, 
-                     "textDocumentSync": 1, 
+                     ],
+                     "hoverProvider": true,
+                     "definitionProvider": true,
+                     "renameProvider": {},
+                     "alsCalledByProvider": true,
+                     "referencesProvider": true,
+                     "textDocumentSync": 1,
                      "completionProvider": {
                         "triggerCharacters": [
                            "."
-                        ], 
+                        ],
                         "resolveProvider": false
-                     }, 
+                     },
                      "documentSymbolProvider": true
                   }
                }
             }
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
-            "jsonrpc": "2.0", 
+            "jsonrpc": "2.0",
             "method": "initialized"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "settings": {
                   "ada": {
-                     "projectFile": "p.gpr", 
-                     "scenarioVariables": {}, 
-                     "enableDiagnostics": false, 
+                     "projectFile": "p.gpr",
+                     "scenarioVariables": {},
+                     "enableDiagnostics": false,
                      "defaultCharset": "ISO-8859-1"
                   }
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "workspace/didChangeConfiguration"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "textDocument": {
-                  "text": "with root; use root;\n\nprocedure main is\n   x : root_t'class := create;\nbegin\n\n   foo (x);\n\n\nend main;\n", 
-                  "version": 0, 
-                  "uri": "$URI{main.adb}", 
+                  "text": "with root; use root;\n\nprocedure main is\n   x : root_t'class := create;\nbegin\n\n   foo (x);\n\n\nend main;\n",
+                  "version": 0,
+                  "uri": "$URI{main.adb}",
                   "languageId": "Ada"
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "textDocument/didOpen"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "position": {
-                  "line": 6, 
+                  "line": 6,
                   "character": 3
-               }, 
+               },
                "textDocument": {
                   "uri": "$URI{main.adb}"
                }
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 2, 
+            },
+            "jsonrpc": "2.0",
+            "id": 2,
             "method": "textDocument/alsCalledBy"
-         }, 
+         },
          "wait": [
             {
-               "id": 2, 
+               "id": 2,
                "result": [
                   {
                      "refs": [
                         {
                            "range": {
                               "start": {
-                                 "line": 6, 
+                                 "line": 6,
                                  "character": 3
-                              }, 
+                              },
                               "end": {
-                                 "line": 6, 
+                                 "line": 6,
                                  "character": 6
                               }
-                           }, 
+                           },
                            "alsKind": [
                               "dispatching call"
-                           ], 
+                           ],
                            "uri": "$URI{main.adb}"
                         }
-                     ], 
+                     ],
                      "location": {
                         "range": {
                            "start": {
-                              "line": 2, 
+                              "line": 2,
                               "character": 10
-                           }, 
+                           },
                            "end": {
-                              "line": 2, 
+                              "line": 2,
                               "character": 14
                            }
-                        }, 
+                        },
                         "uri": "$URI{main.adb}"
-                     }, 
+                     },
                      "name": "main"
                   }
                ]
             }
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
@@ -168,13 +169,13 @@
                "textDocument": {
                   "uri": "$URI{child.ads}"
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "textDocument/didClose"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
@@ -182,28 +183,28 @@
                "textDocument": {
                   "uri": "$URI{main.adb}"
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "textDocument/didClose"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
-            "jsonrpc": "2.0", 
-            "id": 3, 
+            "jsonrpc": "2.0",
+            "id": 3,
             "method": "shutdown"
-         }, 
+         },
          "wait": [
             {
-               "id": 3, 
+               "id": 3,
                "result": null
             }
          ]
       }
-   }, 
+   },
    {
       "stop": {
          "exit_code": 0

--- a/testsuite/ada_lsp/definition_and_overridings/test.json
+++ b/testsuite/ada_lsp/definition_and_overridings/test.json
@@ -52,6 +52,7 @@
                   "capabilities": {
                      "typeDefinitionProvider": true,
                      "alsReferenceKinds": [
+                        "reference",
                         "write",
                         "call",
                         "dispatching call", "parent", "child"

--- a/testsuite/ada_lsp/definition_parents/test.json
+++ b/testsuite/ada_lsp/definition_parents/test.json
@@ -51,6 +51,7 @@
                   "capabilities": {
                      "typeDefinitionProvider": true,
                      "alsReferenceKinds": [
+                        "reference",
                         "write",
                         "call",
                         "dispatching call",

--- a/testsuite/ada_lsp/find_all_refs/find_all_refs.json
+++ b/testsuite/ada_lsp/find_all_refs/find_all_refs.json
@@ -87,7 +87,7 @@
                             "character": 13
                         }
                     },
-                    "alsKind": "<ABSENT>"
+                    "alsKind": ["reference"]
                 }, {
                     "uri": "$URI{bbb.adb}",
                     "range": {

--- a/testsuite/ada_lsp/find_all_refs_subp/find_all_refs_subp.json
+++ b/testsuite/ada_lsp/find_all_refs_subp/find_all_refs_subp.json
@@ -1,6 +1,6 @@
 [
-   {"comment": ["find all refs including inside subprojects"]}, 
-   {"start": {"cmd": ["${ALS}"]}}, 
+   {"comment": ["find all refs including inside subprojects"]},
+   {"start": {"cmd": ["${ALS}"]}},
    {
       "send": {
          "request": {
@@ -10,208 +10,208 @@
                   "textDocument": {
                      "completion": {
                         "completionItem": {
-                           "commitCharactersSupport": true, 
+                           "commitCharactersSupport": true,
                            "snippetSupport": true
-                        }, 
+                        },
                         "dynamicRegistration": true
-                     }, 
+                     },
                      "definition": {
                         "dynamicRegistration": true
-                     }, 
+                     },
                      "signatureHelp": {
                         "dynamicRegistration": true
-                     }, 
+                     },
                      "hover": {
                         "dynamicRegistration": true
-                     }, 
+                     },
                      "formatting": {
                         "dynamicRegistration": true
-                     }, 
+                     },
                      "codeAction": {
                         "dynamicRegistration": true
-                     }, 
+                     },
                      "documentHighlight": {
                         "dynamicRegistration": true
-                     }, 
+                     },
                      "documentSymbol": {
                         "dynamicRegistration": true
-                     }, 
+                     },
                      "rename": {
                         "dynamicRegistration": true
-                     }, 
+                     },
                      "synchronization": {
-                        "didSave": true, 
-                        "willSave": true, 
-                        "willSaveWaitUntil": true, 
+                        "didSave": true,
+                        "willSave": true,
+                        "willSaveWaitUntil": true,
                         "dynamicRegistration": true
-                     }, 
+                     },
                      "references": {
                         "dynamicRegistration": true
-                     }, 
+                     },
                      "rangeFormatting": {
                         "dynamicRegistration": true
-                     }, 
+                     },
                      "onTypeFormatting": {
                         "dynamicRegistration": true
-                     }, 
+                     },
                      "codeLens": {
                         "dynamicRegistration": true
-                     }, 
+                     },
                      "documentLink": {
                         "dynamicRegistration": true
                      }
-                  }, 
+                  },
                   "workspace": {
                      "executeCommand": {
                         "dynamicRegistration": true
-                     }, 
-                     "applyEdit": true, 
+                     },
+                     "applyEdit": true,
                      "symbol": {
                         "dynamicRegistration": true
-                     }, 
+                     },
                      "didChangeWatchedFiles": {
                         "dynamicRegistration": true
-                     }, 
+                     },
                      "didChangeConfiguration": {
                         "dynamicRegistration": true
                      }
                   }
-               }, 
+               },
                "rootUri": "$URI{.}"
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 0, 
+            },
+            "jsonrpc": "2.0",
+            "id": 0,
             "method": "initialize"
-         }, 
+         },
          "wait": [{
-               "id": 0, 
+               "id": 0,
                "result": {
                   "capabilities": {
-                     "documentSymbolProvider": true, 
-                     "definitionProvider": true, 
-                     "textDocumentSync": 1, 
+                     "documentSymbolProvider": true,
+                     "definitionProvider": true,
+                     "textDocumentSync": 1,
                      "completionProvider": {
                         "triggerCharacters": [
                            "."
-                        ], 
+                        ],
                         "resolveProvider": false
-                     }, 
+                     },
                      "referencesProvider": true
                   }
                }
             }]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
-            "params": {}, 
-            "jsonrpc": "2.0", 
+            "params": {},
+            "jsonrpc": "2.0",
             "method": "initialized"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "settings": {
                   "ada": {
-                     "projectFile": "p.gpr", 
-                     "scenarioVariables": {}, 
+                     "projectFile": "p.gpr",
+                     "scenarioVariables": {},
                      "trace": {
                         "server": "off"
                      }
                   }
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "workspace/didChangeConfiguration"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "textDocument": {
-                  "text": "package P is\n   procedure Foo is null;\nend P;\n", 
-                  "version": 1, 
-                  "uri": "$URI{subsrc/p.ads}", 
+                  "text": "package P is\n   procedure Foo is null;\nend P;\n",
+                  "version": 1,
+                  "uri": "$URI{subsrc/p.ads}",
                   "languageId": "ada"
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "textDocument/didOpen"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "position": {
-                  "line": 1, 
+                  "line": 1,
                   "character": 14
-               }, 
+               },
                "textDocument": {
                   "uri": "$URI{subsrc/p.ads}"
-               }, 
+               },
                "context": {
                   "includeDeclaration": true
                }
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 1, 
+            },
+            "jsonrpc": "2.0",
+            "id": 1,
             "method": "textDocument/references"
-         }, 
+         },
          "wait": [ {
-               "id": 1, 
+               "id": 1,
                "result": [
                   {
                      "range": {
                         "start": {
-                           "line": 4, 
+                           "line": 4,
                            "character": 3
-                        }, 
+                        },
                         "end": {
-                           "line": 4, 
+                           "line": 4,
                            "character": 6
                         }
-                     }, 
+                     },
                      "uri": "$URI{main.adb}",
                      "alsKind": ["call"]
-                  }, 
+                  },
                   {
                      "range": {
                         "start": {
-                           "line": 3, 
+                           "line": 3,
                            "character": 3
-                        }, 
+                        },
                         "end": {
-                           "line": 3, 
+                           "line": 3,
                            "character": 6
                         }
-                     }, 
+                     },
                      "uri": "$URI{subsrc/other_main.adb}",
                      "alsKind": ["call"]
-                  }, 
+                  },
                   {
                      "range": {
                         "start": {
-                           "line": 1, 
+                           "line": 1,
                            "character": 13
-                        }, 
+                        },
                         "end": {
-                           "line": 1, 
+                           "line": 1,
                            "character": 16
                         }
-                     }, 
+                     },
                      "uri": "$URI{subsrc/p.ads}",
-                     "alsKind": "<ABSENT>"
+                     "alsKind": ["reference"]
                   }
                ]
             }]
@@ -220,11 +220,11 @@
    {
       "send": {
          "request": {
-            "params": null, 
-            "jsonrpc": "2.0", 
-            "id": 2, 
+            "params": null,
+            "jsonrpc": "2.0",
+            "id": 2,
             "method": "shutdown"
-         }, 
+         },
          "wait": [
             {
                "id": 2,

--- a/testsuite/ada_lsp/implementation.aggregates/test.json
+++ b/testsuite/ada_lsp/implementation.aggregates/test.json
@@ -3,14 +3,14 @@
       "comment": [
          "extensive test of the 'implementation' with aggregate projects"
       ]
-   }, 
+   },
    {
       "start": {
          "cmd": [
             "${ALS}"
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
@@ -19,440 +19,441 @@
                   "textDocument": {
                      "completion": {
                         "completionItemKind": {}
-                     }, 
-                     "documentLink": {}, 
-                     "formatting": {}, 
-                     "documentHighlight": {}, 
-                     "synchronization": {}, 
-                     "references": {}, 
-                     "rangeFormatting": {}, 
-                     "onTypeFormatting": {}, 
-                     "codeLens": {}, 
+                     },
+                     "documentLink": {},
+                     "formatting": {},
+                     "documentHighlight": {},
+                     "synchronization": {},
+                     "references": {},
+                     "rangeFormatting": {},
+                     "onTypeFormatting": {},
+                     "codeLens": {},
                      "colorProvider": {}
-                  }, 
+                  },
                   "workspace": {
-                     "applyEdit": false, 
-                     "executeCommand": {}, 
-                     "didChangeWatchedFiles": {}, 
-                     "workspaceEdit": {}, 
+                     "applyEdit": false,
+                     "executeCommand": {},
+                     "didChangeWatchedFiles": {},
+                     "workspaceEdit": {},
                      "didChangeConfiguration": {}
                   }
-               }, 
+               },
                "rootUri": "$URI{.}"
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 1, 
+            },
+            "jsonrpc": "2.0",
+            "id": 1,
             "method": "initialize"
-         }, 
+         },
          "wait": [
             {
-               "id": 1, 
+               "id": 1,
                "result": {
                   "capabilities": {
-                     "typeDefinitionProvider": true, 
-                     "alsReferenceKinds": [
-                        "write", 
-                        "call", 
-                        "dispatching call", 
-                        "parent", 
+                     "typeDefinitionProvider": true,
+                      "alsReferenceKinds": [
+                        "reference",
+                        "write",
+                        "call",
+                        "dispatching call",
+                        "parent",
                         "child"
-                     ], 
-                     "hoverProvider": true, 
-                     "definitionProvider": true, 
-                     "renameProvider": {}, 
-                     "alsCalledByProvider": true, 
-                     "referencesProvider": true, 
-                     "declarationProvider": true, 
-                     "textDocumentSync": 1, 
+                     ],
+                     "hoverProvider": true,
+                     "definitionProvider": true,
+                     "renameProvider": {},
+                     "alsCalledByProvider": true,
+                     "referencesProvider": true,
+                     "declarationProvider": true,
+                     "textDocumentSync": 1,
                      "completionProvider": {
                         "triggerCharacters": [
                            "."
-                        ], 
+                        ],
                         "resolveProvider": false
-                     }, 
+                     },
                      "documentSymbolProvider": true
                   }
                }
             }
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
-            "jsonrpc": "2.0", 
+            "jsonrpc": "2.0",
             "method": "initialized"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "settings": {
                   "ada": {
-                     "scenarioVariables": {}, 
-                     "enableDiagnostics": false, 
+                     "scenarioVariables": {},
+                     "enableDiagnostics": false,
                      "defaultCharset": "ISO-8859-1"
                   }
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "workspace/didChangeConfiguration"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "textDocument": {
-                  "text": "package common_pack is\n   Foo : Integer := 42;\n\n   function Common_Fun return Integer;\n\nend common_pack;\n", 
-                  "version": 0, 
-                  "uri": "$URI{common/common_pack.ads}", 
+                  "text": "package common_pack is\n   Foo : Integer := 42;\n\n   function Common_Fun return Integer;\n\nend common_pack;\n",
+                  "version": 0,
+                  "uri": "$URI{common/common_pack.ads}",
                   "languageId": "Ada"
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "textDocument/didOpen"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "textDocument": {
-                  "text": "package body Common_Pack is\n   function Common_Fun return Integer is (2);\nend Common_Pack;\n", 
-                  "version": 0, 
-                  "uri": "$URI{p/common_pack.adb}", 
+                  "text": "package body Common_Pack is\n   function Common_Fun return Integer is (2);\nend Common_Pack;\n",
+                  "version": 0,
+                  "uri": "$URI{p/common_pack.adb}",
                   "languageId": "Ada"
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "textDocument/didOpen"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "textDocument": {
-                  "text": "package body Common_Pack is\n   function Common_Fun return Integer is (1);\nend Common_Pack;\n", 
-                  "version": 0, 
-                  "uri": "$URI{q/common_pack.adb}", 
+                  "text": "package body Common_Pack is\n   function Common_Fun return Integer is (1);\nend Common_Pack;\n",
+                  "version": 0,
+                  "uri": "$URI{q/common_pack.adb}",
                   "languageId": "Ada"
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "textDocument/didOpen"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {"comment": "------------  check that bodies are found in both projects ---------"},
    {
       "send": {
          "request": {
             "params": {
                "position": {
-                  "line": 3, 
+                  "line": 3,
                   "character": 12
-               }, 
+               },
                "textDocument": {
                   "uri": "$URI{common/common_pack.ads}"
                }
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 2, 
+            },
+            "jsonrpc": "2.0",
+            "id": 2,
             "method": "textDocument/implementation"
-         }, 
+         },
          "wait": [
             {
-               "id": 2, 
+               "id": 2,
                "result": [
                   {
                      "range": {
                         "start": {
-                           "line": 1, 
+                           "line": 1,
                            "character": 12
-                        }, 
+                        },
                         "end": {
-                           "line": 1, 
+                           "line": 1,
                            "character": 22
                         }
-                     }, 
+                     },
                      "uri": "$URI{p/common_pack.adb}"
-                  }, 
+                  },
                   {
                      "range": {
                         "start": {
-                           "line": 1, 
+                           "line": 1,
                            "character": 12
-                        }, 
+                        },
                         "end": {
-                           "line": 1, 
+                           "line": 1,
                            "character": 22
                         }
-                     }, 
+                     },
                      "uri": "$URI{q/common_pack.adb}"
                   }
                ]
             }
          ]
       }
-   }, 
+   },
    {"comment": "------------ query hovers on targets ---------"},
    {
       "send": {
          "request": {
             "params": {
                "position": {
-                  "line": 1, 
+                  "line": 1,
                   "character": 12
-               }, 
+               },
                "textDocument": {
                   "uri": "$URI{p/common_pack.adb}"
                }
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 3, 
+            },
+            "jsonrpc": "2.0",
+            "id": 3,
             "method": "textDocument/hover"
-         }, 
+         },
          "wait": [
             {
-               "id": 3, 
+               "id": 3,
                "result": {
                   "contents": [
                      {
-                        "value": "function Common_Fun return Integer", 
+                        "value": "function Common_Fun return Integer",
                         "language": "ada"
-                     }, 
+                     },
                      "at common_pack.ads (4:4)"
                   ]
                }
             }
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "position": {
-                  "line": 1, 
+                  "line": 1,
                   "character": 12
-               }, 
+               },
                "textDocument": {
                   "uri": "$URI{p/common_pack.adb}"
                }
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 4, 
+            },
+            "jsonrpc": "2.0",
+            "id": 4,
             "method": "textDocument/hover"
-         }, 
+         },
          "wait": [
             {
-               "id": 4, 
+               "id": 4,
                "result": {
                   "contents": [
                      {
-                        "value": "function Common_Fun return Integer", 
+                        "value": "function Common_Fun return Integer",
                         "language": "ada"
-                     }, 
+                     },
                      "at common_pack.ads (4:4)"
                   ]
                }
             }
          ]
       }
-   }, 
+   },
    {"comment": "------------  check again that bodies are found in both projects ---------"},
    {
       "send": {
          "request": {
             "params": {
                "position": {
-                  "line": 3, 
+                  "line": 3,
                   "character": 12
-               }, 
+               },
                "textDocument": {
                   "uri": "$URI{common/common_pack.ads}"
                }
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 5, 
+            },
+            "jsonrpc": "2.0",
+            "id": 5,
             "method": "textDocument/implementation"
-         }, 
+         },
          "wait": [
             {
-               "id": 5, 
+               "id": 5,
                "result": [
                   {
                      "range": {
                         "start": {
-                           "line": 1, 
+                           "line": 1,
                            "character": 12
-                        }, 
+                        },
                         "end": {
-                           "line": 1, 
+                           "line": 1,
                            "character": 22
                         }
-                     }, 
+                     },
                      "uri": "$URI{p/common_pack.adb}"
-                  }, 
+                  },
                   {
                      "range": {
                         "start": {
-                           "line": 1, 
+                           "line": 1,
                            "character": 12
-                        }, 
+                        },
                         "end": {
-                           "line": 1, 
+                           "line": 1,
                            "character": 22
                         }
-                     }, 
+                     },
                      "uri": "$URI{q/common_pack.adb}"
                   }
                ]
             }
          ]
       }
-   }, 
+   },
    {"comment": "------------  check for 'definition' calls ---------"},
    {
       "send": {
          "request": {
             "params": {
                "position": {
-                  "line": 1, 
+                  "line": 1,
                   "character": 12
-               }, 
+               },
                "textDocument": {
                   "uri": "$URI{q/common_pack.adb}"
                }
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 9, 
+            },
+            "jsonrpc": "2.0",
+            "id": 9,
             "method": "textDocument/definition"
-         }, 
+         },
          "wait": [
             {
-               "id": 9, 
+               "id": 9,
                "result": [
                   {
                      "range": {
                         "start": {
-                           "line": 3, 
+                           "line": 3,
                            "character": 12
-                        }, 
+                        },
                         "end": {
-                           "line": 3, 
+                           "line": 3,
                            "character": 22
                         }
-                     }, 
+                     },
                      "uri": "$URI{common/common_pack.ads}"
                   }
                ]
             }
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "position": {
-                  "line": 1, 
+                  "line": 1,
                   "character": 12
-               }, 
+               },
                "textDocument": {
                   "uri": "$URI{p/common_pack.adb}"
                }
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 10, 
+            },
+            "jsonrpc": "2.0",
+            "id": 10,
             "method": "textDocument/definition"
-         }, 
+         },
          "wait": [
             {
-               "id": 10, 
+               "id": 10,
                "result": [
                   {
                      "range": {
                         "start": {
-                           "line": 3, 
+                           "line": 3,
                            "character": 12
-                        }, 
+                        },
                         "end": {
-                           "line": 3, 
+                           "line": 3,
                            "character": 22
                         }
-                     }, 
+                     },
                      "uri": "$URI{common/common_pack.ads}"
                   }
                ]
             }
          ]
       }
-   }, 
+   },
    {"comment": "------------  check again that bodies are found in both projects ---------"},
    {
       "send": {
          "request": {
             "params": {
                "position": {
-                  "line": 3, 
+                  "line": 3,
                   "character": 12
-               }, 
+               },
                "textDocument": {
                   "uri": "$URI{common/common_pack.ads}"
                }
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 11, 
+            },
+            "jsonrpc": "2.0",
+            "id": 11,
             "method": "textDocument/implementation"
-         }, 
+         },
          "wait": [
             {
-               "id": 11, 
+               "id": 11,
                "result": [
                   {
                      "range": {
                         "start": {
-                           "line": 1, 
+                           "line": 1,
                            "character": 12
-                        }, 
+                        },
                         "end": {
-                           "line": 1, 
+                           "line": 1,
                            "character": 22
                         }
-                     }, 
+                     },
                      "uri": "$URI{p/common_pack.adb}"
-                  }, 
+                  },
                   {
                      "range": {
                         "start": {
-                           "line": 1, 
+                           "line": 1,
                            "character": 12
-                        }, 
+                        },
                         "end": {
-                           "line": 1, 
+                           "line": 1,
                            "character": 22
                         }
-                     }, 
+                     },
                      "uri": "$URI{q/common_pack.adb}"
                   }
                ]
             }
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
@@ -460,13 +461,13 @@
                "textDocument": {
                   "uri": "$URI{common/common_pack.ads}"
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "textDocument/didClose"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
@@ -474,13 +475,13 @@
                "textDocument": {
                   "uri": "$URI{q/common_pack.adb}"
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "textDocument/didClose"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
@@ -488,28 +489,28 @@
                "textDocument": {
                   "uri": "$URI{p/common_pack.adb}"
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "textDocument/didClose"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
-            "jsonrpc": "2.0", 
-            "id": 14, 
+            "jsonrpc": "2.0",
+            "id": 14,
             "method": "shutdown"
-         }, 
+         },
          "wait": [
             {
-               "id": 14, 
+               "id": 14,
                "result": null
             }
          ]
       }
-   }, 
+   },
    {
       "stop": {
          "exit_code": 0

--- a/testsuite/ada_lsp/implementation.overridings/test.json
+++ b/testsuite/ada_lsp/implementation.overridings/test.json
@@ -50,7 +50,8 @@
                "result": {
                   "capabilities": {
                      "typeDefinitionProvider": true,
-                     "alsReferenceKinds": [
+                      "alsReferenceKinds": [
+                        "reference",
                         "write",
                         "call",
                         "dispatching call",

--- a/testsuite/ada_lsp/implementation/test.json
+++ b/testsuite/ada_lsp/implementation/test.json
@@ -3,14 +3,14 @@
       "comment": [
          "basic test for textdocument/implementation"
       ]
-   }, 
+   },
    {
       "start": {
          "cmd": [
             "${ALS}"
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
@@ -19,450 +19,451 @@
                   "textDocument": {
                      "completion": {
                         "completionItemKind": {}
-                     }, 
-                     "documentLink": {}, 
-                     "formatting": {}, 
-                     "documentHighlight": {}, 
-                     "synchronization": {}, 
-                     "references": {}, 
-                     "rangeFormatting": {}, 
-                     "onTypeFormatting": {}, 
-                     "codeLens": {}, 
+                     },
+                     "documentLink": {},
+                     "formatting": {},
+                     "documentHighlight": {},
+                     "synchronization": {},
+                     "references": {},
+                     "rangeFormatting": {},
+                     "onTypeFormatting": {},
+                     "codeLens": {},
                      "colorProvider": {}
-                  }, 
+                  },
                   "workspace": {
-                     "applyEdit": false, 
-                     "executeCommand": {}, 
-                     "didChangeWatchedFiles": {}, 
-                     "workspaceEdit": {}, 
+                     "applyEdit": false,
+                     "executeCommand": {},
+                     "didChangeWatchedFiles": {},
+                     "workspaceEdit": {},
                      "didChangeConfiguration": {}
                   }
-               }, 
+               },
                "rootUri": "$URI{.}"
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 1, 
+            },
+            "jsonrpc": "2.0",
+            "id": 1,
             "method": "initialize"
-         }, 
+         },
          "wait": [
             {
-               "id": 1, 
+               "id": 1,
                "result": {
                   "capabilities": {
-                     "typeDefinitionProvider": true, 
+                     "typeDefinitionProvider": true,
                      "alsReferenceKinds": [
-                        "write", 
-                        "call", 
-                        "dispatching call", 
-                        "parent", 
+                        "reference",
+                        "write",
+                        "call",
+                        "dispatching call",
+                        "parent",
                         "child"
-                     ], 
-                     "hoverProvider": true, 
-                     "definitionProvider": true, 
-                     "renameProvider": {}, 
-                     "alsCalledByProvider": true, 
-                     "referencesProvider": true, 
-                     "declarationProvider": true, 
-                     "textDocumentSync": 1, 
+                     ],
+                     "hoverProvider": true,
+                     "definitionProvider": true,
+                     "renameProvider": {},
+                     "alsCalledByProvider": true,
+                     "referencesProvider": true,
+                     "declarationProvider": true,
+                     "textDocumentSync": 1,
                      "completionProvider": {
                         "triggerCharacters": [
                            "."
-                        ], 
+                        ],
                         "resolveProvider": false
-                     }, 
+                     },
                      "documentSymbolProvider": true
                   }
                }
             }
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
-            "jsonrpc": "2.0", 
+            "jsonrpc": "2.0",
             "method": "initialized"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "settings": {
                   "ada": {
-                     "scenarioVariables": {}, 
-                     "enableDiagnostics": false, 
+                     "scenarioVariables": {},
+                     "enableDiagnostics": false,
                      "defaultCharset": "ISO-8859-1"
                   }
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "workspace/didChangeConfiguration"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "textDocument": {
-                  "text": "package pack is\n\n   procedure Foo;\n\n   procedure Foo2;\n   \n   procedure Foo3;\n   \nprivate\n   \n   procedure Foo2 is null;\n   \n   type R;\n   \nend pack;\n", 
-                  "version": 0, 
-                  "uri": "$URI{pack.ads}", 
+                  "text": "package pack is\n\n   procedure Foo;\n\n   procedure Foo2;\n   \n   procedure Foo3;\n   \nprivate\n   \n   procedure Foo2 is null;\n   \n   type R;\n   \nend pack;\n",
+                  "version": 0,
+                  "uri": "$URI{pack.ads}",
                   "languageId": "Ada"
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "textDocument/didOpen"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {"comment": "------------- pack.ads  Foo -> return implementation in the body --------"},
    {
       "send": {
          "request": {
             "params": {
                "position": {
-                  "line": 2, 
+                  "line": 2,
                   "character": 13
-               }, 
+               },
                "textDocument": {
                   "uri": "$URI{pack.ads}"
                }
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 2, 
+            },
+            "jsonrpc": "2.0",
+            "id": 2,
             "method": "textDocument/implementation"
-         }, 
+         },
          "wait": [
             {
-               "id": 2, 
+               "id": 2,
                "result": [
                   {
                      "range": {
                         "start": {
-                           "line": 4, 
+                           "line": 4,
                            "character": 13
-                        }, 
+                        },
                         "end": {
-                           "line": 4, 
+                           "line": 4,
                            "character": 16
                         }
-                     }, 
+                     },
                      "uri": "$URI{pack.adb}"
                   }
                ]
             }
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "textDocument": {
-                  "text": "package body pack is\n\n   type R is null record;\n   \n   procedure Foo is null;\n\n   procedure Foo3 is separate;\n   \nend pack;\n", 
-                  "version": 0, 
-                  "uri": "$URI{pack.adb}", 
+                  "text": "package body pack is\n\n   type R is null record;\n   \n   procedure Foo is null;\n\n   procedure Foo3 is separate;\n   \nend pack;\n",
+                  "version": 0,
+                  "uri": "$URI{pack.adb}",
                   "languageId": "Ada"
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "textDocument/didOpen"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {"comment": "------------- Foo on the body -> stay on the body --------"},
    {
       "send": {
          "request": {
             "params": {
                "position": {
-                  "line": 4, 
+                  "line": 4,
                   "character": 13
-               }, 
+               },
                "textDocument": {
                   "uri": "$URI{pack.adb}"
                }
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 3, 
+            },
+            "jsonrpc": "2.0",
+            "id": 3,
             "method": "textDocument/implementation"
-         }, 
+         },
          "wait": [
             {
-               "id": 3, 
+               "id": 3,
                "result": [
                   {
                      "range": {
                         "start": {
-                           "line": 4, 
+                           "line": 4,
                            "character": 13
-                        }, 
+                        },
                         "end": {
-                           "line": 4, 
+                           "line": 4,
                            "character": 16
                         }
-                     }, 
+                     },
                      "uri": "$URI{pack.adb}"
                   }
                ]
             }
          ]
       }
-   }, 
+   },
    {"comment": "------------- definition Foo on the body -> go back to the spec --------"},
    {
       "send": {
          "request": {
             "params": {
                "position": {
-                  "line": 4, 
+                  "line": 4,
                   "character": 13
-               }, 
+               },
                "textDocument": {
                   "uri": "$URI{pack.adb}"
                }
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 4, 
+            },
+            "jsonrpc": "2.0",
+            "id": 4,
             "method": "textDocument/definition"
-         }, 
+         },
          "wait": [
             {
-               "id": 4, 
+               "id": 4,
                "result": [
                   {
                      "range": {
                         "start": {
-                           "line": 2, 
+                           "line": 2,
                            "character": 13
-                        }, 
+                        },
                         "end": {
-                           "line": 2, 
+                           "line": 2,
                            "character": 16
                         }
-                     }, 
+                     },
                      "uri": "$URI{pack.ads}"
                   }
                ]
             }
          ]
       }
-   }, 
+   },
    {"comment": "------------- Foo2 on the spec -> find the private implementation --------"},
    {
       "send": {
          "request": {
             "params": {
                "position": {
-                  "line": 4, 
+                  "line": 4,
                   "character": 13
-               }, 
+               },
                "textDocument": {
                   "uri": "$URI{pack.ads}"
                }
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 5, 
+            },
+            "jsonrpc": "2.0",
+            "id": 5,
             "method": "textDocument/implementation"
-         }, 
+         },
          "wait": [
             {
-               "id": 5, 
+               "id": 5,
                "result": [
                   {
                      "range": {
                         "start": {
-                           "line": 10, 
+                           "line": 10,
                            "character": 13
-                        }, 
+                        },
                         "end": {
-                           "line": 10, 
+                           "line": 10,
                            "character": 17
                         }
-                     }, 
+                     },
                      "uri": "$URI{pack.ads}"
                   }
                ]
             }
          ]
       }
-   }, 
+   },
    {"comment": "------------- Foo2 on the private implementation ->  stay there --------"},
    {
       "send": {
          "request": {
             "params": {
                "position": {
-                  "line": 10, 
+                  "line": 10,
                   "character": 13
-               }, 
+               },
                "textDocument": {
                   "uri": "$URI{pack.ads}"
                }
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 6, 
+            },
+            "jsonrpc": "2.0",
+            "id": 6,
             "method": "textDocument/implementation"
-         }, 
+         },
          "wait": [
             {
-               "id": 6, 
+               "id": 6,
                "result": [
                   {
                      "range": {
                         "start": {
-                           "line": 10, 
+                           "line": 10,
                            "character": 13
-                        }, 
+                        },
                         "end": {
-                           "line": 10, 
+                           "line": 10,
                            "character": 17
                         }
-                     }, 
+                     },
                      "uri": "$URI{pack.ads}"
                   }
                ]
             }
          ]
       }
-   }, 
+   },
    {"comment": "------------- Foo3 on the spec ->  list body AND separate implementation --------"},
    {
       "send": {
          "request": {
             "params": {
                "position": {
-                  "line": 6, 
+                  "line": 6,
                   "character": 13
-               }, 
+               },
                "textDocument": {
                   "uri": "$URI{pack.ads}"
                }
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 7, 
+            },
+            "jsonrpc": "2.0",
+            "id": 7,
             "method": "textDocument/implementation"
-         }, 
+         },
          "wait": [
             {
-               "id": 7, 
+               "id": 7,
                "result": [
                   {
                      "range": {
                         "start": {
-                           "line": 6, 
+                           "line": 6,
                            "character": 13
-                        }, 
+                        },
                         "end": {
-                           "line": 6, 
+                           "line": 6,
                            "character": 17
                         }
-                     }, 
+                     },
                      "uri": "$URI{pack.adb}"
-                  }, 
+                  },
                   {
                      "range": {
                         "start": {
-                           "line": 0, 
+                           "line": 0,
                            "character": 26
-                        }, 
+                        },
                         "end": {
-                           "line": 0, 
+                           "line": 0,
                            "character": 30
                         }
-                     }, 
+                     },
                      "uri": "$URI{pack-foo3.adb}"
                   }
                ]
             }
          ]
       }
-   }, 
+   },
    {"comment": "------------- R on the spec ->  find completion in body --------"},
    {
       "send": {
          "request": {
             "params": {
                "position": {
-                  "line": 12, 
+                  "line": 12,
                   "character": 8
-               }, 
+               },
                "textDocument": {
                   "uri": "$URI{pack.ads}"
                }
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 9, 
+            },
+            "jsonrpc": "2.0",
+            "id": 9,
             "method": "textDocument/implementation"
-         }, 
+         },
          "wait": [
             {
-               "id": 9, 
+               "id": 9,
                "result": [
                   {
                      "range": {
                         "start": {
-                           "line": 2, 
+                           "line": 2,
                            "character": 8
-                        }, 
+                        },
                         "end": {
-                           "line": 2, 
+                           "line": 2,
                            "character": 9
                         }
-                     }, 
+                     },
                      "uri": "$URI{pack.adb}"
                   }
                ]
             }
          ]
       }
-   }, 
+   },
    {"comment": "------------- R on the body ->  stay on the body --------"},
    {
       "send": {
          "request": {
             "params": {
                "position": {
-                  "line": 2, 
+                  "line": 2,
                   "character": 8
-               }, 
+               },
                "textDocument": {
                   "uri": "$URI{pack.adb}"
                }
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 10, 
+            },
+            "jsonrpc": "2.0",
+            "id": 10,
             "method": "textDocument/implementation"
-         }, 
+         },
          "wait": [
             {
-               "id": 10, 
+               "id": 10,
                "result": [
                   {
                      "range": {
                         "start": {
-                           "line": 2, 
+                           "line": 2,
                            "character": 8
-                        }, 
+                        },
                         "end": {
-                           "line": 2, 
+                           "line": 2,
                            "character": 9
                         }
-                     }, 
+                     },
                      "uri": "$URI{pack.adb}"
                   }
                ]
             }
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
@@ -470,13 +471,13 @@
                "textDocument": {
                   "uri": "$URI{pack.ads}"
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "textDocument/didClose"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
@@ -484,28 +485,28 @@
                "textDocument": {
                   "uri": "$URI{pack.adb}"
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "textDocument/didClose"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
-            "jsonrpc": "2.0", 
-            "id": 11, 
+            "jsonrpc": "2.0",
+            "id": 11,
             "method": "shutdown"
-         }, 
+         },
          "wait": [
             {
-               "id": 11, 
+               "id": 11,
                "result": null
             }
          ]
       }
-   }, 
+   },
    {
       "stop": {
          "exit_code": 0

--- a/testsuite/ada_lsp/indexing_progress/test.json
+++ b/testsuite/ada_lsp/indexing_progress/test.json
@@ -3,14 +3,14 @@
       "comment": [
          "test automatically generated"
       ]
-   }, 
+   },
    {
       "start": {
          "cmd": [
             "${ALS}"
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
@@ -19,136 +19,137 @@
                   "workspace": {
                      "applyEdit": false
                   }
-               }, 
+               },
                "rootUri": "$URI{.}"
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 1, 
+            },
+            "jsonrpc": "2.0",
+            "id": 1,
             "method": "initialize"
-         }, 
+         },
          "wait": [
             {
-               "id": 1, 
+               "id": 1,
                "result": {
                   "capabilities": {
-                     "typeDefinitionProvider": true, 
+                     "typeDefinitionProvider": true,
                      "alsReferenceKinds": [
-                        "write", 
-                        "call", 
+                       "reference",
+                        "write",
+                        "call",
                         "dispatching call", "parent", "child"
-                     ], 
-                     "hoverProvider": true, 
-                     "definitionProvider": true, 
-                     "renameProvider": {}, 
-                     "alsCalledByProvider": true, 
-                     "referencesProvider": true, 
-                     "textDocumentSync": 1, 
+                     ],
+                     "hoverProvider": true,
+                     "definitionProvider": true,
+                     "renameProvider": {},
+                     "alsCalledByProvider": true,
+                     "referencesProvider": true,
+                     "textDocumentSync": 1,
                      "completionProvider": {
                         "triggerCharacters": [
                            "."
-                        ], 
+                        ],
                         "resolveProvider": false
-                     }, 
+                     },
                      "documentSymbolProvider": true
                   }
                }
             }
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
-            "jsonrpc": "2.0", 
+            "jsonrpc": "2.0",
             "method": "initialized"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "settings": {
                   "ada": {
-                     "scenarioVariables": {}, 
-                     "enableDiagnostics": false, 
+                     "scenarioVariables": {},
+                     "enableDiagnostics": false,
                      "defaultCharset": "ISO-8859-1"
                   }
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "workspace/didChangeConfiguration"
-         }, 
+         },
          "wait": [
             {
                "params": {
-                  "token": "<ANY>", 
+                  "token": "<ANY>",
                   "value": {
-                     "kind": "begin", 
-                     "percentage": 0, 
+                     "kind": "begin",
+                     "percentage": 0,
                      "title": "Indexing"
                   }
-               }, 
+               },
                "method": "$/progress"
-            }, 
+            },
             {
                "params": {
-                  "token": "<ANY>", 
+                  "token": "<ANY>",
                   "value": {
-                     "kind": "report", 
+                     "kind": "report",
                      "percentage": 25
                   }
-               }, 
+               },
                "method": "$/progress"
-            }, 
+            },
             {
                "params": {
-                  "token": "<ANY>", 
+                  "token": "<ANY>",
                   "value": {
-                     "kind": "report", 
+                     "kind": "report",
                      "percentage": 50
                   }
-               }, 
+               },
                "method": "$/progress"
-            }, 
+            },
             {
                "params": {
-                  "token": "<ANY>", 
+                  "token": "<ANY>",
                   "value": {
-                     "kind": "report", 
+                     "kind": "report",
                      "percentage": 75
                   }
-               }, 
+               },
                "method": "$/progress"
-            }, 
+            },
             {
                "params": {
-                  "token": "<ANY>", 
+                  "token": "<ANY>",
                   "value": {
                      "kind": "end"
                   }
-               }, 
+               },
                "method": "$/progress"
             }
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
-            "jsonrpc": "2.0", 
-            "id": 2, 
+            "jsonrpc": "2.0",
+            "id": 2,
             "method": "shutdown"
-         }, 
+         },
          "wait": [
             {
-               "id": 2, 
+               "id": 2,
                "result": null
             }
          ]
       }
-   }, 
+   },
    {
       "stop": {
          "exit_code": 0

--- a/testsuite/ada_lsp/project_reload/project_reload.json
+++ b/testsuite/ada_lsp/project_reload/project_reload.json
@@ -92,7 +92,7 @@
                             "character": 17
                         }
                     },
-                    "alsKind": "<ABSENT>"
+                    "alsKind": ["reference"]
                 }, {
                     "uri": "$URI{second.adb}",
                     "range": {
@@ -161,7 +161,7 @@
                             "character": 17
                         }
                     },
-                    "alsKind": "<ABSENT>"
+                    "alsKind": ["reference"]
                 }, {
                     "uri": "$URI{third.adb}",
                     "range": {

--- a/testsuite/ada_lsp/references.child/default.gpr
+++ b/testsuite/ada_lsp/references.child/default.gpr
@@ -1,0 +1,10 @@
+project Default is
+
+   for Source_Dirs use ("src");
+   for Main use ("main.adb");
+
+   package Compiler is
+      for Switches ("ada") use ("-gnatwa");
+   end Compiler;
+
+end Default;

--- a/testsuite/ada_lsp/references.child/src/children.adb
+++ b/testsuite/ada_lsp/references.child/src/children.adb
@@ -1,0 +1,12 @@
+with Ada.Text_IO;
+
+package body Children is
+
+   procedure Primitive (Self : in out Child;
+                        Id   : Integer) is
+   begin
+      Self.Id := Id;
+      Ada.Text_IO.Put_Line ("Child");
+   end Primitive;
+
+end Children;

--- a/testsuite/ada_lsp/references.child/src/children.ads
+++ b/testsuite/ada_lsp/references.child/src/children.ads
@@ -1,0 +1,9 @@
+with Parents; use Parents;
+package Children is
+
+   type Child is new Parent with null Record;
+
+   procedure Primitive (Self : in out Child;
+                        Id   : Integer);
+
+end Children;

--- a/testsuite/ada_lsp/references.child/src/great_children.adb
+++ b/testsuite/ada_lsp/references.child/src/great_children.adb
@@ -1,0 +1,13 @@
+with Ada.Text_IO;
+
+package body Great_Children is
+
+   procedure Primitive (Self : in out Great_Child;
+                        Id   : Integer) is
+   begin
+      Self.Id := Id;
+
+      Ada.Text_IO.Put_Line ("Great child");
+   end Primitive;
+
+end Great_Children;

--- a/testsuite/ada_lsp/references.child/src/great_children.ads
+++ b/testsuite/ada_lsp/references.child/src/great_children.ads
@@ -1,0 +1,9 @@
+with Children; use Children;
+package Great_Children is
+
+   type Great_Child is new Child with null Record;
+
+   procedure Primitive (Self : in out Great_Child;
+                        Id   : Integer);
+
+end Great_Children;

--- a/testsuite/ada_lsp/references.child/src/main.adb
+++ b/testsuite/ada_lsp/references.child/src/main.adb
@@ -1,0 +1,8 @@
+with Children; use Children;
+with Great_Children; use Great_Children;
+
+procedure Main is
+   Obj : Child'Class := Great_Child'(others => <>);
+begin
+   Obj.Primitive (3);
+end Main;

--- a/testsuite/ada_lsp/references.child/src/parents.ads
+++ b/testsuite/ada_lsp/references.child/src/parents.ads
@@ -1,0 +1,11 @@
+package Parents is
+
+   type Parent is abstract tagged record
+      Id : Integer;
+   end record;
+
+   procedure Primitive (Self : in out Parent;
+                        Id   : Integer) is abstract;
+   --  Parent procedure
+
+end Parents;

--- a/testsuite/ada_lsp/references.child/test.json
+++ b/testsuite/ada_lsp/references.child/test.json
@@ -1,8 +1,8 @@
 [
    {
       "comment": [
-          "This test checks that textDocument/definition responses filter out",
-          "end labels"
+          "This test checks that we correctly flag type derivation ",
+          "references"
       ]
    },
    {
@@ -16,7 +16,7 @@
       "send": {
          "request": {
             "params": {
-               "processId": 15643,
+               "processId": 6284,
                "capabilities": {
                   "textDocument": {
                      "completion": {
@@ -56,15 +56,17 @@
                         "reference",
                         "write",
                         "call",
-                        "dispatching call", "parent", "child"
+                        "dispatching call",
+                        "parent",
+                        "child"
                      ],
                      "hoverProvider": true,
                      "definitionProvider": true,
                      "renameProvider": {},
                      "alsCalledByProvider": true,
                      "referencesProvider": true,
-                     "declarationProvider": true,
                      "textDocumentSync": 1,
+                     "declarationProvider": true,
                      "completionProvider": {
                         "triggerCharacters": [
                            "."
@@ -112,9 +114,9 @@
          "request": {
             "params": {
                "textDocument": {
-                  "text": "package Parent.Child is\n\n   type Child_Type is new Parent_Type with null record;\n\nend Parent.Child;\n",
+                  "text": "package Parents is\n\n   type Parent is abstract tagged record\n      Id : Integer;\n   end record;\n\n   procedure Primitive (Self : in out Parent;\n                        Id   : Integer) is abstract;\n   --  Parent procedure\n\nend Parents;\n",
                   "version": 0,
-                  "uri": "$URI{parent-child.ads}",
+                  "uri": "$URI{src/parents.ads}",
                   "languageId": "Ada"
                }
             },
@@ -129,62 +131,79 @@
          "request": {
             "params": {
                "position": {
-                  "line": 4,
-                  "character": 14
+                  "line": 2,
+                  "character": 13
                },
                "textDocument": {
-                  "uri": "$URI{parent-child.ads}"
-               },
-               "context": {
-                  "includeDeclaration": true
+                  "uri": "$URI{src/parents.ads}"
                }
             },
             "jsonrpc": "2.0",
             "id": 2,
-            "method": "textDocument/references"
+            "method": "textDocument/definition"
          },
          "wait": [
             {
                "id": 2,
+               "result": []
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "position": {
+                  "line": 2,
+                  "character": 13
+               },
+               "textDocument": {
+                  "uri": "$URI{src/parents.ads}"
+               },
+               "context": {
+                  "includeDeclaration": false
+               }
+            },
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "textDocument/references"
+         },
+         "wait": [
+            {
+               "id": 3,
                "result": [
                   {
                      "range": {
                         "start": {
-                           "line": 0,
-                           "character": 12
+                           "line": 3,
+                           "character": 21
                         },
                         "end": {
-                           "line": 0,
-                           "character": 17
+                           "line": 3,
+                           "character": 27
                         }
                      },
-                     "uri": "$URI{main.adb}"
+                     "alsKind": [
+                        "child"
+                     ],
+                     "uri": "$URI{src/children.ads}"
                   },
                   {
                      "range": {
                         "start": {
-                           "line": 0,
-                           "character": 30
+                           "line": 6,
+                           "character": 38
                         },
                         "end": {
-                           "line": 0,
-                           "character": 35
+                           "line": 6,
+                           "character": 44
                         }
                      },
-                     "uri": "$URI{main.adb}"
-                  },
-                  {
-                     "range": {
-                        "start": {
-                           "line": 0,
-                           "character": 8
-                        },
-                        "end": {
-                           "line": 0,
-                           "character": 20
-                        }
-                     },
-                     "uri": "$URI{parent-child.ads}"
+                     "alsKind": [
+                        "reference"
+                     ],
+                     "uri": "$URI{src/parents.ads}"
                   }
                ]
             }
@@ -196,7 +215,38 @@
          "request": {
             "params": {
                "textDocument": {
-                  "uri": "$URI{parent-child.ads}"
+                  "text": "with Parents; use Parents;\npackage Children is\n\n   type Child is new Parent with null Record;\n\n   procedure Primitive (Self : in out Child;\n                        Id   : Integer);\n\nend Children;\n",
+                  "version": 0,
+                  "uri": "$URI{src/children.ads}",
+                  "languageId": "Ada"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{src/parents.ads}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didClose"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{src/children.ads}"
                }
             },
             "jsonrpc": "2.0",
@@ -209,12 +259,12 @@
       "send": {
          "request": {
             "jsonrpc": "2.0",
-            "id": 3,
+            "id": 4,
             "method": "shutdown"
          },
          "wait": [
             {
-               "id": 3,
+               "id": 4,
                "result": null
             }
          ]

--- a/testsuite/ada_lsp/references.child/test.yaml
+++ b/testsuite/ada_lsp/references.child/test.yaml
@@ -1,0 +1,1 @@
+title: 'references.child'

--- a/testsuite/ada_lsp/rename.primitive_parameters/test.json
+++ b/testsuite/ada_lsp/rename.primitive_parameters/test.json
@@ -55,6 +55,7 @@
                   "capabilities": {
                      "typeDefinitionProvider": true,
                      "alsReferenceKinds": [
+                        "reference",
                         "write",
                         "call",
                         "dispatching call",

--- a/testsuite/ada_lsp/rename.tagged_type_primitives/test.json
+++ b/testsuite/ada_lsp/rename.tagged_type_primitives/test.json
@@ -54,6 +54,7 @@
                   "capabilities": {
                      "typeDefinitionProvider": true,
                      "alsReferenceKinds": [
+                        "reference",
                         "write",
                         "call",
                         "dispatching call",

--- a/testsuite/ada_lsp/type_definition.aggregate/test.json
+++ b/testsuite/ada_lsp/type_definition.aggregate/test.json
@@ -3,14 +3,14 @@
       "comment": [
          "test typeDefinition in aggregate projects, and test querying it on the actual definition"
       ]
-   }, 
+   },
    {
       "start": {
          "cmd": [
             "${ALS}"
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
@@ -19,153 +19,154 @@
                   "textDocument": {
                      "completion": {
                         "completionItemKind": {}
-                     }, 
-                     "documentLink": {}, 
-                     "formatting": {}, 
-                     "documentHighlight": {}, 
-                     "synchronization": {}, 
-                     "references": {}, 
-                     "rangeFormatting": {}, 
-                     "onTypeFormatting": {}, 
-                     "codeLens": {}, 
+                     },
+                     "documentLink": {},
+                     "formatting": {},
+                     "documentHighlight": {},
+                     "synchronization": {},
+                     "references": {},
+                     "rangeFormatting": {},
+                     "onTypeFormatting": {},
+                     "codeLens": {},
                      "colorProvider": {}
-                  }, 
+                  },
                   "workspace": {
-                     "applyEdit": false, 
-                     "executeCommand": {}, 
-                     "didChangeWatchedFiles": {}, 
-                     "workspaceEdit": {}, 
+                     "applyEdit": false,
+                     "executeCommand": {},
+                     "didChangeWatchedFiles": {},
+                     "workspaceEdit": {},
                      "didChangeConfiguration": {}
                   }
-               }, 
+               },
                "rootUri": "$URI{.}"
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 1, 
+            },
+            "jsonrpc": "2.0",
+            "id": 1,
             "method": "initialize"
-         }, 
+         },
          "wait": [
             {
-               "id": 1, 
+               "id": 1,
                "result": {
                   "capabilities": {
-                     "typeDefinitionProvider": true, 
+                     "typeDefinitionProvider": true,
                      "alsReferenceKinds": [
-                        "write", 
-                        "call", 
-                        "dispatching call", 
-                        "parent", 
+                        "reference",
+                        "write",
+                        "call",
+                        "dispatching call",
+                        "parent",
                         "child"
-                     ], 
-                     "hoverProvider": true, 
-                     "definitionProvider": true, 
-                     "renameProvider": {}, 
-                     "alsCalledByProvider": true, 
-                     "referencesProvider": true, 
-                     "declarationProvider": true, 
-                     "textDocumentSync": 1, 
+                     ],
+                     "hoverProvider": true,
+                     "definitionProvider": true,
+                     "renameProvider": {},
+                     "alsCalledByProvider": true,
+                     "referencesProvider": true,
+                     "declarationProvider": true,
+                     "textDocumentSync": 1,
                      "completionProvider": {
                         "triggerCharacters": [
                            "."
-                        ], 
+                        ],
                         "resolveProvider": false
-                     }, 
+                     },
                      "documentSymbolProvider": true
                   }
                }
             }
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
-            "jsonrpc": "2.0", 
+            "jsonrpc": "2.0",
             "method": "initialized"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "settings": {
                   "ada": {
-                     "scenarioVariables": {}, 
-                     "enableDiagnostics": false, 
+                     "scenarioVariables": {},
+                     "enableDiagnostics": false,
                      "defaultCharset": "ISO-8859-1"
                   }
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "workspace/didChangeConfiguration"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "textDocument": {
-                  "text": "with truc; use truc;\n\npackage common_pack is\n   X   : My_Definition;\n   Foo : Integer := X.F;\nend common_pack;\n", 
-                  "version": 0, 
-                  "uri": "$URI{common/common_pack.ads}", 
+                  "text": "with truc; use truc;\n\npackage common_pack is\n   X   : My_Definition;\n   Foo : Integer := X.F;\nend common_pack;\n",
+                  "version": 0,
+                  "uri": "$URI{common/common_pack.ads}",
                   "languageId": "Ada"
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "textDocument/didOpen"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {"comment": "---------------------------  typeDefinition on the location of the definition, make sure there are two replies ----------"},
    {
       "send": {
          "request": {
             "params": {
                "position": {
-                  "line": 3, 
+                  "line": 3,
                   "character": 3
-               }, 
+               },
                "textDocument": {
                   "uri": "$URI{common/common_pack.ads}"
                }
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 2, 
+            },
+            "jsonrpc": "2.0",
+            "id": 2,
             "method": "textDocument/typeDefinition"
-         }, 
+         },
          "wait": [
             {
-               "id": 2, 
+               "id": 2,
                "result": [
                   {
                      "range": {
                         "start": {
-                           "line": 2, 
+                           "line": 2,
                            "character": 8
-                        }, 
+                        },
                         "end": {
-                           "line": 2, 
+                           "line": 2,
                            "character": 21
                         }
-                     }, 
+                     },
                      "uri": "$URI{p/truc.ads}"
-                  }, 
+                  },
                   {
                      "range": {
                         "start": {
-                           "line": 3, 
+                           "line": 3,
                            "character": 8
-                        }, 
+                        },
                         "end": {
-                           "line": 3, 
+                           "line": 3,
                            "character": 21
                         }
-                     }, 
+                     },
                      "uri": "$URI{q/truc.ads}"
                   }
                ]
@@ -179,52 +180,52 @@
          "request": {
             "params": {
                "position": {
-                  "line": 4, 
+                  "line": 4,
                   "character": 20
-               }, 
+               },
                "textDocument": {
                   "uri": "$URI{common/common_pack.ads}"
                }
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 6, 
+            },
+            "jsonrpc": "2.0",
+            "id": 6,
             "method": "textDocument/typeDefinition"
-         }, 
+         },
          "wait": [
             {
-               "id": 6, 
+               "id": 6,
                "result": [
                   {
                      "range": {
                         "start": {
-                           "line": 2, 
+                           "line": 2,
                            "character": 8
-                        }, 
+                        },
                         "end": {
-                           "line": 2, 
+                           "line": 2,
                            "character": 21
                         }
-                     }, 
+                     },
                      "uri": "$URI{p/truc.ads}"
-                  }, 
+                  },
                   {
                      "range": {
                         "start": {
-                           "line": 3, 
+                           "line": 3,
                            "character": 8
-                        }, 
+                        },
                         "end": {
-                           "line": 3, 
+                           "line": 3,
                            "character": 21
                         }
-                     }, 
+                     },
                      "uri": "$URI{q/truc.ads}"
                   }
                ]
             }
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
@@ -232,28 +233,28 @@
                "textDocument": {
                   "uri": "$URI{common/common_pack.ads}"
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "textDocument/didClose"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
-            "jsonrpc": "2.0", 
-            "id": 8, 
+            "jsonrpc": "2.0",
+            "id": 8,
             "method": "shutdown"
-         }, 
+         },
          "wait": [
             {
-               "id": 8, 
+               "id": 8,
                "result": null
             }
          ]
       }
-   }, 
+   },
    {
       "stop": {
          "exit_code": 0


### PR DESCRIPTION
* The 'child' reference kind is now actually used to filter
  type derivation references.

* A simple 'reference' kind has been added for all the default
  references

* All teh tests have been adapted