### PR TITLE
Flatten syntax files

### DIFF
--- a/integration/vscode/ada/syntaxes/ada.tmLanguage.json
+++ b/integration/vscode/ada/syntaxes/ada.tmLanguage.json
@@ -22,45 +22,37 @@
 	],
 	"repository": {
 		"aggregate": {
-			"patterns": [
-				{
-					"name": "meta.aggregate.ada",
-					"begin": "\\(",
-					"end": "\\)",
-					"captures": {
-						"0": {
-							"patterns": [
-								{ "include": "#punctuation" }
-							]
-						}
-					},
-					"patterns": [
-						{ "include": "#argument" },
-						{ "include": "#attribute" },
-						{ "include": "#punctuation" }
-					]
-				}	
-			]
+         "name": "meta.aggregate.ada",
+         "begin": "\\(",
+         "end": "\\)",
+         "captures": {
+            "0": {
+               "patterns": [
+                  { "include": "#punctuation" }
+               ]
+            }
+         },
+         "patterns": [
+            { "include": "#argument" },
+            { "include": "#attribute" },
+            { "include": "#punctuation" }
+         ]
 		},
 		"arguments": {
-			"patterns": [
-				{
-					"name": "meta.arguments.ada",
-					"begin": "\\(",
-					"end": "\\)",
-					"captures": {
-						"0": {
-							"patterns": [
-								{ "include": "#punctuation" }
-							]
-						}
-					},
-					"patterns": [
-						{ "include": "#arguments" },
-						{ "include": "#argument" }
-					]
-				}
-			]
+         "name": "meta.arguments.ada",
+         "begin": "\\(",
+         "end": "\\)",
+         "captures": {
+            "0": {
+               "patterns": [
+                  { "include": "#punctuation" }
+               ]
+            }
+         },
+         "patterns": [
+            { "include": "#arguments" },
+            { "include": "#argument" }
+         ]
 		},
 		"argument": {
 			"patterns": [
@@ -274,35 +266,31 @@
 			]
 		},
 		"aspect": {
-			"patterns": [
-				{
-					"name": "meta.aspect.ada",
-					"begin": "\\bwith(?!\\s+(procedure|function))\\b",
-					"end": "(\\bis\\b|;)",
-					"captures": {
-						"0": {
-							"patterns": [
-								{ "include": "#keyword" }
-							]
-						}
-					},
-					"patterns": [
-						{ "include": "#comment" },
-						{
-							"name": "keyword.control.directive.ada",
-							"match": "(?i)\\b(address|alignment|all_calls_remote|asynchronous|atomic|atomic_components|attach_handler|bit_order|component_size|convention|constant_indexing|cpu|default_component_value|default_iterator|default_storage_pool|default_value|dispatching_domain|dynamic_predicate|elaborate_body|export|external_name|external_tag|implicit_dereference|import|independent|independent_components|inline|input|iterator_element|interrupt_handler|interrupt_priority|link_name|machine_radix|no_return|output|pack|post|pre|preelaborate|priority|pure|read|relative_deadline|remote_call_interface|remote_types|size|shared_passive|small|static_predicate|storage_size|storage_pool|stream_size|synchronization|type_invariant|unchecked_union|variable_indexing|volatile|volatile_components|write)\\b"
-						},
-						{
-							"name": "keyword.control.directive.ada",
-							"match": "(?i)\\b(ada_2005|ada_2012|favor_top_level|inline_always|object_size|persistent_bss|pure_function|remote_access_type|shared|suppress_debug_info|test_case|universal_aliasing|unmodified|unreferenced|unreferenced_objects|value_size|warnings)\\b"
-						},
-						{ "include": "#attribute" },
-						{ "include": "#keyword" },
-						{ "include": "#value" },
-						{ "include": "#punctuation" }
-					]
-				}
-			]
+         "name": "meta.aspect.ada",
+         "begin": "\\bwith(?!\\s+(procedure|function))\\b",
+         "end": "(\\bis\\b|;)",
+         "captures": {
+            "0": {
+               "patterns": [
+                  { "include": "#keyword" }
+               ]
+            }
+         },
+         "patterns": [
+            { "include": "#comment" },
+            {
+               "name": "keyword.control.directive.ada",
+               "match": "(?i)\\b(address|alignment|all_calls_remote|asynchronous|atomic|atomic_components|attach_handler|bit_order|component_size|convention|constant_indexing|cpu|default_component_value|default_iterator|default_storage_pool|default_value|dispatching_domain|dynamic_predicate|elaborate_body|export|external_name|external_tag|implicit_dereference|import|independent|independent_components|inline|input|iterator_element|interrupt_handler|interrupt_priority|link_name|machine_radix|no_return|output|pack|post|pre|preelaborate|priority|pure|read|relative_deadline|remote_call_interface|remote_types|size|shared_passive|small|static_predicate|storage_size|storage_pool|stream_size|synchronization|type_invariant|unchecked_union|variable_indexing|volatile|volatile_components|write)\\b"
+            },
+            {
+               "name": "keyword.control.directive.ada",
+               "match": "(?i)\\b(ada_2005|ada_2012|favor_top_level|inline_always|object_size|persistent_bss|pure_function|remote_access_type|shared|suppress_debug_info|test_case|universal_aliasing|unmodified|unreferenced|unreferenced_objects|value_size|warnings)\\b"
+            },
+            { "include": "#attribute" },
+            { "include": "#keyword" },
+            { "include": "#value" },
+            { "include": "#punctuation" }
+         ]
 		},
 		"assignment": {
 			"patterns": [
@@ -444,41 +432,37 @@
 			]
 		},
 		"case": {
-			"patterns": [
-				{
-					"name": "meta.control.case.ada",
-					"begin": "(?i)\\bcase\\s+(\\w|\\.|_)+\\s+is\\b",
-					"end": "(?i)\\bend\\s+case;",
-					"captures": {
-						"0": {
-							"patterns": [
-								{ "include": "#keyword" },
-								{ "include": "#punctuation" },
-								{
-									"name": "variable.name.ada",
-									"match": "\\b(\\w|\\.|_)+\\b"
-								}
-							]
-						}
-					},
-					"patterns": [
-						{
-							"name": "meta.control.case.when.ada",
-							"match": "(?i)\\bwhen\\s+((\\w|_)+\\s*\\|\\s*)*(\\w|_)+\\s*=>",
-							"captures": {
-								"0": {
-									"patterns": [
-										{ "include": "#keyword" },
-										{ "include": "#punctuation" }
-									]
-								}
-							}
-						},
-						{ "include": "#property" },
-						{ "include": "#punctuation" }
-					]
-				}
-			]
+         "name": "meta.control.case.ada",
+         "begin": "(?i)\\bcase\\s+(\\w|\\.|_)+\\s+is\\b",
+         "end": "(?i)\\bend\\s+case;",
+         "captures": {
+            "0": {
+               "patterns": [
+                  { "include": "#keyword" },
+                  { "include": "#punctuation" },
+                  {
+                     "name": "variable.name.ada",
+                     "match": "\\b(\\w|\\.|_)+\\b"
+                  }
+               ]
+            }
+         },
+         "patterns": [
+            {
+               "name": "meta.control.case.when.ada",
+               "match": "(?i)\\bwhen\\s+((\\w|_)+\\s*\\|\\s*)*(\\w|_)+\\s*=>",
+               "captures": {
+                  "0": {
+                     "patterns": [
+                        { "include": "#keyword" },
+                        { "include": "#punctuation" }
+                     ]
+                  }
+               }
+            },
+            { "include": "#property" },
+            { "include": "#punctuation" }
+         ]
 		},
 		"comment": {
 			"patterns": [
@@ -630,27 +614,23 @@
 			]
 		},
 		"goto": {
-			"patterns": [
-				{
-					"name": "meta.goto.ada",
-					"match": "(?i)\\bgoto\\s+(\\w|_)+;",
-					"captures": {
-						"0": {
-							"patterns": [
-								{ "include": "#punctuation" },
-								{
-									"name": "keyword.control.goto.ada",
-									"match": "(?i)\\bgoto\\b"
-								},
-								{
-									"name": "entity.name.label.ada",
-									"match": "\\b(\\w|_)+\\b"
-								}
-							]
-						}
-					}
-				}
-			]
+         "name": "meta.goto.ada",
+         "match": "(?i)\\bgoto\\s+(\\w|_)+;",
+         "captures": {
+            "0": {
+               "patterns": [
+                  { "include": "#punctuation" },
+                  {
+                     "name": "keyword.control.goto.ada",
+                     "match": "(?i)\\bgoto\\b"
+                  },
+                  {
+                     "name": "entity.name.label.ada",
+                     "match": "\\b(\\w|_)+\\b"
+                  }
+               ]
+            }
+         }
 		},
 		"import": {
 			"patterns": [
@@ -721,26 +701,22 @@
 			]
 		},
 		"label": {
-			"patterns": [
-				{
-					"name": "meta.label.ada",
-					"match": "<<(\\w|_)+>>",
-					"captures": {
-						"0": {
-							"patterns": [
-								{
-									"name": "punctuation.label.ada",
-									"match": "(<<|>>)"
-								},
-								{
-									"name": "entity.name.label.ada",
-									"match": "\\b(\\w|_)+\\b"
-								}
-							]
-						}
-					}
-				}
-			]
+         "name": "meta.label.ada",
+         "match": "<<(\\w|_)+>>",
+         "captures": {
+            "0": {
+               "patterns": [
+                  {
+                     "name": "punctuation.label.ada",
+                     "match": "(<<|>>)"
+                  },
+                  {
+                     "name": "entity.name.label.ada",
+                     "match": "\\b(\\w|_)+\\b"
+                  }
+               ]
+            }
+         }
 		},
 		"pragma": {
 			"name": "meta.pragma.ada",
@@ -876,39 +852,35 @@
 		},
         "punctuation": {
             "patterns": [
-                {
-                    "name": "punctuation.delimiter.ada",
-                    "match": "(=>|\\||'|[()]|\\.|,)"
-                },
-				{
-					"name": "punctuation.underline.ada",
-					"match": "_"
-				},
-                {
-                    "name": "punctuation.terminator.ada",
-                    "match": ";"
-				}
+               {
+                  "name": "punctuation.delimiter.ada",
+                  "match": "(=>|\\||'|[()]|\\.|,)"
+               },
+               {
+                  "name": "punctuation.underline.ada",
+                  "match": "_"
+               },
+               {
+                  "name": "punctuation.terminator.ada",
+                  "match": ";"
+               }
             ]
 		},
 		"return": {
-			"patterns": [
-				{
-					"name": "meta.return-block.ada",
-					"begin": "(?i)\\breturn\\s+(\\w|\\.|_)+\\s*:\\s*(\\w|\\.|_)+\\s+do\\b",
-					"end": "(?i)\\bend\\s+return;?",
-					"captures": {
-						"0": {
-							"patterns": [
-								{ "include": "#argument" },
-								{ "include": "#keyword" }
-							]
-						}
-					},
-					"patterns": [
-						{ "include": "#keyword" }
-					]
-				}
-			]
+         "name": "meta.return-block.ada",
+         "begin": "(?i)\\breturn\\s+(\\w|\\.|_)+\\s*:\\s*(\\w|\\.|_)+\\s+do\\b",
+         "end": "(?i)\\bend\\s+return;?",
+         "captures": {
+            "0": {
+               "patterns": [
+                  { "include": "#argument" },
+                  { "include": "#keyword" }
+               ]
+            }
+         },
+         "patterns": [
+            { "include": "#keyword" }
+         ]
 		},
 		"subroutine": {
 			"patterns": [
@@ -1030,7 +1002,7 @@
 								}
 							]
 						}
