### PR TITLE
T224-034 Rework support for canceling requests

### DIFF
--- a/source/ada/lsp-ada_context_sets.adb
+++ b/source/ada/lsp-ada_context_sets.adb
@@ -15,8 +15,6 @@
 -- of the license.                                                          --
 ------------------------------------------------------------------------------
 
-with Ada.Unchecked_Deallocation;
-
 with GNATCOLL.VFS;    use GNATCOLL.VFS;
 
 with URIs;
@@ -27,9 +25,6 @@ package body LSP.Ada_Context_Sets is
      (Create (+(URIs.Conversions.To_File (LSP.Types.To_UTF_8_String (URI)))));
    --  Utility conversion function
 
-   procedure Unchecked_Free is new Ada.Unchecked_Deallocation
-     (LSP.Ada_Contexts.Context, Context_Access);
-
    -------------
    -- Cleanup --
    -------------
@@ -38,10 +33,9 @@ package body LSP.Ada_Context_Sets is
    begin
       while not Self.Contexts.Is_Empty loop
          declare
-            C : Context_Access := Self.Contexts.First_Element;
+            C : LSP.Ada_Contexts.Context := Self.Contexts.First_Element;
          begin
             C.Free;
-            Unchecked_Free (C);
          end;
          Self.Contexts.Delete_First;
       end loop;
@@ -62,7 +56,7 @@ package body LSP.Ada_Context_Sets is
       Result : Context_Lists.List;
    begin
       for C of Self.Contexts loop
-         if Predicate (C.all) then
+         if Predicate (C) then
             Result.Append (C);
          end if;
       end loop;
@@ -75,7 +69,7 @@ package body LSP.Ada_Context_Sets is
 
    function Get_Best_Context
      (Self : Context_Set'Class;
-      URI  : LSP.Messages.DocumentUri) return Context_Access
+      URI  : LSP.Messages.DocumentUri) return LSP.Ada_Contexts.Context
    is
       File : constant Virtual_File := To_File (URI);
    begin
@@ -94,7 +88,7 @@ package body LSP.Ada_Context_Sets is
 
    function Get
      (Self : Context_Set;
-      Id   : LSP.Types.LSP_String) return Context_Access is
+      Id   : LSP.Types.LSP_String) return LSP.Ada_Contexts.Context is
    begin
       return Self.Map (Id);
    end Get;
@@ -114,7 +108,7 @@ package body LSP.Ada_Context_Sets is
 
    procedure Prepend
      (Self : in out Context_Set'Class;
-      Item : Context_Access) is
+      Item : LSP.Ada_Contexts.Context) is
    begin
       Self.Contexts.Prepend (Item);
       Self.Map.Insert (Item.Id, Item);

--- a/source/ada/lsp-ada_context_sets.ads
+++ b/source/ada/lsp-ada_context_sets.ads
@@ -17,8 +17,8 @@
 --
 --  This package provides a set of contexts for Ada Language server.
 
-with Ada.Containers.Doubly_Linked_Lists;
-with Ada.Containers.Hashed_Maps;
+with Ada.Containers.Indefinite_Doubly_Linked_Lists;
+with Ada.Containers.Indefinite_Hashed_Maps;
 
 with LSP.Ada_Contexts;
 with LSP.Messages;
@@ -28,17 +28,16 @@ package LSP.Ada_Context_Sets is
 
    type Context_Set is tagged limited private;
 
-   type Context_Access is access LSP.Ada_Contexts.Context;
-
-   package Context_Lists is new Ada.Containers.Doubly_Linked_Lists
-     (Context_Access);
+   package Context_Lists is new Ada.Containers.Indefinite_Doubly_Linked_Lists
+     (LSP.Ada_Contexts.Context,
+      "=" => LSP.Ada_Contexts."=");
 
    function Is_Empty (Self : Context_Set'Class) return Boolean;
    --  Check if the set has no contexts
 
    procedure Prepend
      (Self : in out Context_Set'Class;
-      Item : Context_Access);
+      Item : LSP.Ada_Contexts.Context);
    --  Append an item to the set
 
    procedure Reload_All_Contexts (Self : in out Context_Set'Class);
@@ -46,7 +45,7 @@ package LSP.Ada_Context_Sets is
 
    function Get_Best_Context
      (Self : Context_Set'Class;
-      URI  : LSP.Messages.DocumentUri) return Context_Access;
+      URI  : LSP.Messages.DocumentUri) return LSP.Ada_Contexts.Context;
    --  Return the first context in Contexts which contains a project
    --  which knows about file. Fallback on the "no project" context.
 
