### PR TITLE
Emit providers information in compability format

### DIFF
--- a/source/protocol/lsp-messages.adb
+++ b/source/protocol/lsp-messages.adb
@@ -6447,9 +6447,17 @@ package body LSP.Messages is
       JS : LSP.JSON_Streams.JSON_Stream'Class renames
         LSP.JSON_Streams.JSON_Stream'Class (S.all);
    begin
-      JS.Start_Object;
-      Write_Optional_Boolean (JS, +"workDoneProgress", V.workDoneProgress);
-      JS.End_Object;
+      --  In case we don't have workDoneProgress property let's write a boolean
+      --  value instead of an empty object to be compatible with older protocol
+      --  readers.
+
+      if not V.workDoneProgress.Is_Set then
+         JS.Write (GNATCOLL.JSON.Create (True));
+      else
+         JS.Start_Object;
+         Write_Optional_Boolean (JS, +"workDoneProgress", V.workDoneProgress);
+         JS.End_Object;
+      end if;
    end Write_WorkDoneProgressOptions;
 
    ----------------------------------

--- a/testsuite/ada_lsp/0003-get_symbols/0003-get_symbols.json
+++ b/testsuite/ada_lsp/0003-get_symbols/0003-get_symbols.json
@@ -14,7 +14,7 @@
                       "result":{
                           "capabilities":{
                               "textDocumentSync": 2,
-                              "documentSymbolProvider":{}
+                              "documentSymbolProvider":true
                           }
                       }
             }]

--- a/testsuite/ada_lsp/C825-005.xrefs.extending/test.json
+++ b/testsuite/ada_lsp/C825-005.xrefs.extending/test.json
@@ -33,11 +33,11 @@
                "result": {
                   "capabilities": {
                      "typeDefinitionProvider": true,
-                     "hoverProvider": {},
-                     "definitionProvider": {},
+                     "hoverProvider": true,
+                     "definitionProvider": true,
                      "renameProvider": {},
                      "alsCalledByProvider": true,
-                     "referencesProvider": {},
+                     "referencesProvider": true,
                      "textDocumentSync": 2,
                      "completionProvider": {
                         "triggerCharacters": [
@@ -45,7 +45,7 @@
                         ],
                         "resolveProvider": false
                      },
-                     "documentSymbolProvider": {}
+                     "documentSymbolProvider": true
                   }
                }
             }

--- a/testsuite/ada_lsp/D301-004.xrefs.generics/test.json
+++ b/testsuite/ada_lsp/D301-004.xrefs.generics/test.json
@@ -33,11 +33,11 @@
                "result": {
                   "capabilities": {
                      "typeDefinitionProvider": true,
-                     "hoverProvider": {},
-                     "definitionProvider": {},
+                     "hoverProvider": true,
+                     "definitionProvider": true,
                      "renameProvider": {},
                      "alsCalledByProvider": true,
-                     "referencesProvider": {},
+                     "referencesProvider": true,
                      "textDocumentSync": 2,
                      "completionProvider": {
                         "triggerCharacters": [
@@ -45,7 +45,7 @@
                         ],
                         "resolveProvider": false
                      },
-                     "documentSymbolProvider": {}
+                     "documentSymbolProvider": true
                   }
                }
             }

--- a/testsuite/ada_lsp/D803-003.xrefs.generics_go_to_body/test.json
+++ b/testsuite/ada_lsp/D803-003.xrefs.generics_go_to_body/test.json
@@ -33,11 +33,11 @@
                "result": {
                   "capabilities": {
                      "typeDefinitionProvider": true,
-                     "hoverProvider": {},
-                     "definitionProvider": {},
+                     "hoverProvider": true,
+                     "definitionProvider": true,
                      "renameProvider": {},
                      "alsCalledByProvider": true,
-                     "referencesProvider": {},
+                     "referencesProvider": true,
                      "textDocumentSync": 2,
                      "completionProvider": {
                         "triggerCharacters": [
@@ -45,7 +45,7 @@
                         ],
                         "resolveProvider": false
                      },
-                     "documentSymbolProvider": {}
+                     "documentSymbolProvider": true
                   }
                }
             }

--- a/testsuite/ada_lsp/F131-024.xrefs.separate_body/test.json
+++ b/testsuite/ada_lsp/F131-024.xrefs.separate_body/test.json
@@ -39,11 +39,11 @@
                         "call",
                         "dispatching call", "parent", "child"
                      ],
-                     "hoverProvider": {},
-                     "definitionProvider": {},
+                     "hoverProvider": true,
+                     "definitionProvider": true,
                      "renameProvider": {},
                      "alsCalledByProvider": true,
-                     "referencesProvider": {},
+                     "referencesProvider": true,
                      "textDocumentSync": 2,
                      "completionProvider": {
                         "triggerCharacters": [
@@ -51,7 +51,7 @@
                         ],
                         "resolveProvider": false
                      },
-                     "documentSymbolProvider": {}
+                     "documentSymbolProvider": true
                   }
                }
             }

--- a/testsuite/ada_lsp/F222-029.xrefs.prefixed_notation/test.json
+++ b/testsuite/ada_lsp/F222-029.xrefs.prefixed_notation/test.json
@@ -33,11 +33,11 @@
                "result": {
                   "capabilities": {
                      "typeDefinitionProvider": true,
-                     "hoverProvider": {},
-                     "definitionProvider": {},
+                     "hoverProvider": true,
+                     "definitionProvider": true,
                      "renameProvider": {},
                      "alsCalledByProvider": true,
-                     "referencesProvider": {},
+                     "referencesProvider": true,
                      "textDocumentSync": 2,
                      "completionProvider": {
                         "triggerCharacters": [
@@ -45,7 +45,7 @@
                         ],
                         "resolveProvider": false
                      },
-                     "documentSymbolProvider": {}
+                     "documentSymbolProvider": true
                   }
                }
             }

