### PR TITLE
SB05-051 Consider runtime files as part of project files

### DIFF
--- a/source/ada/lsp-ada_context_sets.adb
+++ b/source/ada/lsp-ada_context_sets.adb
@@ -50,41 +50,23 @@ package body LSP.Ada_Context_Sets is
       Self.Total := 0;
    end Cleanup;
 
-   ----------------------
-   -- Contexts_For_URI --
-   ----------------------
-
-   function Contexts_For_URI
-     (Self : Context_Set'Class;
-      URI  : LSP.Messages.DocumentUri) return Context_Lists.List
-   is
-      File   : constant Virtual_File := To_File (URI);
-      Result : Context_Lists.List;
-   begin
-      --  If the file does not exist on disk, assume this is a file
-      --  being created and, as a special convenience in this case,
-      --  assume it could belong to any project.
-      if not File.Is_Regular_File then
-         return Self.Contexts;
-      end if;
-
-      for Context of Self.Contexts loop
-         if Context.Is_Part_Of_Project (File) then
-            Result.Append (Context);
-         end if;
-      end loop;
-
-      return Result;
-   end Contexts_For_URI;
-
    ------------------
    -- Each_Context --
    ------------------
 
-   function Each_Context (Self : Context_Set)
-     return Context_Lists.List_Iterator_Interfaces.Forward_Iterator'Class is
+   function Each_Context
+     (Self      : Context_Set;
+      Predicate : Context_Predicate := All_Contexts'Access)
+      return Context_Lists.List
+   is
+      Result : Context_Lists.List;
    begin
-      return Self.Contexts.Iterate;
+      for C of Self.Contexts loop
+         if Predicate (C.all) then
+            Result.Append (C);
+         end if;
+      end loop;
+      return Result;
    end Each_Context;
 
    ----------------------
@@ -161,5 +143,15 @@ package body LSP.Ada_Context_Sets is
    begin
       return Self.Total;
    end Total_Source_Files;
+
+   ------------------
+   -- All_Contexts --
+   ------------------
+
+   function All_Contexts (Context : LSP.Ada_Contexts.Context) return Boolean is
+      pragma Unreferenced (Context);
+   begin
+      return True;
+   end All_Contexts;
 
 end LSP.Ada_Context_Sets;

--- a/source/ada/lsp-ada_context_sets.ads
+++ b/source/ada/lsp-ada_context_sets.ads
@@ -50,29 +50,28 @@ package LSP.Ada_Context_Sets is
    --  Return the first context in Contexts which contains a project
    --  which knows about file. Fallback on the "no project" context.
 
-   function Contexts_For_URI
-     (Self : Context_Set'Class;
-      URI  : LSP.Messages.DocumentUri) return Context_Lists.List;
-   --  Return a list of contexts that are suitable for the given URI:
-   --  a list of all contexts where the file is known to be part of the
-   --  project tree. If the file is not known to any project, return
-   --  an empty list.
-   --  The result should not be freed.
-
    function Total_Source_Files (Self : Context_Set'Class) return Natural;
    --  Number of files in all contexts
 
    procedure Cleanup (Self : in out Context_Set'Class);
    --  Free memory referenced by Self
 
-   function Each_Context (Self : Context_Set)
-     return Context_Lists.List_Iterator_Interfaces.Forward_Iterator'Class;
-   --  Iterate over contexts of the set
-
    function Get
      (Self : Context_Set;
       Id   : LSP.Types.LSP_String) return Context_Access;
    --  Return context by its Id
+
+   type Context_Predicate is access function
+     (Context : LSP.Ada_Contexts.Context) return Boolean;
+
+   function All_Contexts (Context : LSP.Ada_Contexts.Context) return Boolean;
+   --  A Context_Predicate which matches all contexts
+
+   function Each_Context
+     (Self      : Context_Set;
+      Predicate : Context_Predicate := All_Contexts'Access)
+     return Context_Lists.List;
+   --  Return a list of the contexts in the set that match Predicate
 
 private
 

--- a/source/ada/lsp-ada_handlers.ads
+++ b/source/ada/lsp-ada_handlers.ads
@@ -19,6 +19,7 @@
 --  language.
 
 with Ada.Containers.Hashed_Maps;
+with Ada.Containers.Hashed_Sets;
 
 with GNATCOLL.VFS;    use GNATCOLL.VFS;
 with GNATCOLL.Projects;
@@ -80,6 +81,13 @@ private
       Element_Type    => Internal_Document_Access,
       Hash            => LSP.Types.Hash,
       Equivalent_Keys => LSP.Types."=");
+
+   --  Container for the predefined source files
+   package File_Sets is new Ada.Containers.Hashed_Sets
+     (Element_Type        => GNATCOLL.VFS.Virtual_File,
+      Hash                => GNATCOLL.VFS.Full_Name_Hash,
+      Equivalent_Elements => GNATCOLL.VFS."=",
+      "="                 => GNATCOLL.VFS."=");
 
    type Get_Symbol_Access is access procedure
      (Self     : LSP.Ada_Documents.Document;
@@ -148,6 +156,10 @@ private
 
       Project_Environment : GNATCOLL.Projects.Project_Environment_Access;
       --  The project environment for the currently loaded project
+
+      Project_Predefined_Sources : File_Sets.Set;
+      --  A cache for the predefined sources in the loaded project (typically,
+      --  runtime files).
 
       Get_Symbols : Get_Symbol_Access;
       --  textDocument/documentSymbol handler. Actual value depends on


### PR DESCRIPTION
The runtime files should be considered when considering
which contexts are appropriate for a given URI. Do this
by maintain a cache of runtime files.

This fixes requests such as 'called_by' when initiated from
the runtime.

NOTE: it's not possible to add a test in this repository in the
current architecture, since the location of runtime files is a
moving target. I will propose a test as part of GNAT Studio.