### PR TITLE
T211-042: Increase the references array size for hierarchies

### DIFF
--- a/source/ada/lsp-ada_contexts.adb
+++ b/source/ada/lsp-ada_contexts.adb
@@ -328,7 +328,7 @@ package body LSP.Ada_Contexts is
         (Hierarchy : Basic_Decl_Array) return Base_Id_Array
       is
          References       : Base_Id_Array
-           (1 .. Hierarchy'Length * 2);
+           (1 .. Hierarchy'Length * 3);
          Subp_Body_Name   : Defining_Name;
          Subp_Body_Node   : Subp_Body;
          Last             : Positive := References'First;


### PR DESCRIPTION
We were multiplying by 2 in case there is a body for the
base/derived declaration, but in fact we are also adding
the end label when found, so we should multiply the resulting
array size by 3.