--- a/testsuite/ada_lsp/G323-009.tooltips.function_prototype/test.json
+++ b/testsuite/ada_lsp/G323-009.tooltips.function_prototype/test.json
@@ -39,11 +39,11 @@
                         "call",
                         "dispatching call", "parent", "child"
                      ],
-                     "hoverProvider": {},
-                     "definitionProvider": {},
+                     "hoverProvider": true,
+                     "definitionProvider": true,
                      "renameProvider": {},
                      "alsCalledByProvider": true,
-                     "referencesProvider": {},
+                     "referencesProvider": true,
                      "textDocumentSync": 2,
                      "completionProvider": {
                         "triggerCharacters": [
@@ -51,7 +51,7 @@
                         ],
                         "resolveProvider": false
                      },
-                     "documentSymbolProvider": {}
+                     "documentSymbolProvider": true
                   }
                }
             }

--- a/testsuite/ada_lsp/JB24-033.xrefs.no_refs_for_non_loaded_projects/test.json
+++ b/testsuite/ada_lsp/JB24-033.xrefs.no_refs_for_non_loaded_projects/test.json
@@ -33,11 +33,11 @@
                "result": {
                   "capabilities": {
                      "typeDefinitionProvider": true,
-                     "hoverProvider": {},
-                     "definitionProvider": {},
+                     "hoverProvider": true,
+                     "definitionProvider": true,
                      "renameProvider": {},
                      "alsCalledByProvider": true,
-                     "referencesProvider": {},
+                     "referencesProvider": true,
                      "textDocumentSync": 2,
                      "completionProvider": {
                         "triggerCharacters": [
@@ -45,7 +45,7 @@
                         ],
                         "resolveProvider": false
                      },
-                     "documentSymbolProvider": {}
+                     "documentSymbolProvider": true
                   }
                }
             }

--- a/testsuite/ada_lsp/O208-003.xrefs.aggregate_library_projects/test.json
+++ b/testsuite/ada_lsp/O208-003.xrefs.aggregate_library_projects/test.json
@@ -33,11 +33,11 @@
                "result": {
                   "capabilities": {
                      "typeDefinitionProvider": true,
-                     "hoverProvider": {},
-                     "definitionProvider": {},
+                     "hoverProvider": true,
+                     "definitionProvider": true,
                      "renameProvider": {},
                      "alsCalledByProvider": true,
-                     "referencesProvider": {},
+                     "referencesProvider": true,
                      "textDocumentSync": 2,
                      "completionProvider": {
                         "triggerCharacters": [
@@ -45,7 +45,7 @@
                         ],
                         "resolveProvider": false
                      },
-                     "documentSymbolProvider": {}
+                     "documentSymbolProvider": true
                   }
                }
             }

--- a/testsuite/ada_lsp/P107-003.refactoring.underscores/test.json
+++ b/testsuite/ada_lsp/P107-003.refactoring.underscores/test.json
@@ -33,11 +33,11 @@
                "result": {
                   "capabilities": {
                      "typeDefinitionProvider": true,
-                     "hoverProvider": {},
-                     "definitionProvider": {},
+                     "hoverProvider": true,
+                     "definitionProvider": true,
                      "renameProvider": {},
                      "alsCalledByProvider": true,
-                     "referencesProvider": {},
+                     "referencesProvider": true,
                      "textDocumentSync": 2,
                      "completionProvider": {
                         "triggerCharacters": [
@@ -45,7 +45,7 @@
                         ],
                         "resolveProvider": false
                      },
-                     "documentSymbolProvider": {}
+                     "documentSymbolProvider": true
                   }
                }
             }

--- a/testsuite/ada_lsp/P429-023.refactoring.rename_clauses/test.json
+++ b/testsuite/ada_lsp/P429-023.refactoring.rename_clauses/test.json
@@ -33,11 +33,11 @@
                "result": {
                   "capabilities": {
                      "typeDefinitionProvider": true,
-                     "hoverProvider": {},
-                     "definitionProvider": {},
+                     "hoverProvider": true,
+                     "definitionProvider": true,
                      "renameProvider": {},
                      "alsCalledByProvider": true,
-                     "referencesProvider": {},
+                     "referencesProvider": true,
                      "textDocumentSync": 2,
                      "completionProvider": {
                         "triggerCharacters": [
@@ -45,7 +45,7 @@
                         ],
                         "resolveProvider": false
                      },
-                     "documentSymbolProvider": {}
+                     "documentSymbolProvider": true
                   }
                }
             }

--- a/testsuite/ada_lsp/QB01-002.xrefs.non_ascii_documentation/test.json
+++ b/testsuite/ada_lsp/QB01-002.xrefs.non_ascii_documentation/test.json
@@ -33,11 +33,11 @@
                "result": {
                   "capabilities": {
                      "typeDefinitionProvider": true,
-                     "hoverProvider": {},
-                     "definitionProvider": {},
+                     "hoverProvider": true,
+                     "definitionProvider": true,
                      "renameProvider": {},
                      "alsCalledByProvider": true,
-                     "referencesProvider": {},
+                     "referencesProvider": true,
                      "textDocumentSync": 2,
                      "completionProvider": {
                         "triggerCharacters": [
@@ -45,7 +45,7 @@
                         ],
                         "resolveProvider": false
                      },
-                     "documentSymbolProvider": {}
+                     "documentSymbolProvider": true
                   }
                }
             }

