### PR TITLE
Increase the timeout in case of valgrind runs

### DIFF
--- a/testsuite/drivers/basic.py
+++ b/testsuite/drivers/basic.py
@@ -30,7 +30,7 @@ class JsonTestDriver(ALSTestDriver):
             process = self.run_and_log(
                 [self.env.tester_run, json],
                 cwd=wd,
-                timeout=120,
+                timeout=min(780, 120 * self.env.wait_factor),
                 env={'ALS': self.env.als,
                      'ALS_HOME': self.env.als_home,
                      'ALS_WAIT_FACTOR': str(self.env.wait_factor)},


### PR DESCRIPTION
Apply the multiplying factor to the executable timeout, capped
at a maximum.