### PR TITLE
SA17-041 Fix reading of optional values.

### DIFF
--- a/source/protocol/lsp-generic_optional.adb
+++ b/source/protocol/lsp-generic_optional.adb
@@ -33,7 +33,7 @@ package body LSP.Generic_Optional is
 
       Value : constant GNATCOLL.JSON.JSON_Value := JS.Read;
    begin
-      if Value.Is_Empty then
+      if Value.Kind in GNATCOLL.JSON.JSON_Null_Type then
          V := (Is_Set => False);
       elsif Value.Kind in GNATCOLL.JSON.JSON_Boolean_Type then
          --  During protocol extension some boolean settings become objects.


### PR DESCRIPTION
Corner case is an empty JSON object. Before this patch it's
read as an absent value.