@@ -58,7 +57,7 @@ package LSP.Ada_Context_Sets is
 
    function Get
      (Self : Context_Set;
-      Id   : LSP.Types.LSP_String) return Context_Access;
+      Id   : LSP.Types.LSP_String) return LSP.Ada_Contexts.Context;
    --  Return context by its Id
 
    type Context_Predicate is access function
@@ -75,12 +74,12 @@ package LSP.Ada_Context_Sets is
 
 private
 
-   package Maps is new Ada.Containers.Hashed_Maps
+   package Maps is new Ada.Containers.Indefinite_Hashed_Maps
      (Key_Type        => LSP.Types.LSP_String,
-      Element_Type    => Context_Access,
+      Element_Type    => LSP.Ada_Contexts.Context,
       Hash            => LSP.Types.Hash,
       Equivalent_Keys => LSP.Types."=",
-      "="             => "=");
+      "="             => LSP.Ada_Contexts."=");
 
    type Context_Set is tagged limited record
       Contexts : Context_Lists.List;

--- a/source/ada/lsp-ada_contexts.ads
+++ b/source/ada/lsp-ada_contexts.ads
@@ -32,8 +32,7 @@ with LSP.Types;
 
 package LSP.Ada_Contexts is
 
-   type Context (Trace : GNATCOLL.Traces.Trace_Handle) is
-     tagged limited private;
+   type Context (Trace : GNATCOLL.Traces.Trace_Handle) is tagged private;
    --  A context contains a non-aggregate project tree and its associated
    --  libadalang context.
 
@@ -175,7 +174,7 @@ private
       Default_Project,        --  No project provided or found, use default
       Found_Unique_Project);  --  No project provided, but server found one
 
-   type Context (Trace : GNATCOLL.Traces.Trace_Handle) is tagged limited record
+   type Context (Trace : GNATCOLL.Traces.Trace_Handle) is tagged record
       Id             : LSP.Types.LSP_String;
       Unit_Provider  : Libadalang.Analysis.Unit_Provider_Reference;
       LAL_Context    : Libadalang.Analysis.Analysis_Context;

--- a/source/ada/lsp-ada_handlers-named_parameters_commands.adb
+++ b/source/ada/lsp-ada_handlers-named_parameters_commands.adb
@@ -99,8 +99,8 @@ package body LSP.Ada_Handlers.Named_Parameters_Commands is
       Message_Handler : LSP.Ada_Handlers.Message_Handler renames
         LSP.Ada_Handlers.Message_Handler (Handler.all);
 
-      Context         : LSP.Ada_Contexts.Context renames
-        Message_Handler.Contexts.Get (Self.Context).all;
+      Context   : LSP.Ada_Contexts.Context renames
+        Message_Handler.Contexts.Get (Self.Context);
 
       Document  : constant LSP.Ada_Documents.Document_Access :=
         Message_Handler.Get_Open_Document (Self.Where.textDocument.uri);

--- a/source/ada/lsp-ada_handlers.adb
+++ b/source/ada/lsp-ada_handlers.adb
@@ -792,7 +792,7 @@ package body LSP.Ada_Handlers is
       for C of Self.Contexts_For_URI (Params.textDocument.uri) loop
          Analyse_In_Context (C, Document, Response.result, Found);
 
-         exit when Request.Canceled or else Found;
+         exit when Self.Server.Cancel_Current or else Found;
       end loop;
 
       return Response;
@@ -865,7 +865,7 @@ package body LSP.Ada_Handlers is
             Response.result,
             Imprecise);
 
-         exit when Request.Canceled;
+         exit when Self.Server.Cancel_Current;
       end loop;
 
       if Imprecise then
@@ -1005,7 +1005,7 @@ package body LSP.Ada_Handlers is
       for C of Self.Contexts_For_URI (Position.textDocument.uri) loop
          Resolve_In_Context (C);
 
-         exit when Request.Canceled;
+         exit when Self.Server.Cancel_Current;
       end loop;
 
       if Imprecise then
@@ -1130,7 +1130,7 @@ package body LSP.Ada_Handlers is
       for C of Self.Contexts_For_URI (Value.textDocument.uri) loop
          Resolve_In_Context (C);
 
-         exit when Request.Canceled;
+         exit when Self.Server.Cancel_Current;
       end loop;
 
       if Imprecise then
