### PR TITLE
T311-013 Execute window/workDoneProgress/create request

### DIFF
--- a/integration/vscode/ada/package.json
+++ b/integration/vscode/ada/package.json
@@ -185,7 +185,7 @@
         "postinstall": "vscode-install"
     },
     "dependencies": {
-        "vscode-languageclient": "^5.2.1",
+        "vscode-languageclient": "^6.0.1",
         "ws": "^6.0.0",
         "process": "^0.10.0"
     }

--- a/source/protocol/lsp-client_request_receivers.ads
+++ b/source/protocol/lsp-client_request_receivers.ads
@@ -38,4 +38,9 @@ package LSP.Client_Request_Receivers is
       Message : LSP.Messages.Client_Requests.Workspace_Configuration_Request)
         is abstract;
 
+   procedure On_WorkDoneProgress_Create_Request
+     (Self    : access Client_Request_Receiver;
+      Message : LSP.Messages.Client_Requests.WorkDoneProgressCreate_Request)
+        is abstract;
+
 end LSP.Client_Request_Receivers;

--- a/source/protocol/lsp-messages-client_requests.adb
+++ b/source/protocol/lsp-messages-client_requests.adb
@@ -44,6 +44,17 @@ package body LSP.Messages.Client_Requests is
    -----------
 
    overriding procedure Visit