--- a/testsuite/ada_lsp/S510-020.exceptions_reporting/test.json
+++ b/testsuite/ada_lsp/S510-020.exceptions_reporting/test.json
@@ -16,7 +16,7 @@
                 "result":{
                     "capabilities":{
                         "textDocumentSync": 2,
-                        "referencesProvider":{}
+                        "referencesProvider":true
                     }
                 }
             }]

--- a/testsuite/ada_lsp/S516-013.no_file/no_file.json
+++ b/testsuite/ada_lsp/S516-013.no_file/no_file.json
@@ -17,7 +17,7 @@
                       "result":{
                           "capabilities":{
                               "textDocumentSync": 2,
-                              "hoverProvider":{}
+                              "hoverProvider":true
                           }
                       }
             }]

--- a/testsuite/ada_lsp/S820-016.called_by.entry/test.json
+++ b/testsuite/ada_lsp/S820-016.called_by.entry/test.json
@@ -38,11 +38,11 @@
                         "call",
                         "dispatching call", "parent", "child"
                      ],
-                     "hoverProvider": {},
-                     "definitionProvider": {},
+                     "hoverProvider": true,
+                     "definitionProvider": true,
                      "renameProvider": {},
                      "alsCalledByProvider": true,
-                     "referencesProvider": {},
+                     "referencesProvider": true,
                      "textDocumentSync": 2,
                      "completionProvider": {
                         "triggerCharacters": [
@@ -50,7 +50,7 @@
                         ],
                         "resolveProvider": false
                      },
-                     "documentSymbolProvider": {}
+                     "documentSymbolProvider": true
                   }
                }
             }

--- a/testsuite/ada_lsp/SA11-040.definition.fallback/test.json
+++ b/testsuite/ada_lsp/SA11-040.definition.fallback/test.json
@@ -38,11 +38,11 @@
                         "call",
                         "dispatching call", "parent", "child"
                      ],
-                     "hoverProvider": {},
-                     "definitionProvider": {},
+                     "hoverProvider": true,
+                     "definitionProvider": true,
                      "renameProvider": {},
                      "alsCalledByProvider": true,
-                     "referencesProvider": {},
+                     "referencesProvider": true,
                      "textDocumentSync": 2,
                      "completionProvider": {
                         "triggerCharacters": [
@@ -50,7 +50,7 @@
                         ],
                         "resolveProvider": false
                      },
-                     "documentSymbolProvider": {}
+                     "documentSymbolProvider": true
                   }
                }
             }

--- a/testsuite/ada_lsp/SA22-029.rename_in_comments/test.json
+++ b/testsuite/ada_lsp/SA22-029.rename_in_comments/test.json
@@ -38,11 +38,11 @@
                         "call",
                         "dispatching call", "parent", "child"
                      ],
-                     "hoverProvider": {},
-                     "definitionProvider": {},
+                     "hoverProvider": true,
+                     "definitionProvider": true,
                      "renameProvider": {},
                      "alsCalledByProvider": true,
-                     "referencesProvider": {},
+                     "referencesProvider": true,
                      "textDocumentSync": 2,
                      "completionProvider": {
                         "triggerCharacters": [
@@ -50,7 +50,7 @@
                         ],
                         "resolveProvider": false
                      },
-                     "documentSymbolProvider": {}
+                     "documentSymbolProvider": true
                   }
                }
             }

--- a/testsuite/ada_lsp/SA24-055.called_by_on_abstract/test.json
+++ b/testsuite/ada_lsp/SA24-055.called_by_on_abstract/test.json
@@ -38,11 +38,11 @@
                         "call",
                         "dispatching call", "parent", "child"
                      ],
-                     "hoverProvider": {},
-                     "definitionProvider": {},
+                     "hoverProvider": true,
+                     "definitionProvider": true,
                      "renameProvider": {},
                      "alsCalledByProvider": true,
-                     "referencesProvider": {},
+                     "referencesProvider": true,
                      "textDocumentSync": 2,
                      "completionProvider": {
                         "triggerCharacters": [
@@ -50,7 +50,7 @@
                         ],
                         "resolveProvider": false
                      },
-                     "documentSymbolProvider": {}
+                     "documentSymbolProvider": true
                   }
                }
             }

--- a/testsuite/ada_lsp/SB21-042.tooltips.aspects/test.json
+++ b/testsuite/ada_lsp/SB21-042.tooltips.aspects/test.json
@@ -38,11 +38,11 @@
                         "call",
                         "dispatching call", "parent", "child"
                      ],
-                     "hoverProvider": {},
-                     "definitionProvider": {},
+                     "hoverProvider": true,
+                     "definitionProvider": true,
                      "renameProvider": {},
                      "alsCalledByProvider": true,
-                     "referencesProvider": {},
+                     "referencesProvider": true,
                      "textDocumentSync": 2,
                      "completionProvider": {
                         "triggerCharacters": [
@@ -50,7 +50,7 @@
                         ],
                         "resolveProvider": false
                      },
-                     "documentSymbolProvider": {}
+                     "documentSymbolProvider": true
                   }
                }
             }

