### PR TITLE
T313-025 Rename only whole words in comments

### DIFF
--- a/source/ada/lsp-ada_handlers.adb
+++ b/source/ada/lsp-ada_handlers.adb
@@ -2123,7 +2123,7 @@ package body LSP.Ada_Handlers is
          begin
             while Token /= No_Token loop
                if Kind (Data (Token)) = Ada_Comment
-                 and then Contains (Token, Name, Span)
+                 and then Contains (Token, Name, True, Span)
                then
                   declare
                      C : constant LSP.Messages.TextEdit :=

--- a/source/ada/lsp-lal_utils.ads
+++ b/source/ada/lsp-lal_utils.ads
@@ -148,8 +148,11 @@ package LSP.Lal_Utils is
    function Contains
      (Token   : Libadalang.Common.Token_Reference;
       Pattern : Wide_Wide_String;
+      As_Word : Boolean;
       Span    : out LSP.Messages.Span)
       return Boolean;
-   --  Return True if the Token text contains Pattern and set position in Span
+   --  Return True if the Token text contains Pattern and set position in Span.
+   --  Checks whether the Token's Pattern is delimited by word delimiters
+   --  if As_Word is True.
 
 end LSP.Lal_Utils;

--- a/testsuite/ada_lsp/rename/main.adb
+++ b/testsuite/ada_lsp/rename/main.adb
@@ -3,5 +3,6 @@ with Ada.Text_IO;
 procedure Main is
    A : Integer := 10;
 begin
+   --  Check that A_letter is not renamed
    Ada.Text_IO.Put_Line (Integer'Image (A));
 end Main;

--- a/testsuite/ada_lsp/rename/rename.json
+++ b/testsuite/ada_lsp/rename/rename.json
@@ -156,7 +156,7 @@
                         "uri": "$URI{main.adb}",
                         "languageId": "ada",
                         "version": 1,
-                        "text": "with Ada.Text_IO;\n\nprocedure Main is\n   A : Integer := 10;\nbegin\n   Ada.Text_IO.Put_Line (Integer'Image (A));\nend Main;\n"
+                        "text": "with Ada.Text_IO;\n\nprocedure Main is\n   A : Integer := 10;\nbegin\n   --  Check that A_letter is not renamed\n   Ada.Text_IO.Put_Line (Integer'Image (A));\nend Main;\n"
                     }
                 }
             },
@@ -185,8 +185,8 @@
                     "changes":{
                         "$URI{main.adb}":[{
                             "range":{
-                                "start":{"line":5,"character":40},
-                                "end":{"line":5,"character":41}
+                                "start":{"line":6,"character":40},
+                                "end":{"line":6,"character":41}
                             },
                             "newText":"BB"
                         },{


### PR DESCRIPTION
For example:
 rename 'A' to 'B' but not 'A_letter' to 'B_Letter'