### PR TITLE
T114-020 add a valgrind exception, and increase timeout multiplier

### DIFF
--- a/testsuite/leaks.supp
+++ b/testsuite/leaks.supp
@@ -44,3 +44,19 @@
    fun:gpr__proc__recursive_process__process_aggregated_projects
 }
 
+### T114-020 leaks with extending project and custom renaming
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   fun:__gnat_malloc
+   fun:system__pool_global__allocate
+   fun:gpr__nmsc__add_source
+   fun:gpr__nmsc__check_file
+   fun:gpr__nmsc__search_directories__2
+   fun:gpr__nmsc__find_sources
+   fun:gpr__nmsc__look_for_sources
+   fun:gpr__nmsc__process_naming_scheme__check
+}
+

--- a/testsuite/testsuite.py
+++ b/testsuite/testsuite.py
@@ -84,7 +84,7 @@ class ALSTestsuite(Testsuite):
                 self.lookup_program("valgrind"),
                 " ".join(VALGRIND_OPTIONS).format(base=self.env.repo_base),
                 self.lookup_program('server', 'ada_language_server'))
-            self.env.wait_factor = 20  # valgrind is slow
+            self.env.wait_factor = 40  # valgrind is slow
         else:
             self.env.als = self.lookup_program('server', 'ada_language_server')
 


### PR DESCRIPTION
As discussed with the GPR team, the leak is inconsequential.

Increase the timeout multiplier in an effort to stabilize the
nightly runs.