--- a/testsuite/ada_lsp/SC16-095.fallback_when_no_body/test.json
+++ b/testsuite/ada_lsp/SC16-095.fallback_when_no_body/test.json
@@ -56,11 +56,11 @@
                         "call",
                         "dispatching call", "parent", "child"
                      ],
-                     "hoverProvider": {},
-                     "definitionProvider": {},
+                     "hoverProvider": true,
+                     "definitionProvider": true,
                      "renameProvider": {},
                      "alsCalledByProvider": true,
-                     "referencesProvider": {},
+                     "referencesProvider": true,
                      "declarationProvider": true,
                      "textDocumentSync": 2,
                      "completionProvider": {
@@ -69,7 +69,7 @@
                         ],
                         "resolveProvider": false
                      },
-                     "documentSymbolProvider": {}
+                     "documentSymbolProvider": true
                   }
                }
             }

--- a/testsuite/ada_lsp/T123-048.incremental_editing/test.json
+++ b/testsuite/ada_lsp/T123-048.incremental_editing/test.json
@@ -273,11 +273,11 @@
                         "parent", 
                         "child"
                      ], 
-                     "hoverProvider": {}, 
-                     "definitionProvider": {}, 
+                     "hoverProvider": true, 
+                     "definitionProvider": true, 
                      "renameProvider": {}, 
                      "alsCalledByProvider": true, 
-                     "referencesProvider": {}, 
+                     "referencesProvider": true, 
                      "textDocumentSync": 2, 
                      "declarationProvider": true, 
                      "completionProvider": {
@@ -286,7 +286,7 @@
                         ], 
                         "resolveProvider": false
                      }, 
-                     "documentSymbolProvider": {}
+                     "documentSymbolProvider": true
                   }
                }
             }

--- a/testsuite/ada_lsp/aggregate.references_after_update/test.json
+++ b/testsuite/ada_lsp/aggregate.references_after_update/test.json
@@ -56,11 +56,11 @@
                         "call",
                         "dispatching call", "parent", "child"
                      ],
-                     "hoverProvider": {},
-                     "definitionProvider": {},
+                     "hoverProvider": true,
+                     "definitionProvider": true,
                      "renameProvider": {},
                      "alsCalledByProvider": true,
-                     "referencesProvider": {},
+                     "referencesProvider": true,
                      "declarationProvider": true,
                      "textDocumentSync": 2,
                      "completionProvider": {
@@ -69,7 +69,7 @@
                         ],
                         "resolveProvider": false
                      },
-                     "documentSymbolProvider": {}
+                     "documentSymbolProvider": true
                   }
                }
             }

--- a/testsuite/ada_lsp/aggregate.simple/test.json
+++ b/testsuite/ada_lsp/aggregate.simple/test.json
@@ -38,11 +38,11 @@
                         "call",
                         "dispatching call", "parent", "child"
                      ],
-                     "hoverProvider": {},
-                     "definitionProvider": {},
+                     "hoverProvider": true,
+                     "definitionProvider": true,
                      "renameProvider": {},
                      "alsCalledByProvider": true,
-                     "referencesProvider": {},
+                     "referencesProvider": true,
                      "textDocumentSync": 2,
                      "completionProvider": {
                         "triggerCharacters": [
@@ -50,7 +50,7 @@
                         ],
                         "resolveProvider": false
                      },
-                     "documentSymbolProvider": {}
+                     "documentSymbolProvider": true
                   }
                }
             }]

--- a/testsuite/ada_lsp/called_by.null_subp/called_by.null_subp.json
+++ b/testsuite/ada_lsp/called_by.null_subp/called_by.null_subp.json
@@ -34,11 +34,11 @@
                "result": {
                   "capabilities": {
                      "typeDefinitionProvider": true, 
-                     "hoverProvider": {}, 
-                     "definitionProvider": {}, 
+                     "hoverProvider": true, 
+                     "definitionProvider": true, 
                      "renameProvider": {}, 
                      "alsCalledByProvider": true, 
-                     "referencesProvider": {}, 
+                     "referencesProvider": true, 
                      "textDocumentSync": 2, 
                      "completionProvider": {
                         "triggerCharacters": [
@@ -46,7 +46,7 @@
                         ], 
                         "resolveProvider": false
                      }, 
-                     "documentSymbolProvider": {}
+                     "documentSymbolProvider": true
                   }
                }
             }]

--- a/testsuite/ada_lsp/called_by/called_by.json
+++ b/testsuite/ada_lsp/called_by/called_by.json
@@ -31,9 +31,9 @@
                "id": 1, 
                "result": {
                   "capabilities": {
-                     "hoverProvider": {}, 
-                     "documentSymbolProvider": {}, 
-                     "referencesProvider": {}, 
+                     "hoverProvider": true, 
+                     "documentSymbolProvider": true, 
+                     "referencesProvider": true, 
                      "textDocumentSync": 2, 
                      "completionProvider": {
                         "triggerCharacters": [
@@ -41,7 +41,7 @@
                         ], 
                         "resolveProvider": false
                      }, 
-                     "definitionProvider": {},
+                     "definitionProvider": true,
                      "alsCalledByProvider": true
                   }
                }

--- a/testsuite/ada_lsp/called_by_dispatching/test.json
+++ b/testsuite/ada_lsp/called_by_dispatching/test.json
@@ -39,11 +39,11 @@
                         "call",
                         "dispatching call", "parent", "child"
                      ],
