### PR TITLE
T306-021: Add memory usage monitor based on GNATCOLL.Memory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,7 @@ endif
 all: coverage-instrument
 	$(GPRBUILD) -P gnat/spawn_tests.gpr -p $(BUILD_FLAGS)
 	$(GPRBUILD) -P gnat/tester.gpr -p $(BUILD_FLAGS)
+	$(GPRBUILD) -d -ws -c -u -P gnat/lsp_server.gpr -p $(BUILD_FLAGS) s-memory.adb
 	$(GPRBUILD) -P gnat/lsp_server.gpr -p $(COVERAGE_BUILD_FLAGS) \
 		-XVERSION=$(TRAVIS_TAG)
 	$(GPRBUILD) -P gnat/codec_test.gpr -p $(COVERAGE_BUILD_FLAGS)

--- a/doc/HACKING.md
+++ b/doc/HACKING.md
@@ -10,14 +10,29 @@ ALS.IN=yes > inout.txt:buffer_size=0
 ALS.OUT=yes > inout.txt:buffer_size=0
 ```
 
-When this is present, the ALS will generate a file `$HOME/.als/inout.txt`
-which logs the input received and the output sent by the language server.
+When this is present, the Ada Language Server will generate a file
+`$HOME/.als/inout.txt` which logs the input received and the output sent by
+the language server.
+
+You can also monitor the server's memory usage by adding the following lines:
+
+```
+>ada_ls_log.$T.txt:buffer_size=0:buffer_size=0
+ALS.MAIN=yes
+DEBUG.ADA_MEMORY=yes
+```
+
+This will create `ada_ls_log.<timestamp>.txt` log files in your `$HOME/.als`
+directory each time the Ada Language Server is run, with additional information
+about memory usage, allowing to track down which parts of the program consumes
+the most memory.
+This is very useful to resolve unexpected memory consumption issues.
 
 ### Writing tests
 
 To write a functional test for Ada Language Server:
 
-  * Choose a meaninful name for your test, for instance `completion_inside_generics`. 
+  * Choose a meaninful name for your test, for instance `completion_inside_generics`.
      We'll refer to this as `<testname>` below
   * Create a new directory `testsuite/ada_lsp/<testname>` containing your test data
   * Activate full in/out language server traces. See the Debugging section above.
@@ -26,7 +41,7 @@ To write a functional test for Ada Language Server:
      python scripts/traces_to_test.py <testname> <path_to_the_als_traces_file>
      ```
   * Delete all extra requests, notifications and capabilities that are not related
-    to the feature being tested. It will help a lot later when tests are 
+    to the feature being tested. It will help a lot later when tests are
     baselined because of changes in protocol, capablitities or message formats.
   * Replace the comment at the beginning of the test with something meaningful:
   ```
@@ -108,7 +123,7 @@ sed -n -e '/^```typescript/,/^```/p' specification-3-14.md |sed -e 's/^/   --/'
 
 To extract corresponding snippets from `lsp-messages.ads` use this:
 ```
