### PR TITLE
T318-072 We still compile ALS on RHES 5

### DIFF
--- a/source/spawn/pipe2.c
+++ b/source/spawn/pipe2.c
@@ -2,6 +2,7 @@
 #include <unistd.h>
 
 #ifndef O_CLOEXEC
+/* There is no such constant on RHES 5 and earlier */
 #define O_CLOEXEC 0x80000
 #endif
 

--- a/source/spawn/posix_const.c
+++ b/source/spawn/posix_const.c
@@ -3,6 +3,11 @@
 #include <errno.h>
 #include <sys/wait.h>
 
+#ifndef O_CLOEXEC
+/* There is no such constant on RHES 5 and earlier */
+#define O_CLOEXEC 0x80000
+#endif
+
 int SPAWN_O_NONBLOCK = O_NONBLOCK;
 int SPAWN_O_CLOEXEC = O_CLOEXEC;
 int SPAWN_WNOHANG = WNOHANG;


### PR DESCRIPTION
where there is no O_CLOEXEC nor pipe2. This fix is to avoid
compilation error there.