+     (Self    : WorkDoneProgressCreate_Request;
+      Reciver : access Client_Request_Receiver'Class) is
+   begin
+      Reciver.On_WorkDoneProgress_Create_Request (Self);
+   end Visit;
+
+   -----------
+   -- Visit --
+   -----------
+
+   overriding procedure Visit
      (Self    : Workspace_Configuration_Request;
       Reciver : access Client_Request_Receiver'Class) is
    begin

--- a/source/protocol/lsp-messages-client_requests.ads
+++ b/source/protocol/lsp-messages-client_requests.ads
@@ -67,4 +67,17 @@ package LSP.Messages.Client_Requests is
      (Self    : Workspace_Configuration_Request;
       Reciver : access Client_Request_Receiver'Class);
 
+   package WorkDoneProgressCreate_Requests is
+     new LSP.Generic_Requests
+       (Client_Request,
+        WorkDoneProgressCreateParams,
+        Client_Request_Receiver'Class);
+
+   type WorkDoneProgressCreate_Request is
+     new WorkDoneProgressCreate_Requests.Request with null record;
+
+   overriding procedure Visit
+     (Self    : WorkDoneProgressCreate_Request;
+      Reciver : access Client_Request_Receiver'Class);
+
 end LSP.Messages.Client_Requests;

--- a/source/protocol/lsp-messages.adb
+++ b/source/protocol/lsp-messages.adb
@@ -3231,6 +3231,22 @@ package body LSP.Messages is
       JS.End_Object;
    end Read_WindowClientCapabilities;
 
+   ---------------------------------------
+   -- Read_WorkDoneProgressCreateParams --
+   ---------------------------------------
+
+   procedure Read_WorkDoneProgressCreateParams
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out WorkDoneProgressCreateParams)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+   begin
+      JS.Start_Object;
+      Read_Number_Or_String (JS, +"token", V.token);
+      JS.End_Object;
+   end Read_WorkDoneProgressCreateParams;
+
    ----------------------------------
    -- Read_WorkDoneProgressOptions --
    ----------------------------------
@@ -6469,6 +6485,22 @@ package body LSP.Messages is
       Write_Optional_Number (JS, +"percentage", V.percentage);
       JS.End_Object;
    end Write_WorkDoneProgressBegin;
+
+   ----------------------------------------
+   -- Write_WorkDoneProgressCreateParams --
+   ----------------------------------------
+
+   procedure Write_WorkDoneProgressCreateParams
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : WorkDoneProgressCreateParams)
+   is
+      JS : LSP.JSON_Streams.JSON_Stream'Class renames
+        LSP.JSON_Streams.JSON_Stream'Class (S.all);
+   begin
+      JS.Start_Object;
+      Write_Number_Or_String (JS, +"token", V.token);
+      JS.End_Object;
+   end Write_WorkDoneProgressCreateParams;
 
    -----------------------------------
    -- Write_WorkDoneProgressOptions --

--- a/source/protocol/lsp-messages.ads
+++ b/source/protocol/lsp-messages.ads
@@ -2963,6 +2963,20 @@ package LSP.Messages is
    --	token: ProgressToken;
    --}
    --```
+   type WorkDoneProgressCreateParams is record
+      token: ProgressToken;
+   end record;
+
+   procedure Read_WorkDoneProgressCreateParams
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : out WorkDoneProgressCreateParams);
+
+   procedure Write_WorkDoneProgressCreateParams
+     (S : access Ada.Streams.Root_Stream_Type'Class;
+      V : WorkDoneProgressCreateParams);
+
+   for WorkDoneProgressCreateParams'Read use Read_WorkDoneProgressCreateParams;
+   for WorkDoneProgressCreateParams'Write use Write_WorkDoneProgressCreateParams;
 
    --```typescript
    --export interface WorkDoneProgressParams {

--- a/source/server/lsp-message_loggers.adb
+++ b/source/server/lsp-message_loggers.adb
@@ -31,6 +31,7 @@ package body LSP.Message_Loggers is
    function Image (Value : LSP.Messages.ResponseMessage'Class) return String;
    function Image (Value : LSP.Messages.Position) return String;
    function Image (Value : LSP.Messages.Span) return String;
+   function Image (Value : LSP.Types.LSP_Number_Or_String) return String;
 
    function Image
      (Value : LSP.Messages.TextDocumentPositionParams'Class) return String;
@@ -50,14 +51,23 @@ package body LSP.Message_Loggers is
    -- Image --
    -----------
 
+   function Image (Value : LSP.Types.LSP_Number_Or_String) return String is
+   begin
+      if Value.Is_Number then
+         return LSP.Types.LSP_Number'Image (Value.Number);
+      else
+         return +Value.String;
+      end if;
+   end Image;
+
+   -----------
+   -- Image --
+   -----------
+
    function Image (Value : LSP.Messages.RequestMessage'Class) return String is
       Prefix : constant String := "Request ";
    begin
-      if Value.id.Is_Number then
-         return Prefix & LSP.Types.LSP_Number'Image (Value.id.Number) & ' ';
-      else
-         return Prefix & (+Value.id.String) & ' ';
-      end if;
+      return Prefix & Image (Value.id) & ' ';
    end Image;
 
    -----------
@@ -1281,5 +1291,20 @@ package body LSP.Message_Loggers is
          & Image (Value)
          & (+Value.params.query));
    end On_Workspace_Symbols_Request;
+
+   ----------------------------------------
+   -- On_WorkDoneProgress_Create_Request --
+   ----------------------------------------
+
+   overriding procedure On_WorkDoneProgress_Create_Request
+     (Self  : access Message_Logger;
+      Value : LSP.Messages.Client_Requests.WorkDoneProgressCreate_Request)
+   is
+   begin
+      Self.Trace.Trace
+        ("WorkDoneProgress_Create_Request: "
+         & Image (Value)
+         & Image (Value.params.token));
+   end On_WorkDoneProgress_Create_Request;
 
 end LSP.Message_Loggers;

--- a/source/server/lsp-message_loggers.ads
+++ b/source/server/lsp-message_loggers.ads
@@ -306,6 +306,10 @@ private
      (Self   : access Message_Logger;
       Value  : LSP.Messages.Client_Requests.ShowMessage_Request);
 
+   overriding procedure On_WorkDoneProgress_Create_Request
+     (Self  : access Message_Logger;
+      Value : LSP.Messages.Client_Requests.WorkDoneProgressCreate_Request);
+
    overriding procedure On_Workspace_Apply_Edit_Request
      (Self   : access Message_Logger;
       Value  : LSP.Messages.Client_Requests.Workspace_Apply_Edit_Request);

--- a/source/server/lsp-servers.adb
+++ b/source/server/lsp-servers.adb
@@ -615,6 +615,17 @@ package body LSP.Servers is
       Self.Send_Request ("workspace/configuration", Message);
    end On_Workspace_Configuration_Request;
 
+   ----------------------------------------
+   -- On_WorkDoneProgress_Create_Request --
+   ----------------------------------------
+
+   overriding procedure On_WorkDoneProgress_Create_Request
+     (Self    : access Server;
+      Message : LSP.Messages.Client_Requests.WorkDoneProgressCreate_Request) is
+   begin
+      Self.Send_Request ("window/workDoneProgress/create", Message);
+   end On_WorkDoneProgress_Create_Request;
+
    ---------
    -- Run --
    ---------

--- a/source/server/lsp-servers.ads
+++ b/source/server/lsp-servers.ads
@@ -120,6 +120,10 @@ package LSP.Servers is
      (Self    : access Server;
       Message : LSP.Messages.Client_Requests.Workspace_Configuration_Request);
 
+   overriding procedure On_WorkDoneProgress_Create_Request
+     (Self    : access Server;
+      Message : LSP.Messages.Client_Requests.WorkDoneProgressCreate_Request);
+
    function Has_Pending_Work (Self : Server) return Boolean;
    --  Return True if the server has work in the queue, other than the
    --  notification/request it's currently processing. This should only be

--- a/testsuite/ada_lsp/indexing_progress/test.json
+++ b/testsuite/ada_lsp/indexing_progress/test.json
@@ -83,6 +83,14 @@
          },
          "wait": [
             {
+               "jsonrpc":"2.0",
+               "id":2,
+               "method":"window/workDoneProgress/create",
+               "params":{
+                  "token":"<ANY>"
+               }
+            },
+            {
                "params": {
                   "token": "<ANY>",
                   "value": {


### PR DESCRIPTION
before sending work progress report. This enables progress indicator
in vscode.