-                     "hoverProvider": {},
-                     "definitionProvider": {},
+                     "hoverProvider": true,
+                     "definitionProvider": true,
                      "renameProvider": {},
                      "alsCalledByProvider": true,
-                     "referencesProvider": {},
+                     "referencesProvider": true,
                      "textDocumentSync": 2,
                      "completionProvider": {
                         "triggerCharacters": [
@@ -51,7 +51,7 @@
                         ],
                         "resolveProvider": false
                      },
-                     "documentSymbolProvider": {}
+                     "documentSymbolProvider": true
                   }
                }
             }

--- a/testsuite/ada_lsp/called_by_not_open/called_by_not_open.json
+++ b/testsuite/ada_lsp/called_by_not_open/called_by_not_open.json
@@ -31,9 +31,9 @@
                "id": 1, 
                "result": {
                   "capabilities": {
-                     "hoverProvider": {}, 
-                     "documentSymbolProvider": {}, 
-                     "referencesProvider": {}, 
+                     "hoverProvider": true, 
+                     "documentSymbolProvider": true, 
+                     "referencesProvider": true, 
                      "textDocumentSync": 2, 
                      "completionProvider": {
                         "triggerCharacters": [
@@ -41,7 +41,7 @@
                         ], 
                         "resolveProvider": false
                      }, 
-                     "definitionProvider": {},
+                     "definitionProvider": true,
                      "alsCalledByProvider": true
                   }
                }

--- a/testsuite/ada_lsp/callgraph.named_blocks/test.json
+++ b/testsuite/ada_lsp/callgraph.named_blocks/test.json
@@ -33,11 +33,11 @@
                "result": {
                   "capabilities": {
                      "typeDefinitionProvider": true,
-                     "hoverProvider": {},
-                     "definitionProvider": {},
+                     "hoverProvider": true,
+                     "definitionProvider": true,
                      "renameProvider": {},
                      "alsCalledByProvider": true,
-                     "referencesProvider": {},
+                     "referencesProvider": true,
                      "textDocumentSync": 2,
                      "completionProvider": {
                         "triggerCharacters": [
@@ -45,7 +45,7 @@
                         ],
                         "resolveProvider": false
                      },
-                     "documentSymbolProvider": {}
+                     "documentSymbolProvider": true
                   }
                }
             }

--- a/testsuite/ada_lsp/cancel/cancel.json
+++ b/testsuite/ada_lsp/cancel/cancel.json
@@ -17,7 +17,7 @@
                 "result":{
                     "capabilities":{
                         "textDocumentSync": 2,
-                        "definitionProvider":{}
+                        "definitionProvider":true
                     }
                 }
             }]

--- a/testsuite/ada_lsp/declaration.overridings/test.json
+++ b/testsuite/ada_lsp/declaration.overridings/test.json
@@ -60,11 +60,11 @@
                         "parent",
                         "child"
                      ],
-                     "hoverProvider": {},
-                     "definitionProvider": {},
+                     "hoverProvider": true,
+                     "definitionProvider": true,
                      "renameProvider": {},
                      "alsCalledByProvider": true,
-                     "referencesProvider": {},
+                     "referencesProvider": true,
                      "textDocumentSync": 2,
                      "declarationProvider": true,
                      "completionProvider": {
@@ -73,7 +73,7 @@
                         ],
                         "resolveProvider": false
                      },
-                     "documentSymbolProvider": {}
+                     "documentSymbolProvider": true
                   }
                }
             }

--- a/testsuite/ada_lsp/def_name/def_name.json
+++ b/testsuite/ada_lsp/def_name/def_name.json
@@ -20,7 +20,7 @@
                 "result":{
                     "capabilities":{
                         "textDocumentSync": 2,
-                        "definitionProvider":{}
+                        "definitionProvider":true
                     }
                 }
             }]

--- a/testsuite/ada_lsp/def_name/uri_with_slash.json
+++ b/testsuite/ada_lsp/def_name/uri_with_slash.json
@@ -20,7 +20,7 @@
                 "result":{
                     "capabilities":{
                         "textDocumentSync": 2,
-                        "definitionProvider":{}
+                        "definitionProvider":true
                     }
                 }
             }]

--- a/testsuite/ada_lsp/definition_and_overridings/test.json
+++ b/testsuite/ada_lsp/definition_and_overridings/test.json
@@ -57,11 +57,11 @@
                         "call",
                         "dispatching call", "parent", "child"
                      ],
-                     "hoverProvider": {},
-                     "definitionProvider": {},
+                     "hoverProvider": true,
+                     "definitionProvider": true,
                      "renameProvider": {},
                      "alsCalledByProvider": true,
-                     "referencesProvider": {},
+                     "referencesProvider": true,
                      "textDocumentSync": 2,
                      "completionProvider": {
                         "triggerCharacters": [
@@ -69,7 +69,7 @@
                         ],
                         "resolveProvider": false
                      },
-                     "documentSymbolProvider": {}
+                     "documentSymbolProvider": true
                   }
                }
             }

--- a/testsuite/ada_lsp/definition_parents/test.json
+++ b/testsuite/ada_lsp/definition_parents/test.json
@@ -58,11 +58,11 @@
                         "parent",
                         "child"
                      ],
-                     "hoverProvider": {},
-                     "definitionProvider": {},
+                     "hoverProvider": true,
+                     "definitionProvider": true,
                      "renameProvider": {},
                      "alsCalledByProvider": true,
-                     "referencesProvider": {},
+                     "referencesProvider": true,
                      "declarationProvider": true,
                      "textDocumentSync": 2,
                      "completionProvider": {
@@ -71,7 +71,7 @@
                         ],
                         "resolveProvider": false
                      },
