### PR TITLE
T330-041 Fix behavior when encountering an invalid project

### DIFF
--- a/source/ada/lsp-ada_context_sets.adb
+++ b/source/ada/lsp-ada_context_sets.adb
@@ -85,7 +85,7 @@ package body LSP.Ada_Context_Sets is
          end if;
       end loop;
 
-      return Self.Contexts.Last_Element;
+      return Self.Contexts.First_Element;
    end Get_Best_Context;
 
    ---------

--- a/source/ada/lsp-ada_context_sets.ads
+++ b/source/ada/lsp-ada_context_sets.ads
@@ -48,7 +48,8 @@ package LSP.Ada_Context_Sets is
      (Self : Context_Set'Class;
       URI  : LSP.Messages.DocumentUri) return Context_Access;
    --  Return the first context in Contexts which contains a project
-   --  which knows about file. Fallback on the "no project" context.
+   --  which knows about file. Return the first context if no such
+   --  context was found.
 
    function Total_Source_Files (Self : Context_Set'Class) return Natural;
    --  Number of files in all contexts

--- a/testsuite/ada_lsp/invalid_project/foo.ads
+++ b/testsuite/ada_lsp/invalid_project/foo.ads
@@ -1,0 +1,3 @@
+package foo is
+   A : Integer := 1;
+end foo;

--- a/testsuite/ada_lsp/invalid_project/invalid.gpr
+++ b/testsuite/ada_lsp/invalid_project/invalid.gpr
@@ -1,0 +1,3 @@
+with "doesnotexist";
+project invalid is
+end project;

--- a/testsuite/ada_lsp/invalid_project/main.adb
+++ b/testsuite/ada_lsp/invalid_project/main.adb
@@ -1,0 +1,7 @@
+with foo; use foo;
+procedure Main is
+begin
+   if A = 2 then
+      raise Program_Error;
+   end if;
+end;

--- a/testsuite/ada_lsp/invalid_project/test.json
+++ b/testsuite/ada_lsp/invalid_project/test.json
@@ -1,0 +1,329 @@
+[
+   {
+      "comment": [
+         "verify that basic behavior is working even if the project is invalid"
+      ]
+   }, 
+   {
+      "start": {
+         "cmd": [
+            "${ALS}"
+         ]
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "capabilities": {
+                  "textDocument": {
+                     "completion": {
+                        "completionItem": {
+                           "documentationFormat": [
+                              "plaintext", 
+                              "markdown"
+                           ], 
+                           "snippetSupport": false
+                        }, 
+                        "completionItemKind": {}, 
+                        "dynamicRegistration": true
+                     }, 
+                     "definition": {}, 
+                     "hover": {}, 
+                     "codeLens": {}, 
+                     "selectionRange": {}, 
+                     "implementation": {}, 
+                     "formatting": {}, 
+                     "typeDefinition": {}, 
+                     "documentHighlight": {}, 
+                     "synchronization": {}, 
+                     "references": {}, 
+                     "rangeFormatting": {}, 
+                     "onTypeFormatting": {}, 
+                     "declaration": {}, 
+                     "foldingRange": {
+                        "lineFoldingOnly": true
+                     }, 
+                     "colorProvider": {}
+                  }, 
+                  "workspace": {
+                     "applyEdit": true, 
+                     "executeCommand": {}, 
+                     "didChangeWatchedFiles": {}, 
+                     "workspaceEdit": {}, 
+                     "didChangeConfiguration": {}
+                  }
+               }, 
+               "rootUri": "$URI{.}"
+            }, 
+            "jsonrpc": "2.0", 
+            "id": 1, 
+            "method": "initialize"
+         }, 
+         "wait": []
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0", 
+            "method": "initialized"
+         }, 
+         "wait": []
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "settings": {
+                  "ada": {
+                     "projectFile": "invalid.gpr", 
+                     "scenarioVariables": {}, 
+                     "enableDiagnostics": false, 
+                     "defaultCharset": "UTF-8"
+                  }
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "method": "workspace/didChangeConfiguration"
+         }, 
+         "wait": [
+         ]
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "text": "with foo; use foo;\nprocedure Main is\nbegin\n   if A = 2 then\n      raise Program_Error;\n   end if;\nend;\n", 
+                  "version": 0, 
+                  "uri": "$URI{main.adb}", 
+                  "languageId": "Ada"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "method": "textDocument/didOpen"
+         }, 
+         "wait": []
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{main.adb}"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "id": 2, 
+            "method": "textDocument/foldingRange"
+         }, 
+         "wait": [
+            {
+               "id": 2, 
+               "result": [
+                  {
+                     "endLine": 6, 
+                     "startLine": 1, 
+                     "kind": "region"
+                  }, 
+                  {
+                     "endLine": 5, 
+                     "startLine": 3, 
+                     "kind": "region"
+                  }
+               ]
+            }
+         ]
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{main.adb}"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "id": 3, 
+            "method": "textDocument/foldingRange"
+         }, 
+         "wait": [
+            {
+               "id": 3, 
+               "result": [
+                  {
+                     "endLine": 6, 
+                     "startLine": 1, 
+                     "kind": "region"
+                  }, 
+                  {
+                     "endLine": 5, 
+                     "startLine": 3, 
+                     "kind": "region"
+                  }
+               ]
+            }
+         ]
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "position": {
+                  "line": 3, 
+                  "character": 6
+               }, 
+               "textDocument": {
+                  "uri": "$URI{main.adb}"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "id": 4, 
+            "method": "textDocument/definition"
+         }, 
+         "wait": [
+            {
+               "id": 4, 
+               "result": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 1, 
+                           "character": 3
+                        }, 
+                        "end": {
+                           "line": 1, 
+                           "character": 4
+                        }
+                     }, 
+                     "uri": "$URI{foo.ads}"
+                  }
+               ]
+            }
+         ]
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "text": "package foo is\n   A : Integer := 1;\nend foo;\n", 
+                  "version": 0, 
+                  "uri": "$URI{foo.ads}", 
+                  "languageId": "Ada"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "method": "textDocument/didOpen"
+         }, 
+         "wait": []
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.ads}"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "id": 5, 
+            "method": "textDocument/foldingRange"
+         }, 
+         "wait": [
+            {
+               "id": 5, 
+               "result": [
+                  {
+                     "endLine": 2, 
+                     "startLine": 0, 
+                     "kind": "region"
+                  }
+               ]
+            }
+         ]
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.ads}"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "id": 6, 
+            "method": "textDocument/foldingRange"
+         }, 
+         "wait": [
+            {
+               "id": 6, 
+               "result": [
+                  {
+                     "endLine": 2, 
+                     "startLine": 0, 
+                     "kind": "region"
+                  }
+               ]
+            }
+         ]
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{main.adb}"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "method": "textDocument/didClose"
+         }, 
+         "wait": []
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.ads}"
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "method": "textDocument/didClose"
+         }, 
+         "wait": []
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0", 
+            "id": 7, 
+            "method": "shutdown"
+         }, 
+         "wait": [
+            {
+               "id": 7, 
+               "result": null
+            }
+         ]
+      }
+   }, 
+   {
+      "stop": {
+         "exit_code": 0
+      }
+   }
+]

--- a/testsuite/ada_lsp/invalid_project/test.yaml
+++ b/testsuite/ada_lsp/invalid_project/test.yaml
@@ -1,0 +1,1 @@
+title: 'invalid_project'


### PR DESCRIPTION
When the language server is given a project that does not load,
it should fall back on the implicit project.

Clarify the documentation and behavior of Get_Best_Context.