-sed -n -e '/^   --```typescript/,/^   --```/p' lsp-messages.ads 
+sed -n -e '/^   --```typescript/,/^   --```/p' lsp-messages.ads
 ```
 
 Unfortunately we have to reorder Ada declarations to follow _"define before use"_

--- a/source/memory/lsp-memory_statistics.adb
+++ b/source/memory/lsp-memory_statistics.adb
@@ -1,0 +1,99 @@
+------------------------------------------------------------------------------
+--                         Language Server Protocol                         --
+--                                                                          --
+--                        Copyright (C) 2020, AdaCore                       --
+--                                                                          --
+-- This is free software;  you can redistribute it  and/or modify it  under --
+-- terms of the  GNU General Public License as published  by the Free Soft- --
+-- ware  Foundation;  either version 3,  or (at your option) any later ver- --
+-- sion.  This software is distributed in the hope  that it will be useful, --
+-- but WITHOUT ANY WARRANTY;  without even the implied warranty of MERCHAN- --
+-- TABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public --
+-- License for  more details.  You should have  received  a copy of the GNU --
+-- General  Public  License  distributed  with  this  software;   see  file --
+-- COPYING3.  If not, go to http://www.gnu.org/licenses for a complete copy --
+-- of the license.                                                          --
+------------------------------------------------------------------------------
+
+with Ada.Strings.Unbounded;   use Ada.Strings.Unbounded;
+with GNAT.Regpat;             use GNAT.Regpat;
+with GNAT.Traceback.Symbolic; use GNAT.Traceback.Symbolic;
+with System.Address_Image;
+with System.Storage_Elements; use System.Storage_Elements;
+
+package body LSP.Memory_Statistics is
+
+   ----------------------------
+   -- Dump_Memory_Statistics --
+   ----------------------------
+
+   function Dump_Memory_Statistics
+     (Size   : Positive;
+      Report : Report_Type := Memory_Usage)
+      return String
+   is
+      Buffer           : Unbounded_String := To_Unbounded_String
+        ("Dump_Memory_Statistics at 0x" &
+           System.Address_Image (Dump_Memory_Statistics'Address) & ASCII.LF);
+      Traceback_Regexp : constant Pattern_Matcher :=
+                           Compile ("\s0x0+([0-9a-zA-Z]+)");
+
+      procedure Trace_Put (S : String);
+
+      procedure Trace_Put_Line (S : String);
+
+      ---------------
+      -- Trace_Put --
+      ---------------
+
+      procedure Trace_Put (S : String) is
+         Matched : Match_Array (0 .. 1);
+      begin
+         Match (Traceback_Regexp, S, Matched);
+
+         --  If we are dealing with traceback addresses, resolve it to the
+         --  actual source location using GNAT.Traceback.Symbolic.
+         --  This is needed since these addresses can point to relocatable
+         --  libraries, in which case addr2line won't be able to find the
+         --  corresponding source locations.
+
+         if Matched (0) = No_Match then
+            Append (Buffer, S);
+         else
+            declare
+               Traceback_Str : constant String :=
+                                 S (Matched (1).First .. Matched (1).Last);
+               Traceback_Long : constant Long_Integer :=
+                                  Long_Integer'Value
+                                    ("16#" & Traceback_Str & "#");
+               Traceback_Addr : constant System.Address :=
+                                  To_Address
+                                    (Integer_Address (Traceback_Long));
+               New_S          : constant String :=
+                                  Symbolic_Traceback_No_Hex
+                                    ((1 => Traceback_Addr));
+            begin
+               Append (Buffer, New_S);
+            end;
+         end if;
+      end Trace_Put;
+
+      --------------------
+      -- Trace_Put_Line --
+      --------------------
+
+      procedure Trace_Put_Line (S : String) is
+      begin
+         Append (Buffer, S & ASCII.LF);
+      end Trace_Put_Line;
+
+      procedure Internal is new GNATCOLL.Memory.Redirectable_Dump
+        (Put_Line => Trace_Put_Line,
+         Put      => Trace_Put);
+
+   begin
+      Internal (Size, Report);
+      return To_String (Buffer);
+   end Dump_Memory_Statistics;
+
+end LSP.Memory_Statistics;

--- a/source/memory/lsp-memory_statistics.ads
+++ b/source/memory/lsp-memory_statistics.ads
@@ -1,7 +1,7 @@
 ------------------------------------------------------------------------------
 --                         Language Server Protocol                         --
 --                                                                          --
---                        Copyright (C) 2018, AdaCore                       --
+--                        Copyright (C) 2020, AdaCore                       --
 --                                                                          --
 -- This is free software;  you can redistribute it  and/or modify it  under --
 -- terms of the  GNU General Public License as published  by the Free Soft- --
@@ -15,37 +15,19 @@
 -- of the license.                                                          --
 ------------------------------------------------------------------------------
 
-with "libadalang";
+--  This package is used to dump the memory statistics gathered by
+--  GNATCOLL.Memory.
 
-with "lsp";
+with GNATCOLL.Memory; use GNATCOLL.Memory;
 
-project LSP_Server is
+package LSP.Memory_Statistics is
 
-   VERSION := external ("VERSION", "latest");
+   function Dump_Memory_Statistics
+     (Size   : Positive;
+      Report : Report_Type := Memory_Usage)
+      return String;
+   --  Dump information about memory usage to configurable output
+   --  Size is the number of the biggest memory users we want to show. Report
+   --  indicates which sorting order is used in the report.
 
-   for Source_Dirs use
-     ("../source/server",
-      "../source/server/generated",
-      "../source/ada",
-      "../source/memory");
-
-   for Object_Dir use "../.obj/server";
-   for Main use ("lsp-ada_driver.adb");
-
-   package Compiler is
-      for Default_Switches ("Ada") use LSP.Ada_Switches;
-      for Switches ("lsp-ada_driver.adb") use
-        LSP.Ada_Switches & ("-gnateDVERSION=""" & VERSION & """");
-      for Switches ("s-memory.adb") use ("-g", "-O2", "-gnatpg");
-   end Compiler;
-
-
-   package Binder is
-      for Switches ("ada") use ("-E");
-   end Binder;
-
-   package Builder is
-      for Executable ("lsp-ada_driver") use "ada_language_server";
-   end Builder;
-
-end LSP_Server;
+end LSP.Memory_Statistics;

--- a/source/memory/s-memory.adb
+++ b/source/memory/s-memory.adb
@@ -1,7 +1,7 @@
 ------------------------------------------------------------------------------
 --                         Language Server Protocol                         --
 --                                                                          --
---                        Copyright (C) 2018, AdaCore                       --
+--                        Copyright (C) 2020, AdaCore                       --
 --                                                                          --
 -- This is free software;  you can redistribute it  and/or modify it  under --
 -- terms of the  GNU General Public License as published  by the Free Soft- --
@@ -15,37 +15,23 @@
 -- of the license.                                                          --
 ------------------------------------------------------------------------------
 
-with "libadalang";
+with GNATCOLL.Memory;
 
-with "lsp";
+package body System.Memory is
+   package M renames GNATCOLL.Memory;
 
-project LSP_Server is
+   function Alloc (Size : size_t) return System.Address is
+   begin
+      return M.Alloc (M.size_t (Size));
+   end Alloc;
 
-   VERSION := external ("VERSION", "latest");
+   procedure Free (Ptr : System.Address) renames M.Free;
 
-   for Source_Dirs use
-     ("../source/server",
-      "../source/server/generated",
-      "../source/ada",
-      "../source/memory");
-
-   for Object_Dir use "../.obj/server";
-   for Main use ("lsp-ada_driver.adb");
-
-   package Compiler is
-      for Default_Switches ("Ada") use LSP.Ada_Switches;
-      for Switches ("lsp-ada_driver.adb") use
-        LSP.Ada_Switches & ("-gnateDVERSION=""" & VERSION & """");
-      for Switches ("s-memory.adb") use ("-g", "-O2", "-gnatpg");
-   end Compiler;
-
-
-   package Binder is
-      for Switches ("ada") use ("-E");
-   end Binder;
-
-   package Builder is
-      for Executable ("lsp-ada_driver") use "ada_language_server";
-   end Builder;
-
-end LSP_Server;
+   function Realloc
+     (Ptr  : System.Address;
+      Size : size_t)
+      return System.Address is
+   begin
+      return M.Realloc (Ptr, M.size_t (Size));
+   end Realloc;
+end System.Memory;

--- a/source/server/lsp-servers.adb
+++ b/source/server/lsp-servers.adb
@@ -44,7 +44,7 @@ package body LSP.Servers is
 
    function "+" (Text : Ada.Strings.UTF_Encoding.UTF_8_String)
       return LSP.Types.LSP_String renames
-       LSP.Types.To_LSP_String;
+     LSP.Types.To_LSP_String;
 
    procedure Process_One_Message
      (Self        : in out Server'Class;
@@ -144,8 +144,7 @@ package body LSP.Servers is
 
    procedure Initialize
      (Self         : in out Server;
-      Stream       : access Ada.Streams.Root_Stream_Type'Class)
-   is
+      Stream       : access Ada.Streams.Root_Stream_Type'Class) is
    begin
       Self.Stream := Stream;
    end Initialize;


### PR DESCRIPTION
when the DEBUG.ADA_MEMORY trace is enabled, we now monitor the
memory usage consumption and dump it in the logs.

This allows to identify which parts of the program are the
biggest memory usage consumers.

The stacktrace addresses are resolved using GNAT.Symbolic.Traceback
because we link the ALS with relocatable libraries.