-                     "documentSymbolProvider": {}
+                     "documentSymbolProvider": true
                   }
                }
             }

--- a/testsuite/ada_lsp/editor.incremental/test.json
+++ b/testsuite/ada_lsp/editor.incremental/test.json
@@ -273,11 +273,11 @@
                         "parent",
                         "child"
                      ],
-                     "hoverProvider": {},
-                     "definitionProvider": {},
+                     "hoverProvider": true,
+                     "definitionProvider": true,
                      "renameProvider": {},
                      "alsCalledByProvider": true,
-                     "referencesProvider": {},
+                     "referencesProvider": true,
                      "textDocumentSync": 2,
                      "declarationProvider": true,
                      "completionProvider": {
@@ -286,7 +286,7 @@
                         ],
                         "resolveProvider": false
                      },
-                     "documentSymbolProvider": {}
+                     "documentSymbolProvider": true
                   }
                }
             }

--- a/testsuite/ada_lsp/find_all_refs/find_all_refs.json
+++ b/testsuite/ada_lsp/find_all_refs/find_all_refs.json
@@ -19,7 +19,7 @@
                 "result":{
                     "capabilities":{
                         "textDocumentSync": 2,
-                        "referencesProvider":{}
+                        "referencesProvider":true
                     }
                 }
             }]

--- a/testsuite/ada_lsp/find_all_refs_child_package/test.json
+++ b/testsuite/ada_lsp/find_all_refs_child_package/test.json
@@ -58,11 +58,11 @@
                         "call",
                         "dispatching call", "parent", "child"
                      ],
-                     "hoverProvider": {},
-                     "definitionProvider": {},
+                     "hoverProvider": true,
+                     "definitionProvider": true,
                      "renameProvider": {},
                      "alsCalledByProvider": true,
-                     "referencesProvider": {},
+                     "referencesProvider": true,
                      "declarationProvider": true,
                      "textDocumentSync": 2,
                      "completionProvider": {
@@ -71,7 +71,7 @@
                         ],
                         "resolveProvider": false
                      },
-                     "documentSymbolProvider": {}
+                     "documentSymbolProvider": true
                   }
                }
             }

--- a/testsuite/ada_lsp/find_all_refs_kinds/find_all_refs_kinds.json
+++ b/testsuite/ada_lsp/find_all_refs_kinds/find_all_refs_kinds.json
@@ -19,7 +19,7 @@
                 "result":{
                     "capabilities":{
                         "textDocumentSync": 2,
-                        "referencesProvider":{}
+                        "referencesProvider":true
                     }
                 }
             }]

--- a/testsuite/ada_lsp/find_all_refs_subp/find_all_refs_subp.json
+++ b/testsuite/ada_lsp/find_all_refs_subp/find_all_refs_subp.json
@@ -87,8 +87,8 @@
                "id": 0,
                "result": {
                   "capabilities": {
-                     "documentSymbolProvider": {},
-                     "definitionProvider": {},
+                     "documentSymbolProvider": true,
+                     "definitionProvider": true,
                      "textDocumentSync": 2,
                      "completionProvider": {
                         "triggerCharacters": [
@@ -96,7 +96,7 @@
                         ],
                         "resolveProvider": false
                      },
-                     "referencesProvider": {}
+                     "referencesProvider": true
                   }
                }
             }]

--- a/testsuite/ada_lsp/get_symbol_hier/test.json
+++ b/testsuite/ada_lsp/get_symbol_hier/test.json
@@ -29,7 +29,7 @@
                       "result":{
                           "capabilities":{
                               "textDocumentSync": 2,
-                              "documentSymbolProvider":{}
+                              "documentSymbolProvider":true
                           }
                       }
             }]

--- a/testsuite/ada_lsp/implementation.aggregates/test.json
+++ b/testsuite/ada_lsp/implementation.aggregates/test.json
@@ -58,12 +58,12 @@
                         "parent",
                         "child"
                      ],
-                     "hoverProvider": {},
-                     "definitionProvider": {},
+                     "hoverProvider": true,
+                     "definitionProvider": true,
                      "implementationProvider": true,
                      "renameProvider": {},
                      "alsCalledByProvider": true,
-                     "referencesProvider": {},
+                     "referencesProvider": true,
                      "declarationProvider": true,
                      "textDocumentSync": 2,
                      "completionProvider": {
@@ -72,7 +72,7 @@
                         ],
                         "resolveProvider": false
                      },
-                     "documentSymbolProvider": {}
+                     "documentSymbolProvider": true
                   }
                }
             }

--- a/testsuite/ada_lsp/implementation.overridings/test.json
+++ b/testsuite/ada_lsp/implementation.overridings/test.json
@@ -58,12 +58,12 @@
                         "parent",
                         "child"
                      ],
-                     "hoverProvider": {},
-                     "definitionProvider": {},
+                     "hoverProvider": true,
+                     "definitionProvider": true,
                      "implementationProvider": true,
                      "renameProvider": {},
                      "alsCalledByProvider": true,
-                     "referencesProvider": {},
+                     "referencesProvider": true,
                      "declarationProvider": true,
                      "textDocumentSync": 2,
                      "completionProvider": {
@@ -72,7 +72,7 @@
                         ],
                         "resolveProvider": false
                      },
-                     "documentSymbolProvider": {}
+                     "documentSymbolProvider": true
                   }
                }
             }

