### PR TITLE
Fixes type names for certain themes

### DIFF
--- a/integration/vscode/ada/syntaxes/ada.tmLanguage.json
+++ b/integration/vscode/ada/syntaxes/ada.tmLanguage.json
@@ -144,10 +144,7 @@
 												{ "include": "#attribute" },
 												{ "include": "#keyword" },
 												{ "include": "#punctuation" },
-												{
-													"name": "storage.type.ada",
-													"match": "\\b(\\w|\\.|_)+\\b"
-												}
+												{ "include": "#subtype_mark" }
 											]
 										}
 									}
@@ -195,10 +192,7 @@
 												{ "include": "#attribute" },
 												{ "include": "#keyword" },
 												{ "include": "#punctuation" },
-												{
-													"name": "storage.type.ada",
-													"match": "\\b(\\w|\\.|_)+\\b"
-												}
+												{ "include": "#subtype_mark" }
 											]
 										}
 									}
@@ -308,10 +302,7 @@
 											"patterns": [
 												{ "include": "#attribute" },
 												{ "include": "#keyword" },
-												{
-													"name": "storage.type.ada",
-													"match": "\\b(\\w|\\.|_)+\\b"
-												}
+												{ "include": "#subtype_mark" }
 											]
 										}
 									}
@@ -357,10 +348,7 @@
 											"patterns": [
 												{ "include": "#attribute" },
 												{ "include": "#keyword" },
-												{
-													"name": "storage.type.ada",
-													"match": "\\b(\\w|\\.|_)+\\b"
-												}
+												{ "include": "#subtype_mark" }
 											]
 										}
 									}
@@ -678,14 +666,10 @@
 												{ "include": "#attribute" },
 												{ "include": "#keyword" },
 												{
-													"name": "storage.type.ada",
-													"match": "\\b(\\w|\\.|_)+(\\s*\\((\\\\.|[^)])*\\))?",
+													"match": "\\b((?:\\w|\\.|_)+)(\\s*\\((\\\\.|[^)])*\\))?",
 													"captures": {
-														"0": {
-															"patterns": [
-																{ "include": "#discriminant" }
-															]
-														}
+                                          "1": { "patterns": [ { "include": "#subtype_mark" } ] },
+														"2": { "patterns": [ { "include": "#discriminant" } ] }
 													}
 												}
 											]
@@ -727,14 +711,10 @@
 												{ "include": "#attribute" },
 												{ "include": "#keyword" },
 												{
-													"name": "storage.type.ada",
-													"match": "\\b(\\w|\\.|_)+(\\s*\\((\\\\.|[^)])*\\))?",
+													"match": "\\b((?:\\w|\\.|_)+)(\\s*\\((\\\\.|[^)])*\\))?",
 													"captures": {
-														"0": {
-															"patterns": [
-																{ "include": "#discriminant" }
-															]
-														}
+                                          "1": { "patterns": [ { "include": "#subtype_mark" } ] },
+														"2": { "patterns": [ { "include": "#discriminant" } ] }
 													}
 												}
 											]
@@ -844,10 +824,7 @@
 													"name": "keyword.ada",
 													"match": "(?i)\\breturn\\b"
 												},
-												{
-													"name": "storage.type.ada",
-													"match": "\\b(\\w|\\.|_)+\\b"
-												}
+												{ "include": "#subtype_mark" }
 											]
 										}
 									}
@@ -896,10 +873,7 @@
 													"name": "keyword.ada",
 													"match": "(?i)\\breturn\\b"
 												},
-												{
-													"name": "storage.type.ada",
-													"match": "\\b(\\w|\\.|_)+\\b"
-												}
+                                    { "include": "#subtype_mark" }
 											]
 										}
 									}
@@ -949,10 +923,7 @@
 													"name": "keyword.ada",
 													"match": "(?i)\\breturn\\b"
 												},
-												{
-													"name": "storage.type.ada",
-													"match": "\\b(\\w|\\.|_)+\\b"
-												}
+												{ "include": "#subtype_mark" }
 											]
 										}
 									}
@@ -1014,10 +985,7 @@
 													"name": "keyword.ada",
 													"match": "(?i)\\breturn\\b"
 												},
-												{
-													"name": "storage.type.ada",
-													"match": "\\b(\\w|\\.|_)+\\b"
-												}
+												{ "include": "#subtype_mark" }
 											]
 										}
 									}