@@ -1216,7 +1216,7 @@ package body LSP.Ada_Handlers is
       for C of Self.Contexts_For_URI (Position.textDocument.uri) loop
          Resolve_In_Context (C);
 
-         exit when Request.Canceled;
+         exit when Self.Server.Cancel_Current;
       end loop;
 
       return Response;
@@ -1491,7 +1491,7 @@ package body LSP.Ada_Handlers is
       --  Get the associated basic declaration
       Decl := Defining_Name_Node.P_Basic_Decl;
 
-      if Decl = No_Basic_Decl or else Request.Canceled then
+      if Decl = No_Basic_Decl or else Self.Server.Cancel_Current then
          return Response;
       end if;
 
@@ -1691,7 +1691,9 @@ package body LSP.Ada_Handlers is
       begin
          Self.Imprecise_Resolve_Name (C, Value, Definition);
 
-         if Definition = No_Defining_Name or else Request.Canceled then
+         if Definition = No_Defining_Name
+           or else Self.Server.Cancel_Current
+         then
             return;
          end if;
 
@@ -1713,7 +1715,7 @@ package body LSP.Ada_Handlers is
                      Get_Reference_Kind (Node.As_Ada_Node));
                end if;
 
-               exit when Count = 0  and then Request.Canceled;
+               exit when Count = 0  and then Self.Server.Cancel_Current;
             end loop;
 
             if Value.context.includeDeclaration then
@@ -1729,7 +1731,7 @@ package body LSP.Ada_Handlers is
       for C of Self.Contexts_For_URI (Value.textDocument.uri) loop
          Process_Context (C);
 
-         exit when Request.Canceled;
+         exit when Self.Server.Cancel_Current;
       end loop;
 
       if Imprecise then
@@ -1805,7 +1807,7 @@ package body LSP.Ada_Handlers is
 
          if Definition = No_Defining_Name
            or else not Definition.P_Basic_Decl.P_Is_Subprogram
-           or else Request.Canceled
+           or else Self.Server.Cancel_Current
          then
             return;
          end if;
@@ -1839,7 +1841,7 @@ package body LSP.Ada_Handlers is
                                       Get_Reference_Kind (Ref.As_Name));
                      Count := Count - 1;
 
-                     if Count = 0 and then Request.Canceled then
+                     if Count = 0 and then Self.Server.Cancel_Current then
                         return;
                      end if;
                   end loop;
@@ -1856,7 +1858,7 @@ package body LSP.Ada_Handlers is
       for C of Self.Contexts_For_URI (Value.textDocument.uri) loop
          Process_Context (C);
 
-         exit when Request.Canceled;
+         exit when Self.Server.Cancel_Current;
       end loop;
 
       if Imprecise then
@@ -2099,7 +2101,7 @@ package body LSP.Ada_Handlers is
             return;
          end if;
 
-         if Definition = No_Defining_Name or Request.Canceled then
+         if Definition = No_Defining_Name or Self.Server.Cancel_Current then
             return;
          end if;
 
@@ -2146,7 +2148,7 @@ package body LSP.Ada_Handlers is
                      Response.result.changes (Location.uri).Append (Item);
                   end if;
 
-                  exit when Count = 0 and then Request.Canceled;
+                  exit when Count = 0 and then Self.Server.Cancel_Current;
 
                   Count := Count - 1;
                end;
@@ -2158,7 +2160,7 @@ package body LSP.Ada_Handlers is
       for C of Self.Contexts_For_URI (Value.textDocument.uri) loop
          Process_Context (C);
 
-         exit when Request.Canceled;
+         exit when Self.Server.Cancel_Current;
       end loop;
       return Response;
    end On_Rename_Request;

--- a/source/protocol/generated/lsp-messages-server_requests.ads
+++ b/source/protocol/generated/lsp-messages-server_requests.ads
@@ -8,9 +8,8 @@ use LSP.Server_Request_Receivers;
 
 package LSP.Messages.Server_Requests is
 
-   type Server_Request is abstract new LSP.Messages.RequestMessage with record
-      Canceled : Boolean := False with Atomic;
-   end record;
+   type Server_Request is abstract new LSP.Messages.RequestMessage
+     with null record;
 
    function Decode
      (JS : not null access LSP.JSON_Streams.JSON_Stream)


### PR DESCRIPTION
Use a protected object for data that's shared between the Input_Task
and the Processing_Task. Remove the use of a set of pointers in
Request_Map.