--- a/testsuite/ada_lsp/implementation/test.json
+++ b/testsuite/ada_lsp/implementation/test.json
@@ -58,12 +58,12 @@
                         "parent",
                         "child"
                      ],
-                     "hoverProvider": {},
-                     "definitionProvider": {},
+                     "hoverProvider": true,
+                     "definitionProvider": true,
                      "implementationProvider": true,
                      "renameProvider": {},
                      "alsCalledByProvider": true,
-                     "referencesProvider": {},
+                     "referencesProvider": true,
                      "declarationProvider": true,
                      "textDocumentSync": 2,
                      "completionProvider": {
@@ -72,7 +72,7 @@
                         ],
                         "resolveProvider": false
                      },
-                     "documentSymbolProvider": {}
+                     "documentSymbolProvider": true
                   }
                }
             }

--- a/testsuite/ada_lsp/incorrect_fallback/incorrect_fallback.json
+++ b/testsuite/ada_lsp/incorrect_fallback/incorrect_fallback.json
@@ -100,9 +100,9 @@
                "id": 0,
                "result": {
                   "capabilities": {
-                     "hoverProvider": {}, 
-                     "documentSymbolProvider": {}, 
-                     "referencesProvider": {}, 
+                     "hoverProvider": true, 
+                     "documentSymbolProvider": true, 
+                     "referencesProvider": true, 
                      "textDocumentSync": 2, 
                      "completionProvider": {
                         "triggerCharacters": [
@@ -110,7 +110,7 @@
                         ], 
                         "resolveProvider": false
                      }, 
-                     "definitionProvider": {}
+                     "definitionProvider": true
                   }
                }
             }

--- a/testsuite/ada_lsp/indexing_progress/test.json
+++ b/testsuite/ada_lsp/indexing_progress/test.json
@@ -38,11 +38,11 @@
                         "call",
                         "dispatching call", "parent", "child"
                      ],
-                     "hoverProvider": {},
-                     "definitionProvider": {},
+                     "hoverProvider": true,
+                     "definitionProvider": true,
                      "renameProvider": {},
                      "alsCalledByProvider": true,
-                     "referencesProvider": {},
+                     "referencesProvider": true,
                      "textDocumentSync": 2,
                      "completionProvider": {
                         "triggerCharacters": [
@@ -50,7 +50,7 @@
                         ],
                         "resolveProvider": false
                      },
-                     "documentSymbolProvider": {}
+                     "documentSymbolProvider": true
                   }
                }
             }

--- a/testsuite/ada_lsp/invalidation.file_contents/test.json
+++ b/testsuite/ada_lsp/invalidation.file_contents/test.json
@@ -33,11 +33,11 @@
                "result": {
                   "capabilities": {
                      "typeDefinitionProvider": true, 
-                     "hoverProvider": {}, 
-                     "definitionProvider": {}, 
+                     "hoverProvider": true, 
+                     "definitionProvider": true, 
                      "renameProvider": {}, 
                      "alsCalledByProvider": true, 
-                     "referencesProvider": {}, 
+                     "referencesProvider": true, 
                      "textDocumentSync": 2,
                      "completionProvider": {
                         "triggerCharacters": [
@@ -45,7 +45,7 @@
                         ], 
                         "resolveProvider": false
                      }, 
-                     "documentSymbolProvider": {}
+                     "documentSymbolProvider": true
                   }
                }
             }

--- a/testsuite/ada_lsp/no_root/no_root.json
+++ b/testsuite/ada_lsp/no_root/no_root.json
@@ -20,7 +20,7 @@
                 "result":{
                     "capabilities":{
                         "textDocumentSync": 2,
-                        "definitionProvider":{}
+                        "definitionProvider":true
                     }
                 }
             }]

--- a/testsuite/ada_lsp/no_root/uri_with_slash.json
+++ b/testsuite/ada_lsp/no_root/uri_with_slash.json
@@ -20,7 +20,7 @@
                 "result":{
                     "capabilities":{
                         "textDocumentSync": 2,
-                        "definitionProvider":{}
+                        "definitionProvider":true
                     }
                 }
             }]

--- a/testsuite/ada_lsp/non_project_files/non_project_files.json
+++ b/testsuite/ada_lsp/non_project_files/non_project_files.json
@@ -19,7 +19,7 @@
                 "result":{
                     "capabilities":{
                         "textDocumentSync": 2,
-                        "definitionProvider":{}
+                        "definitionProvider":true
                     }
                 }
             }]

--- a/testsuite/ada_lsp/project_config/project_config.json
+++ b/testsuite/ada_lsp/project_config/project_config.json
@@ -21,7 +21,7 @@
                 "result":{
                     "capabilities":{
                         "textDocumentSync": 2,
-                        "definitionProvider":{}
+                        "definitionProvider":true
                     }
                 }
             }]

--- a/testsuite/ada_lsp/project_config/project_config_2.json
+++ b/testsuite/ada_lsp/project_config/project_config_2.json
@@ -21,7 +21,7 @@
                 "result":{
                     "capabilities":{
                         "textDocumentSync": 2,
-                        "definitionProvider":{}
+                        "definitionProvider":true
                     }
                 }
             }]

--- a/testsuite/ada_lsp/project_reload/project_reload.json
+++ b/testsuite/ada_lsp/project_reload/project_reload.json
@@ -19,7 +19,7 @@
                 "result":{
                     "capabilities":{
                         "textDocumentSync": 2,
-                        "referencesProvider":{}
+                        "referencesProvider":true
                     }
                 }
             }]