@@ -1064,6 +1032,10 @@
 					}
 				}
 			]
+      },
+      "subtype_mark": {
+			"name": "entity.name.type.ada",
+         "match": "\\b(?:\\w|\\d|\\.|_)+\\b"
 		},
 		"type": {
 			"patterns": [
@@ -1076,10 +1048,7 @@
 							"patterns": [
 								{ "include": "#discriminant" },
 								{ "include": "#keyword" },
-								{
-									"name": "storage.type.ada",
-									"match": "\\b(\\w|_)+\\b"
-								}
+								{ "include": "#subtype_mark" }
 							]
 						}
 					},
@@ -1097,10 +1066,7 @@
 							"patterns": [
 								{ "include": "#discriminant" },
 								{ "include": "#keyword" },
-								{
-									"name": "storage.type.ada",
-									"match": "\\b(\\w|\\.|_)+\\b"
-								}
+								{ "include": "#subtype_mark" }
 							]
 						}
 					}
@@ -1114,10 +1080,7 @@
 							"patterns": [
 								{ "include": "#discriminant" },
 								{ "include": "#keyword" },
-								{
-									"name": "storage.type.ada",
-									"match": "\\b(\\w|\\.|_)+\\b"
-								}
+								{ "include": "#subtype_mark" }
 							]
 						}
 					},
@@ -1139,10 +1102,7 @@
 										"0": {
 											"patterns": [
 												{ "include": "#keyword" },
-												{
-													"name": "storage.type.ada",
-													"match": "\\b(\\w|\\.|_)+\\b"
-												}
+												{ "include": "#subtype_mark" }
 											]
 										}
 									}
@@ -1154,19 +1114,13 @@
 										"0": {
 											"patterns": [
 												{ "include": "#keyword" },
-												{
-													"name": "storage.type.ada",
-													"match": "\\b(\\w|\\.|_)+\\b"
-												}
+												{ "include": "#subtype_mark" }
 											]
 										}
 									}
 								},
 								{ "include": "#keyword" },
-								{
-									"name": "storage.type.ada",
-									"match": "\\b(\\w|_)+\\b"
-								}
+								{ "include": "#subtype_mark" }
 							]
 						}
 					}
@@ -1182,17 +1136,7 @@
 									"match": "\\baccess(\\s+all)?\\b"
 								},
 								{ "include": "#keyword" },
-								{
-									"name": "storage.type.ada",
-									"match": "\\b(\\w|\\.|_)+\\b",
-									"captures": {
-										"0": {
-											"patterns": [
-												{ "include": "#punctuation" }
-											]
-										}
-									}
-								}
+								{ "include": "#subtype_mark" }
 							]
 						}
 					}
@@ -1205,17 +1149,7 @@
 							"patterns": [
 								{ "include": "#discriminant" },
 								{ "include": "#keyword" },
-								{
-									"name": "storage.type.ada",
-									"match": "\\b(\\w|_)+\\b",
-									"captures": {
-										"0": {
-											"patterns": [
-												{ "include": "#punctuation" }
-											]
-										}
-									}
-								}
+								{ "include": "#subtype_mark" }
 							]
 						}
 					}
@@ -1228,17 +1162,7 @@
 							"patterns": [
 								{ "include": "#aspect" },
 								{ "include": "#keyword" },
-								{
-									"name": "storage.type.ada",
-									"match": "\\b(\\w|\\.|_)+\\b",
-									"captures": {
-										"0": {
-											"patterns": [
-												{ "include": "#punctuation" }
-											]
-										}
-									}
-								}
+								{ "include": "#subtype_mark" }
 							]
 						}
 					}
@@ -1250,17 +1174,7 @@
 						"0": {
 							"patterns": [
 								{ "include": "#aggregate" },
-								{
-									"name": "storage.type.ada",
-									"match": "\\b(\\w|\\.|_)+'",
-									"captures": {
-										"0": {
-											"patterns": [
-												{ "include": "#punctuation" }
-											]
-										}
-									}
-								}
+								{ "include": "#subtype_mark" }
 							]
 						}
 					}


### PR DESCRIPTION
Certain themes, namely the Microsoft Light+/Dark+ themes, highlight `storage.type` the same as `keyword`, which is appropriate for C/C++/C#, but not most other languages. This winds up being confusing with Ada. By using `entity.name.type`, all the built in themes highlight types distinctly.