### PR TITLE
T131-020: Add child/parent kinds for textDocument/declaration

### DIFF
--- a/source/ada/lsp-common.ads
+++ b/source/ada/lsp-common.ads
@@ -19,10 +19,19 @@
 
 with Ada.Exceptions;
 with GNATCOLL.Traces;
+with LSP.Messages;
 with LSP.Types;           use LSP.Types;
 with Libadalang.Analysis; use Libadalang.Analysis;
 
 package LSP.Common is
+
+   Is_Parent : constant LSP.Messages.AlsReferenceKind_Set :=
+     (Is_Server_Side => True,
+      As_Flags => (LSP.Messages.Parent => True, others => False));
+   Is_Child : constant LSP.Messages.AlsReferenceKind_Set :=
+     (Is_Server_Side => True,
+      As_Flags => (LSP.Messages.Child => True, others => False));
+   --  Convenient constants
 
    procedure Log
      (Trace   : GNATCOLL.Traces.Trace_Handle;

--- a/testsuite/ada_lsp/declaration.overridings/p.gpr
+++ b/testsuite/ada_lsp/declaration.overridings/p.gpr
@@ -1,0 +1,2 @@
+project p is
+end p;

--- a/testsuite/ada_lsp/declaration.overridings/pack.adb
+++ b/testsuite/ada_lsp/declaration.overridings/pack.adb
@@ -1,0 +1,29 @@
+pragma Ada_2012;
+package body pack is
+
+
+   procedure Method (X : Child) is
+   begin
+      null;
+   end Method;
+
+   ------------
+   -- Method --
+   ------------
+
+   procedure Method (X : Grandchild) is
+      X : Child;
+   begin
+      X.Method;
+   end Method;
+
+   ------------
+   -- Method --
+   ------------
+
+   procedure Method (X : Great_Grandchild) is
+   begin
+      null;
+   end Method;
+
+end pack;

--- a/testsuite/ada_lsp/declaration.overridings/pack.ads
+++ b/testsuite/ada_lsp/declaration.overridings/pack.ads
@@ -1,0 +1,15 @@
+package pack is
+
+   type Root is tagged null record;
+   procedure Method (X : Root) is abstract;
+   
+   type Child is new Root with null record;
+   procedure Method (X : Child);
+   
+   type Grandchild is new Child with null record;
+   procedure Method (X : Grandchild);
+
+   type Great_Grandchild is new Grandchild with null record;
+   procedure Method (X : Great_Grandchild);
+   
+end pack;

--- a/testsuite/ada_lsp/declaration.overridings/test.json
+++ b/testsuite/ada_lsp/declaration.overridings/test.json
@@ -1,0 +1,280 @@
+[
+   {
+      "comment": [
+          "This test checks that textDocument/declaration lists correctly ",
+          "the overriding and base declarations when clicking on a tagged ",
+          "type primitive body."
+      ]
+   },
+   {
+      "start": {
+         "cmd": [
+            "${ALS}"
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "capabilities": {
+                  "textDocument": {
+                     "completion": {
+                        "completionItemKind": {}
+                     },
+                     "documentLink": {},
+                     "formatting": {},
+                     "documentHighlight": {},
+                     "synchronization": {},
+                     "references": {},
+                     "rangeFormatting": {},
+                     "onTypeFormatting": {},
+                     "codeLens": {},
+                     "colorProvider": {}
+                  },
+                  "workspace": {
+                     "applyEdit": false,
+                     "executeCommand": {},
+                     "didChangeWatchedFiles": {},
+                     "workspaceEdit": {},
+                     "didChangeConfiguration": {}
+                  }
+               },
+               "rootUri": "$URI{.}"
+            },
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize"
+         },
+         "wait": [
+            {
+               "id": 1,
+               "result": {
+                  "capabilities": {
+                     "typeDefinitionProvider": true,
+                     "alsReferenceKinds": [
+                        "reference",
+                        "write",
+                        "call",
+                        "dispatching call",
+                        "parent",
+                        "child"
+                     ],
+                     "hoverProvider": true,
+                     "definitionProvider": true,
+                     "renameProvider": {},
+                     "alsCalledByProvider": true,
+                     "referencesProvider": true,
+                     "textDocumentSync": 2,
+                     "declarationProvider": true,
+                     "completionProvider": {
+                        "triggerCharacters": [
+                           "."
+                        ],
+                        "resolveProvider": false
+                     },
+                     "documentSymbolProvider": true
+                  }
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "initialized"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "settings": {
+                  "ada": {
+                     "projectFile": "$URI{p.gpr}",
+                     "scenarioVariables": {},
+                     "enableDiagnostics": false,
+                     "enableIndexing": false,
+                     "defaultCharset": "ISO-8859-1"
+                  }
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "workspace/didChangeConfiguration"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "text": "pragma Ada_2012;\npackage body pack is\n\n\n   procedure Method (X : Child) is\n   begin\n      null;\n   end Method;\n\n   ------------\n   -- Method --\n   ------------\n\n   procedure Method (X : Grandchild) is\n      X : Child;\n   begin\n      X.Method;\n   end Method;\n\n   ------------\n   -- Method --\n   ------------\n\n   procedure Method (X : Great_Grandchild) is\n   begin\n      null;\n   end Method;\n\nend pack;\n",
+                  "version": 0,
+                  "uri": "$URI{pack.adb}",
+                  "languageId": "Ada"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "position": {
+                  "line": 23,
+                  "character": 17
+               },
+               "textDocument": {
+                  "uri": "$URI{pack.adb}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "textDocument/declaration"
+         },
+         "wait": [
+            {
+               "id": 2,
+               "result": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 3,
+                           "character": 13
+                        },
+                        "end": {
+                           "line": 3,
+                           "character": 19
+                        }
+                     },
+                     "alsKind": [
+                        "parent"
+                     ],
+                     "uri": "$URI{pack.ads}"
+                  },
+                  {
+                     "range": {
+                        "start": {
+                           "line": 6,
+                           "character": 13
+                        },
+                        "end": {
+                           "line": 6,
+                           "character": 19
+                        }
+                     },
+                     "alsKind": [
+                        "parent"
+                     ],
+                     "uri": "$URI{pack.ads}"
+                  },
+                  {
+                     "range": {
+                        "start": {
+                           "line": 9,
+                           "character": 13
+                        },
+                        "end": {
+                           "line": 9,
+                           "character": 19
+                        }
+                     },
+                     "alsKind": [
+                        "parent"
+                     ],
+                     "uri": "$URI{pack.ads}"
+                  },
+                  {
+                     "range": {
+                        "start": {
+                           "line": 12,
+                           "character": 13
+                        },
+                        "end": {
+                           "line": 12,
+                           "character": 19
+                        }
+                     },
+                     "uri": "$URI{pack.ads}"
+                  }
+               ]
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "text": "package pack is\n\n   type Root is tagged null record;\n   procedure Method (X : Root) is abstract;\n   \n   type Child is new Root with null record;\n   procedure Method (X : Child);\n   \n   type Grandchild is new Child with null record;\n   procedure Method (X : Grandchild);\n\n   type Great_Grandchild is new Grandchild with null record;\n   procedure Method (X : Great_Grandchild);\n   \nend pack;\n",
+                  "version": 0,
+                  "uri": "$URI{pack.ads}",
+                  "languageId": "Ada"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{pack.adb}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didClose"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{pack.ads}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didClose"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": 11,
+            "method": "shutdown"
+         },
+         "wait": [
+            {
+               "id": 11,
+               "result": null
+            }
+         ]
+      }
+   },
+   {
+      "stop": {
+         "exit_code": 0
+      }
+   }
+]

--- a/testsuite/ada_lsp/declaration.overridings/test.yaml
+++ b/testsuite/ada_lsp/declaration.overridings/test.yaml
@@ -1,0 +1,1 @@
+title: 'declaration.overridings'


### PR DESCRIPTION
To mimic what we are already doing for textDocument/definition.

An automatic test has been added.