### PR TITLE
T130-026 When the project is implicit, load dirs on demand

### DIFF
--- a/source/ada/lsp-ada_handlers.ads
+++ b/source/ada/lsp-ada_handlers.ads
@@ -146,6 +146,14 @@ private
       Open_Documents : Document_Maps.Map;
       --  The documents that are currently open
 
+      Get_Symbols : Get_Symbol_Access;
+      --  textDocument/documentSymbol handler. Actual value depends on
+      --  client's capabilities.
+
+      ----------------------
+      -- Project handling --
+      ----------------------
+
       Project_Tree : GNATCOLL.Projects.Project_Tree_Access;
       --  The currently loaded project tree
 
@@ -156,9 +164,11 @@ private
       --  A cache for the predefined sources in the loaded project (typically,
       --  runtime files).
 
-      Get_Symbols : Get_Symbol_Access;
-      --  textDocument/documentSymbol handler. Actual value depends on
-      --  client's capabilities.
+      Implicit_Project_Loaded : Boolean := False;
+      --  Whether we are loading the implicit project
+
+      Project_Dirs_Loaded : LSP.Ada_Contexts.File_Sets.Set;
+      --  The directories to load in the "implicit project"
    end record;
 
    overriding procedure Before_Work


### PR DESCRIPTION
When the language server is loading an implicit project,
check whenever a new file is open: if it's in a directory that's
outside of the project, add it and reload the project.