--- a/testsuite/ada_lsp/project_search/project_search.json
+++ b/testsuite/ada_lsp/project_search/project_search.json
@@ -21,7 +21,7 @@
                 "result":{
                     "capabilities":{
                         "textDocumentSync": 2,
-                        "definitionProvider":{}
+                        "definitionProvider":true
                     }
                 }
             }]

--- a/testsuite/ada_lsp/references.child/test.json
+++ b/testsuite/ada_lsp/references.child/test.json
@@ -60,11 +60,11 @@
                         "parent",
                         "child"
                      ],
-                     "hoverProvider": {},
-                     "definitionProvider": {},
+                     "hoverProvider": true,
+                     "definitionProvider": true,
                      "renameProvider": {},
                      "alsCalledByProvider": true,
-                     "referencesProvider": {},
+                     "referencesProvider": true,
                      "textDocumentSync": 2,
                      "declarationProvider": true,
                      "completionProvider": {
@@ -73,7 +73,7 @@
                         ],
                         "resolveProvider": false
                      },
-                     "documentSymbolProvider": {}
+                     "documentSymbolProvider": true
                   }
                }
             }

--- a/testsuite/ada_lsp/rename.not_up_to_date/test.json
+++ b/testsuite/ada_lsp/rename.not_up_to_date/test.json
@@ -33,11 +33,11 @@
                "result": {
                   "capabilities": {
                      "typeDefinitionProvider": true,
-                     "hoverProvider": {},
-                     "definitionProvider": {},
+                     "hoverProvider": true,
+                     "definitionProvider": true,
                      "renameProvider": {},
                      "alsCalledByProvider": true,
-                     "referencesProvider": {},
+                     "referencesProvider": true,
                      "textDocumentSync": 2,
                      "completionProvider": {
                         "triggerCharacters": [
@@ -45,7 +45,7 @@
                         ],
                         "resolveProvider": false
                      },
-                     "documentSymbolProvider": {}
+                     "documentSymbolProvider": true
                   }
                }
             }

--- a/testsuite/ada_lsp/rename.primitive_parameters/test.json
+++ b/testsuite/ada_lsp/rename.primitive_parameters/test.json
@@ -62,11 +62,11 @@
                         "parent",
                         "child"
                      ],
-                     "hoverProvider": {},
-                     "definitionProvider": {},
+                     "hoverProvider": true,
+                     "definitionProvider": true,
                      "renameProvider": {},
                      "alsCalledByProvider": true,
-                     "referencesProvider": {},
+                     "referencesProvider": true,
                      "declarationProvider": true,
                      "textDocumentSync": 2,
                      "completionProvider": {
@@ -75,7 +75,7 @@
                         ],
                         "resolveProvider": false
                      },
-                     "documentSymbolProvider": {}
+                     "documentSymbolProvider": true
                   }
                }
             }

--- a/testsuite/ada_lsp/rename.tagged_type_primitives/test.json
+++ b/testsuite/ada_lsp/rename.tagged_type_primitives/test.json
@@ -61,11 +61,11 @@
                         "parent",
                         "child"
                      ],
-                     "hoverProvider": {},
-                     "definitionProvider": {},
+                     "hoverProvider": true,
+                     "definitionProvider": true,
                      "renameProvider": {},
                      "alsCalledByProvider": true,
-                     "referencesProvider": {},
+                     "referencesProvider": true,
                      "declarationProvider": true,
                      "textDocumentSync": 2,
                      "completionProvider": {
@@ -74,7 +74,7 @@
                         ],
                         "resolveProvider": false
                      },
-                     "documentSymbolProvider": {}
+                     "documentSymbolProvider": true
                   }
                }
             }

--- a/testsuite/ada_lsp/skip__standard/skip__standard.json
+++ b/testsuite/ada_lsp/skip__standard/skip__standard.json
@@ -19,7 +19,7 @@
                 "result":{
                     "capabilities":{
                         "textDocumentSync": 2,
-                        "definitionProvider":{}
+                        "definitionProvider":true
                     }
                 }
             }]

--- a/testsuite/ada_lsp/spec_from_body/spec_from_body.json
+++ b/testsuite/ada_lsp/spec_from_body/spec_from_body.json
@@ -21,7 +21,7 @@
                 "result":{
                     "capabilities":{
                         "textDocumentSync": 2,
-                        "definitionProvider":{}
+                        "definitionProvider":true
                     }
                 }
             }]

--- a/testsuite/ada_lsp/type_definition.aggregate/test.json
+++ b/testsuite/ada_lsp/type_definition.aggregate/test.json
@@ -58,11 +58,11 @@
                         "parent",
                         "child"
                      ],
-                     "hoverProvider": {},
-                     "definitionProvider": {},
+                     "hoverProvider": true,
+                     "definitionProvider": true,
                      "renameProvider": {},
                      "alsCalledByProvider": true,
-                     "referencesProvider": {},
+                     "referencesProvider": true,
                      "declarationProvider": true,
                      "textDocumentSync": 2,
                      "completionProvider": {
@@ -71,7 +71,7 @@
                         ],
                         "resolveProvider": false
                      },
-                     "documentSymbolProvider": {}
+                     "documentSymbolProvider": true
                   }
                }
             }


### PR DESCRIPTION
when workDoneProgress is not used.
This reverts commit 6d8bea4ae32393bb8cf448472b69ed7b765de33b
for rebased tests.