-					}	
+					}
 				},
 				{
 					"name": "meta.instantiation.ada",
@@ -1148,7 +1120,7 @@
 								}
 							]
 						}
-					}	
+					}
 				},
 				{
 					"name": "meta.operator.instantiation.ada",

--- a/integration/vscode/ada/syntaxes/ada.tmLanguage.json
+++ b/integration/vscode/ada/syntaxes/ada.tmLanguage.json
@@ -399,18 +399,7 @@
          "match": "(')((?:\\w|\\d|_)+)\\b",
          "captures": {
             "1": { "name": "punctuation.ada" },
-            "2": {
-               "patterns": [
-                  {
-                     "name": "invalid.deprecated.ada",
-                     "match": "(?i)(?:emax|epsilon|large|mantissa|safe_emax|safe_large|safe_small)"
-                  },
-                  {
-                     "name": "entity.other.attribute-name.ada",
-                     "match": "\\b(\\w|\\d|_)+\\b"
-                  }
-               ]
-            }
+            "2": { "name": "entity.other.attribute-name.ada" }
          }
 		},
 		"case": {

--- a/integration/vscode/ada/syntaxes/ada.tmLanguage.json
+++ b/integration/vscode/ada/syntaxes/ada.tmLanguage.json
@@ -466,56 +466,32 @@
 		},
 		"comment": {
 			"patterns": [
-				{
-					"name": "comment.line.double-dash.ada",
-					"match": "--[^-]+--\\s*$",
-					"captures": {
-						"0": {
-							"patterns": [
-								{
-									"name": "entity.name.section",
-									"match": "[^-]+"
-								}
-							]
-						}
-					}
-				},
-				{
-					"name": "comment.line.double-dash.ada",
-					"match": "--.*$",
-					"captures": {
-						"0": {
-							"patterns": [
-								{
-									"name": "comment.block.documentation.gnatdoc",
-									"match": "@.*$",
-									"captures": {
-										"0": {
-											"patterns": [
-												{
-													"name": "entity.name.tag.gnatdoc",
-													"match": "@\\w+",
-													"captures": {
-														"0": {
-															"patterns": [
-																{
-																	"name": "punctuation.definition.tag.gnatdoc",
-																	"match": "@"
-																}
-															]
-														}
-													}
-												}
-											]
-										}
-									}
-								}
-							]
-						}
-					}
-				}
+            { "include": "#comment-section" },
+            { "include": "#comment-doc" },
+            { "include": "#comment-line" }
 			]
-		},
+      },
+      "comment-doc": {
+         "name": "comment.block.documentation.gnatdoc",
+         "match": "(--)(@)(\\w+)\\s+(.*)$",
+         "captures": {
+            "1": { "name": "comment.line.double-dash.ada" },
+            "2": { "name": "punctuation.definition.tag.gnatdoc" },
+            "3": { "name": "entity.name.tag.gnatdoc" },
+            "4": { "name": "comment.line.double-dash.ada" }
+         }
+      },
+      "comment-line": {
+         "name": "comment.line.double-dash.ada",
+         "match": "--.*$"
+      },
+      "comment-section": {
+         "name": "comment.line.double-dash.ada",
+         "match": "--\\s*((?:\\w|\\d|\\.|_)+)\\s*--$",
+         "captures": {
+            "1": { "name": "entity.name.section.ada" }
+         }
+      },
 		"discriminant": {
 			"patterns": [
 				{

--- a/integration/vscode/ada/syntaxes/ada.tmLanguage.json
+++ b/integration/vscode/ada/syntaxes/ada.tmLanguage.json
@@ -267,14 +267,14 @@
 		},
 		"aspect": {
          "name": "meta.aspect.ada",
-         "begin": "\\bwith(?!\\s+(procedure|function))\\b",
-         "end": "(\\bis\\b|;)",
-         "captures": {
-            "0": {
-               "patterns": [
-                  { "include": "#keyword" }
-               ]
-            }
+         "begin": "(?i)\\b(with)(?!\\s+(procedure|function))\\b",
+         "end": "(?i)(?:\\b(is)\\b|(;))",
+         "beginCaptures": {
+            "1": { "name": "keyword.ada" }
+         },
+         "endCaptures": {
+            "1": { "name": "keyword.ada" },
+            "2": { "name": "punctuation.ada" }
          },
          "patterns": [
             { "include": "#comment" },

--- a/integration/vscode/ada/syntaxes/ada.tmLanguage.json
+++ b/integration/vscode/ada/syntaxes/ada.tmLanguage.json
@@ -395,41 +395,23 @@
 			]
 		},
 		"attribute": {
-			"patterns": [
-				{
-					"name": "entity.other.attribute-name.ada",
-					"match": "(?i)'(access|address|adjacent|aft|alignment|base|bit_order|body_version|callable|caller|ceiling|class|component_size|compose|constrained|copy_sign|count|definite|delta|denorm|digits|exponent|external_tag|first|first_bit|floor|fore|fraction|identity|image|input|last|last_bit|leading_part|length|machine|machine_emax|machine_emin|machine_mantissa|machine_overflows|machine_radix|machine_rounding|machine_rounds|max|max_alignment_for_allocation|max_size_in_storage_elements|min|mod|model|model_emin|model_epsilon|model_mantissa|model_small|modulus|old|output|overlaps_storage|partition_id|pos|position|pred|priority|range|read|remainder|result|round|rounding|safe_first|safe_last|scale|scaling|signed_zeros|size|small|storage_pool|storage_size|stream_size|succ|tag|terminated|truncation|unbiased_rounding|unchecked_access|val|valid|value|version|wide_image|wide_value|wide_wide_image|wide_wide_value|wide_wide_width|wide_width|width|write)\\b",
-					"captures": {
-						"0": {
-							"patterns": [
-								{ "include": "#punctuation" }
-							]
-						}
-					}
-				},
-				{
-					"name": "entity.other.attribute-name.ada",
-					"match": "(?i)'(abort_signal|address_size|asm_input|asm_output|ast_entry|bit|bit_position|code_address|default_bit_order|elaborated|elab_body|elab_spec|emax|enabled|enum_rep|enum_val|epsilon|fixed_value|has_access_values|has_discriminants|img|integer_value|invalid_value|machine_size|max_interrupt_priority|max_priority|maximum_alignment|machanism_code|null_parameter|object_size|old|passed_by_reference|pool_address|range_length|storage_unit|stub_type|target_name|tick|to_address|type_class|uet_address|unconstrained_array|universal_literal_string|unrestricted_access|vads_size|value_size|wchar_t_size|word_size)\\b",
-					"captures": {
-						"0": {
-							"patterns": [
-								{ "include": "#punctuation" }
-							]
-						}
-					}
-				},
-				{
-					"name": "invalid.deprecated.ada",
-					"match": "(?i)'(emax|epsilon|large|mantissa|safe_emax|safe_large|safe_small)\\b",
-					"captures": {
-						"0": {
-							"patterns": [
-								{ "include": "#punctuation" }
-							]
-						}
-					}
-				}
-			]
+         "name": "meta.attribute.ada",
+         "match": "(')((?:\\w|\\d|_)+)\\b",
+         "captures": {
+            "1": { "name": "punctuation.ada" },
+            "2": {
+               "patterns": [
+                  {
+                     "name": "invalid.deprecated.ada",
+                     "match": "(?i)(?:emax|epsilon|large|mantissa|safe_emax|safe_large|safe_small)"
+                  },
+                  {
+                     "name": "entity.other.attribute-name.ada",
+                     "match": "\\b(\\w|\\d|_)+\\b"
+                  }
+               ]
+            }
+         }
 		},
 		"case": {
          "name": "meta.control.case.ada",

--- a/integration/vscode/ada/syntaxes/ada.tmLanguage.json
+++ b/integration/vscode/ada/syntaxes/ada.tmLanguage.json
@@ -659,33 +659,17 @@
 		},
 		"pragma": {
 			"name": "meta.pragma.ada",
-			"begin": "pragma",
-			"end": ";",
-			"captures": {
-				"0": {
-					"patterns": [
-						{ "include": "#keyword" }
-					]
-				}
-			},
+			"begin": "(?i)\\b(pragma)\\s+((?:\\w|\\d|_)+)\\b",
+         "end": "(;)",
+         "beginCaptures": {
+            "1": { "name": "keyword.ada" },
+            "2": { "name": "keyword.control.directive.ada" }
+         },
+         "endCaptures": {
+            "1": { "name": "punctuation.ada" }
+         },
 			"patterns": [
-				{ "include": "#arguments" },
-				{
-					"name": "keyword.control.directive.ada",
-					"match": "(?i)\\b(all_calls_remote|assert|assertion_policy|cpu|default_storage_pool|detect_blocking|discard_names|dispatching_domain|elaborate|elaborate_all|elaborate_body|independent|independent_component|inspection_point|linker_options|list|locking_policy|normalize_scalars|optimize|page|partial_elaboration_policy|preelaborable_initialization|preelaborate|priority_specific_dispatching|profile|pure|queueing_policy|relative_deadline|remote_call_interface|remote_types|restrictions|reviewable|shared_passive|storage_size|suppress|task_dispatching_policy|unchecked_union|unsuppress|volatile|volatile_components)\\b"
-				},
-                {
-                    "name": "keyword.control.directive.ada",
-                    "match": "(?i)\\b(abort_defer|ada_83|ada_95|ada_05|ada_2005|ada_12|ada_2012|annotate|assume_no_invalid_values|ast_entry|c_pass_by_copy|canonical_streams|check|check_name|check_policy|comment|common_object|compile_time_error|compile_time_warning|complete_representation|complex_representation|component_alignment|convention_identifier|cpp_class|cpp_constructor|cpp_virtual|cpp_vtable|debug|debug_policy|elaboration_checks|eliminate|export_exception|export_function|export_object|export_procedure|export_value|export_valued_procedure|extend_system|extensions_allowed|external|external_name_casing|fast_math|favor_top_level|finalize_storage_only|float_representation|ident|implemented|implicit_packing|import_exception|import_function|import_object|import_procedure|import_valued_procedure|initialize_scalars|inline_always|inline_generic|interface_name|interrupt_state|invariant|keep_names|license|link_with|linker_alias|linker_constructor|linker_destructor|linker_section|long_float|machine_attribute|main|main_storage|no_body|no_strict_aliasing|obsolescent|optimize_alignment|ordered|passive|persistent_bss|polling|postcondition|precondition|profile_warnings|propagate_exceptions|psect_object|pure_function|restriction_warnings|share_generic|short_circuit_and_or|short_descriptors|simple_storage_pool_type|source_file_name|source_file_name_project|source_reference|static_elaboration_desired|stream_convert|style_checks|subtitle|suppress_all|suppress_exception_locations|suppress_initialization|task_info|task_name|task_storage|test_case|thread_body|thread_local_storage|time_slice|title|unimplemented_unit|universal_aliasing|universal_data|unmodified|unreferenced|unreferenced_objects|unreserve_all_interrupts|use_vads_size|validity_checks|warnings|weak_external|wide_character_encoding)\\b"
-				},
-                {
-                    "name": "invalid.deprecated.ada",
-                    "match": "(?i)\\b(asynchronous|atomic|atomic_components|attach_handler|controlled|convention|export|import|inline|interface|interrupt_handler|interrupt_priority|memory_size|no_return|pack|priority|shared|storage_unit|system_name)\\b"
-                },
-                {
-                    "name": "invalid.illegal.ada",
-                    "match": "\\b(\\w|_)+\\b"
-                }
+				{ "include": "#arguments" }
 			]
 		},
 		"property": {

--- a/integration/vscode/ada/syntaxes/ada.tmLanguage.json
+++ b/integration/vscode/ada/syntaxes/ada.tmLanguage.json
@@ -572,22 +572,12 @@
 			]
 		},
 		"goto": {
-         "name": "meta.goto.ada",
-         "match": "(?i)\\bgoto\\s+(\\w|_)+;",
+         "name": "meta.statement.goto.ada",
+         "match": "(?i)\\b(goto)\\s+((?:\\w|\\d|_)+)\\s*(;)",
          "captures": {
-            "0": {
-               "patterns": [
-                  { "include": "#punctuation" },
-                  {
-                     "name": "keyword.control.goto.ada",
-                     "match": "(?i)\\bgoto\\b"
-                  },
-                  {
-                     "name": "entity.name.label.ada",
-                     "match": "\\b(\\w|_)+\\b"
-                  }
-               ]
-            }
+            "1": { "name": "keyword.control.goto.ada" },
+            "2": { "name": "entity.name.label.ada" },
+            "3": { "name": "punctuation.ada" }
          }
 		},
 		"import": {

--- a/integration/vscode/ada/syntaxes/ada.tmLanguage.json
+++ b/integration/vscode/ada/syntaxes/ada.tmLanguage.json
@@ -650,20 +650,11 @@
 		},
 		"label": {
          "name": "meta.label.ada",
-         "match": "<<(\\w|_)+>>",
+         "match": "(<<)((?:\\w|\\d|_)+)(>>)",
          "captures": {
-            "0": {
-               "patterns": [
-                  {
-                     "name": "punctuation.label.ada",
-                     "match": "(<<|>>)"
-                  },
-                  {
-                     "name": "entity.name.label.ada",
-                     "match": "\\b(\\w|_)+\\b"
-                  }
-               ]
-            }
+            "1": { "name": "punctuation.label.ada" },
+            "2": { "name": "entity.name.label.ada" },
+            "3": { "name": "punctuation.label.ada" }
          }
 		},
 		"pragma": {

--- a/integration/vscode/ada/syntaxes/ali.tmLanguage.json
+++ b/integration/vscode/ada/syntaxes/ali.tmLanguage.json
@@ -2,347 +2,183 @@
 	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
 	"name": "ALI",
 	"patterns": [
-		{ "include": "#version" },
-		{ "include": "#mainprogram" },
-		{ "include": "#arguments" },
-		{ "include": "#program" },
-		{ "include": "#restriction" },
-		{ "include": "#unit" },
-		{ "include": "#with" },
-		{ "include": "#external" },
-		{ "include": "#dependency" },
-		{ "include": "#reference" },
-		{ "include": "#dispatching" },
-		{ "include": "#limitedwith" },
-		{ "include": "#implicitwith" },
-		{ "include": "#sco" },
-		{ "include": "#sparkcrossreference" },
-		{ "include": "#taskstackinfo" }
+      { "include": "#line" }
 	],
 	"repository": {
+      "line": {
+         "patterns": [
+            { "include": "#version" },
+            { "include": "#mainprogram" },
+            { "include": "#arguments" },
+            { "include": "#program" },
+            { "include": "#restriction" },
+            { "include": "#unit" },
+            { "include": "#with" },
+            { "include": "#external" },
+            { "include": "#dependency" },
+            { "include": "#reference" },
+            { "include": "#dispatching" },
+            { "include": "#limitedwith" },
+            { "include": "#implicitwith" },
+            { "include": "#sco" },
+            { "include": "#sparkcrossreference" },
+            { "include": "#taskstackinfo" }
+         ]
+      },
 		"version": {
-			"patterns": [
-				{
-					"name": "version.ali",
-					"match": "^V.*$",
-					"captures": {
-						"0": {
-							"patterns": [
-								{
-									"name": "keyword.control.ali",
-									"match": "V"
-								},
-								{
-									"name": "constant.ali",
-									"match": ".*"
-								}
-							]
-						}
-					}
-				}
-			]
+         "name": "version.ali",
+         "match": "^(V)(.*)$",
+         "captures": {
+            "1": { "name": "keyword.control.ali" },
+            "2": { "name": "string.quoted.double.ali" }
+         }
 		},
 		"mainprogram": {
-			"patterns": [
-				{
-					"name": "mainprogram.ali",
-					"match": "^M.*$",
-					"captures": {
-						"0": {
-							"patterns": [
-								{
-									"name": "keyword.control.ali",
-									"match": "^M"
-								},
-								{
-									"name": "constant.ali",
-									"match": ".*"
-								}
-							]
-						}
-					}
-				}
-			]
+         "name": "mainprogram.ali",
+         "match": "^(M)(.*)$",
+         "captures": {
+            "1": { "name": "keyword.control.ali" },
+            "2": { "name": "constant.ali" }
+         }
 		},
 		"arguments": {
-			"patterns": [
-				{
-					"name": "argument.ali",
-					"match": "^A.*$",
-					"captures": {
-						"0": {
-							"patterns": [
-								{
-									"name": "entity.other.attribute-name.ali",
-									"match": "-\\S+\\b"
-								},
-								{
-									"name": "keyword.control.ali",
-									"match": "^A"
-								}
-							]
-						}
-					}
-				}
-			]
+         "name": "argument.ali",
+         "match": "^(A)(.*)$",
+         "captures": {
+            "1": { "name": "keyword.control.ali" },
+            "2": {
+               "patterns": [
+                  {
+                     "name": "entity.other.attribute-name.ali",
+                     "match": "-\\S+\\b"
+                  }
+               ]
+            }
+         }
 		},
 		"program": {
-			"patterns": [
-				{
-					"name": "program.ali",
-					"match": "^P.*$",
-					"captures": {
-						"0": {
-							"patterns": [
-								{
-									"name": "keyword.control.ali",
-									"match": "^P"
-								}
-							]
-						}
-					}
-				}
-			]
+         "name": "program.ali",
+         "match": "^(P)(.*)$",
+         "captures": {
+            "1": { "name": "keyword.control.ali" }
+         }
 		},
 		"restriction": {
-			"patterns": [
-				{
-					"name": "restriction.ali",
-					"match": "^R.*$",
-					"captures": {
-						"0": {
-							"patterns": [
-								{
-									"name": "keyword.control.ali",
-									"match": "^R\\w"
-								},
-								{
-									"name": "keyword.control.directive.ali",
-									"match": "(\\w|_)+"
-								}
-							]
-						}
-					}
-				}
-			]
+         "name": "restriction.ali",
+         "match": "^(R\\w?)(.*)$",
+         "captures": {
+            "1": { "name": "keyword.control.ali" },
+            "2": { "name": "keyword.control.directive.ali" }
+         }
 		},
 		"unit": {
-			"patterns": [
-				{
-					"name": "unit.ali",
-					"match": "^U.*$",
-					"captures": {
-						"0": {
-							"patterns": [
-								{
-									"name": "keyword.control.ali",
-									"match": "^U"
-								}
-							]
-						}
-					}
-				}
-			]
+         "name": "unit.ali",
+         "match": "^(U)(.*)$",
+         "captures": {
+            "1": { "name": "keyword.control.ali" }
+         }
 		},
 		"with": {
-			"patterns": [
-				{
-					"name": "with.ali",
-					"match": "^W.*$",
-					"captures": {
-						"0": {
-							"patterns": [
-								{
-									"name": "keyword.control.ali",
-									"match": "^W"
-								},
-								{
-									"name": "entity.name.package.ali",
-									"match": "(\\w|\\.|-)+%[bs]"
-								}
-							]
-						}
-					}
-				}
-			]
+         "name": "with.ali",
+         "match": "^(W)(.*)$",
+         "captures": {
+            "1": { "name": "keyword.control.ali" },
+            "2": {
+               "patterns": [
+                  {
+                     "name": "entity.name.package.ali",
+                     "match": "(\\w|\\d|\\.|_)+%[bs]"
+                  }
+               ]
+            }
+         }
 		},
 		"external": {
-			"patterns": [
-				{
-					"name": "external.ali",
-					"match": "^E.*$",
-					"captures": {
-						"0": {
-							"patterns": [
-								{
-									"name": "keyword.control.ali",
-									"match": "^E"
-								}
-							]
-						}
-					}
-				}
-			]
+         "name": "external.ali",
+         "match": "^(E)(.*)$",
+         "captures": {
+            "1": { "name": "keyword.control.ali" }
+         }
 		},
 		"dependency": {
-			"patterns": [
-				{
-					"name": "dependency.ali",
-					"match": "^D.*$",
-					"captures": {
-						"0": {
-							"patterns": [
-								{
-									"name": "keyword.control.ali",
-									"match": "^D"
-								},
-								{
-									"name": "entity.name.package.ali",
-									"match": "(\\w|\\.|-)+%[bs]"
-								},
-								{
-									"name": "constant.numeric.ali",
-									"match": "\\b\\h+\\b"
-								}
-							]
-						}
-					}
-				}
-			]
+         "name": "dependency.ali",
+         "match": "^(D)(.*)$",
+         "captures": {
+            "1": { "name": "keyword.control.ali" },
+            "2": {
+               "patterns": [
+                  {
+                     "name": "entity.name.package.ali",
+                     "match": "(\\w|\\.|-)+%[bs]"
+                  },
+                  {
+                     "name": "constant.numeric.ali",
+                     "match": "\\b\\h+\\b"
+                  }
+               ]
+            }
+         }
 		},
 		"reference": {
-			"patterns": [
-				{
-					"name": "reference.ali",
-					"match": "^X.*$",
-					"captures": {
-						"0": {
-							"patterns": [
-								{
-									"name": "keyword.control.ali",
-									"match": "^X"
-								},
-								{
-									"name": "variable.name.ali",
-									"match": "\\b\\w+\\.\\w+\\b"
-								},
-								{
-									"name": "constant.numeric.ali",
-									"match": "\\d+"
-								}
-							]
-						}
-					}
-				}
-			]
+         "name": "reference.ali",
+         "match": "^(X)(.*)$",
+         "captures": {
+            "1": { "name": "keyword.control.ali" },
+            "2": {
+               "patterns": [
+                  {
+                     "name": "variable.name.ali",
+                     "match": "\\b\\w+\\.\\w+\\b"
+                  },
+                  {
+                     "name": "constant.numeric.ali",
+                     "match": "\\d+"
+                  }
+               ]
+            }
+         }
 		},
 		"dispatching": {
-			"patterns": [
-				{
-					"name": "dispatching.ali",
-					"match": "^S.*$",
-					"captures": {
-						"0": {
-							"patterns": [
-								{
-									"name": "keyword.control.ali",
-									"match": "^S"
-								}
-							]
-						}
-					}
-				}
-			]
+         "name": "dispatching.ali",
+         "match": "^(S)(.*)$",
+         "captures": {
+            "1": { "name": "keyword.control.ali" }
+         }
 		},
 		"limitedwith": {
-			"patterns": [
-				{
-					"name": "limitedwith.ali",
-					"match": "^Y.*$",
-					"captures": {
-						"0": {
-							"patterns": [
-								{
-									"name": "keyword.control.ali",
-									"match": "^Y"
-								}
-							]
-						}
-					}
-				}
-			]
+         "name": "limitedwith.ali",
+         "match": "^(Y)(.*)$",
+         "captures": {
+            "1": { "name": "keyword.control.ali" }
+         }
 		},
 		"implicitwith": {
-			"patterns": [
-				{
-					"name": "implicitwith.ali",
-					"match": "^Z.*$",
-					"captures": {
-						"0": {
-							"patterns": [
-								{
-									"name": "keyword.control.ali",
-									"match": "^Z"
-								}
-							]
-						}
-					}
-				}
-			]
+         "name": "implicitwith.ali",
+         "match": "^(Z)(.*)$",
+         "captures": {
+            "1": { "name": "keyword.control.ali" }
+         }
 		},
 		"sco": {
-			"patterns": [
-				{
-					"name": "sco.ali",
-					"match": "^C.*$",
-					"captures": {
-						"0": {
-							"patterns": [
-								{
-									"name": "keyword.control.ali",
-									"match": "^C"
-								}
-							]
-						}
-					}
-				}
-			]
+         "name": "sco.ali",
+         "match": "^(C)(.*)$",
+         "captures": {
+            "1": { "name": "keyword.control.ali" }
+         }
 		},
 		"sparkcrossreference": {
-			"patterns": [
-				{
-					"name": "sparkcrossreference.ali",
-					"match": "^F.*$",
-					"captures": {
-						"0": {
-							"patterns": [
-								{
-									"name": "keyword.control.ali",
-									"match": "^F"
-								}
-							]
-						}
-					}
-				}
-			]
+         "name": "sparkcrossreference.ali",
+         "match": "^(F)(.*)$",
+         "captures": {
+            "1": { "name": "keyword.control.ali" }
+         }
 		},
 		"taskstackinfo": {
-			"patterns": [
-				{
-					"name": "taskstackinfo.ali",
-					"match": "^T.*$",
-					"captures": {
-						"0": {
-							"patterns": [
-								{
-									"name": "keyword.control.ali",
-									"match": "^T"
-								}
-							]
-						}
-					}
-				}
-			]
+         "name": "taskstackinfo.ali",
+         "match": "^(T)(.*)$",
+         "captures": {
+            "1": { "name": "keyword.control.ali" }
+         }
 		}
 	},
 	"scopeName": "source.ali"

--- a/integration/vscode/ada/syntaxes/gpr.tmLanguage.json
+++ b/integration/vscode/ada/syntaxes/gpr.tmLanguage.json
@@ -2,47 +2,40 @@
     "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
     "name": "gpr",
     "patterns": [
-        { "include": "#comment" },
-        { "include": "#package" },
-        { "include": "#attribute" },
-        { "include": "#keyword" },
-        { "include": "#value" }
+        { "include": "#project" },
+        { "include": "#comment" }
     ],
     "repository": {
         "attribute": {
+            "name": "meta.attribute.gpr",
+            "begin": "(?i)\\b(for)\\s+((?:\\w|_)+)(?:\\s*\\((.*)\\))?\\s+(use)\\b",
+            "end": ";",
+            "beginCaptures": {
+               "1": { "name": "keyword.gpr" },
+               "2": { "name": "entity.other.attribute-name.gpr" },
+               "3": { "name": "string.quoted.gpr" },
+               "4": { "name": "keyword.gpr" }
+            },
+            "endCaptures": {
+               "0": { "name": "punctuation.gpr" }
+            },
             "patterns": [
-                {
-                    "name": "meta.attribute.gpr",
-                    "begin": "\\bfor\\s+(\\w|_)+(\\s*\\(.*\\))?\\s+use\\b",
-                    "end": ";",
-                    "captures": {
-                        "0": {
-                            "patterns": [
-                                { "include": "#keyword" },
-                                { "include": "#value" },
-                                {
-                                    "name": "entity.other.attribute-name",
-                                    "match": "\\b(\\w|_)+\\b"
-                                }
-                            ]
-                        }
-                    },
-                    "patterns": [
-                        { "include": "#value" }
-                    ]
-                }
+               {
+                  "name": "string.quoted.gpr",
+                  "match": "\"(\\\\.|[^\"])*\""
+               }
             ]
         },
         "comment": {
             "patterns": [
                 {
-                    "name": "comment.line.double-dash.ada",
+                    "name": "comment.line.double-dash.gpr",
                     "match": "--[^-]+--\\s*$",
                     "captures": {
                         "0": {
                             "patterns": [
                                 {
-                                    "name": "entity.name.section",
+                                    "name": "entity.name.section.gpr",
                                     "match": "\\b(\\w|\\s|_)*\\b"
                                 }
                             ]
@@ -50,54 +43,48 @@
                     }
                 },
                 {
-                    "name": "comment.line.double-dash.ada",
+                    "name": "comment.line.double-dash.gpr",
                     "match": "--.*$"
                 }
             ]
         },
-        "keyword": {
-            "patterns": [
-                {
-                    "name": "keyword.gpr",
-                    "match": "(?i)\\b(abstract|aggregate|all|at|case|end|extends|external|external_as_list|for|is|library|limited|null|others|package|project|renames|type|use|when|with)\\b"
-                }
-            ]
-        },
         "package": {
+            "name": "meta.package.gpr",
+            "begin": "(?i)\\b(package)\\s+((?:\\w|\\d|_)+)\\s+(is)\\b",
+            "end": "(?i)\\b(end)\\s+(\\2)\\s*(;)",
+            "beginCaptures": {
+               "1": { "name": "keyword.gpr" },
+               "2": { "name": "entity.name.package.gpr" },
+               "3": { "name": "keyword.gpr" }
+            },
+            "endCaptures": {
+               "1": { "name": "keyword.gpr" },
+               "2": { "name": "entity.name.package.gpr" },
+               "3": { "name": "punctuation.gpr" }
+            },
             "patterns": [
-                {
-                    "name": "meta.package.gpr",
-                    "begin": "(?i)\\bpackage\\s+(\\w|_)+\\s+is\\b",
-                    "end": "(?i)\\bend\\s+(\\w|_)+\\b",
-                    "captures": {
-                        "0": {
-                            "patterns": [
-                                { "include": "#keyword" },
-                                {
-                                    "name": "entity.name.package.gpr",
-                                    "match": "\\b(\\w|_)+\\b"
-                                }
-                            ]
-                        }
-                    },
-                    "patterns": [
-                        { "include": "#comment" },
-                        { "include": "#attribute" }
-                    ]
-                }
+               { "include": "#comment" },
+               { "include": "#attribute" }
             ]
         },
-        "value": {
+        "project": {
+            "name": "meta.project.gpr",
+            "begin": "(?i)\\b(?:(abstract|aggregate|library)\\s+)?(project)\\s+((?:\\w|\\d|_)+)\\s+(is)\\b",
+            "end": "(?i)\\b(end)\\s+(\\3)\\s*(;)",
+            "beginCaptures": {
+               "1": { "name": "keyword.gpr" },
+               "2": { "name": "keyword.gpr" },
+               "3": { "name": "entity.name.project.gpr" },
+               "4": { "name": "keyword.gpr" }
+            },
+            "endCaptures": {
+               "1": { "name": "keyword.gpr" },
+               "3": { "name": "punctuation.gpr" }
+            },
             "patterns": [
-                {
-                    "name": "string.quoted.single.gpr",
-                    "match": "'.'"
-                },
-                {
-                    "name": "string.quoted.double.gpr",
-                    "begin": "\"",
-                    "end": "\""
-                }
+               { "include": "#package" },
+               { "include": "#comment" },
+               { "include": "#attribute" }
             ]
         }
     },


### PR DESCRIPTION
I've flattened the syntax files for ALI/GPR completely. The Ada syntax files have been partially flattened, with the remaining components being easier to tackle through a bottom-up rewrite of those parts.