### PR TITLE
T319-027: Add completion for subprogram parameters

### DIFF
--- a/source/ada/lsp-ada_documents.ads
+++ b/source/ada/lsp-ada_documents.ads
@@ -95,10 +95,11 @@ package LSP.Ada_Documents is
    --  Get Libadalang Node for given position in the document.
 
    procedure Get_Completions_At
-     (Self     : Document;
-      Context  : LSP.Ada_Contexts.Context;
-      Position : LSP.Messages.Position;
-      Result   : out LSP.Messages.CompletionList);
+     (Self             : Document;
+      Context          : LSP.Ada_Contexts.Context;
+      Position         : LSP.Messages.Position;
+      Snippets_Enabled : Boolean;
+      Result           : out LSP.Messages.CompletionList);
    --  Populate Result with completions for given position in the document.
 
    procedure Get_Folding_Blocks

--- a/source/ada/lsp-ada_handlers.adb
+++ b/source/ada/lsp-ada_handlers.adb
@@ -597,6 +597,16 @@ package body LSP.Ada_Handlers is
            foldingRange.Value.lineFoldingOnly.Value;
       end if;
 
+      if Value.capabilities.textDocument.completion.completionItem.Is_Set
+        and then Value.capabilities.textDocument.completion.
+          completionItem.Value.snippetSupport.Is_Set
+          and then Value.capabilities.textDocument.completion.
+            completionItem.Value.snippetSupport.Value
+      then
+         --  Client capability to support snippets for completion
+         Self.Completion_Snippets_Enabled := True;
+      end if;
+
       if not LSP.Types.Is_Empty (Value.rootUri) then
          Root := URI_To_File (Value.rootUri);
       else
@@ -2835,7 +2845,11 @@ package body LSP.Ada_Handlers is
         (Is_Error => False);
    begin
       Document.Get_Completions_At
-        (Context.all, Value.position, Response.result);
+        (Context          => Context.all,
+         Position         => Value.position,
+         Snippets_Enabled => Self.Completion_Snippets_Enabled,
+         Result           => Response.result);
+
       return Response;
    end On_Completion_Request;
 

--- a/source/ada/lsp-ada_handlers.ads
+++ b/source/ada/lsp-ada_handlers.ads
@@ -153,6 +153,9 @@ private
       Line_Folding_Only : Boolean := False;
       --  Client capabilities, folding only per lines
 
+      Completion_Snippets_Enabled : Boolean := False;
+      --  True if the client supports completion snippets
+
       ----------------------
       -- Project handling --
       ----------------------

--- a/source/tester/tester-macros.adb
+++ b/source/tester/tester-macros.adb
@@ -36,7 +36,7 @@ package body Tester.Macros is
    --  Turn Path into URI with scheme 'file://'
 
    Pattern : constant GNAT.Regpat.Pattern_Matcher :=
-     GNAT.Regpat.Compile ("\${([^}]+)}|\$URI{([^}]+)}");
+     GNAT.Regpat.Compile ("\${([\W]+)}|\$URI{([^}]+)}");
 
    function Expand
      (Value    : GNATCOLL.JSON.JSON_Value;

--- a/testsuite/ada_lsp/completion.subp_parameters/default.gpr
+++ b/testsuite/ada_lsp/completion.subp_parameters/default.gpr
@@ -1,0 +1,7 @@
+project Default is
+
+   for Languages use ("Ada");
+   for Source_Dirs use ("src");
+   for Main use ("main.adb");
+
+end Default;

--- a/testsuite/ada_lsp/completion.subp_parameters/src/bar.ads
+++ b/testsuite/ada_lsp/completion.subp_parameters/src/bar.ads
@@ -1,0 +1,9 @@
+package Bar is
+
+   type My_Int is tagged record
+      A : Integer;
+   end record;
+
+   procedure Do_Nothing (Obj : My_Int; A :Integer) is null;
+
+end Bar;

--- a/testsuite/ada_lsp/completion.subp_parameters/src/main.adb
+++ b/testsuite/ada_lsp/completion.subp_parameters/src/main.adb
@@ -1,0 +1,13 @@
+with Bar; use Bar;
+
+procedure Main is
+   Obj : My_Int := (A => 10);
+
+   function Add (A, B : Integer) return Integer
+   is
+      (A + B);
+
+   A : Integer := 3;
+begin
+   Obj
+end Main;

--- a/testsuite/ada_lsp/completion.subp_parameters/test.json
+++ b/testsuite/ada_lsp/completion.subp_parameters/test.json
@@ -1,0 +1,451 @@
+[
+   {
+      "comment": [
+          "check that completion snippets for subprograms are properly ",
+          "formatted. This test verifies that snippets work well with ",
+          "dotted notation and with subpograms that list several parameters",
+          "with the same type with the ',' notation ",
+          "(e.g: procedure Add (A, B: Integer)"
+      ]
+   },
+   {
+      "start": {
+         "cmd": [
+            "${ALS}"
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "processId": 26867,
+               "capabilities": {
+                  "textDocument": {
+                     "completion": {
+                        "completionItem": {
+                           "documentationFormat": [
+                              "plaintext",
+                              "markdown"
+                           ],
+                           "snippetSupport": true
+                        },
+                        "completionItemKind": {},
+                        "dynamicRegistration": true
+                     },
+                     "definition": {},
+                     "hover": {},
+                     "codeLens": {},
+                     "selectionRange": {},
+                     "implementation": {},
+                     "formatting": {},
+                     "typeDefinition": {},
+                     "documentHighlight": {},
+                     "synchronization": {},
+                     "references": {},
+                     "rangeFormatting": {},
+                     "onTypeFormatting": {},
+                     "declaration": {},
+                     "foldingRange": {
+                        "lineFoldingOnly": true
+                     },
+                     "colorProvider": {}
+                  },
+                  "workspace": {
+                     "applyEdit": true,
+                     "executeCommand": {},
+                     "didChangeWatchedFiles": {},
+                     "workspaceEdit": {},
+                     "didChangeConfiguration": {}
+                  }
+               },
+               "rootUri": "$URI{src}"
+            },
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize"
+         },
+          "wait":
+          [
+              {
+                  "jsonrpc": "2.0",
+                  "id": 1,
+                  "result": {
+                      "capabilities": {
+                          "textDocumentSync": 2,
+                          "completionProvider": {
+                              "resolveProvider": false,
+                              "triggerCharacters": [
+                                  "."
+                              ]
+                          },
+                          "hoverProvider": true,
+                          "declarationProvider": true,
+                          "definitionProvider": true,
+                          "typeDefinitionProvider": true,
+                          "implementationProvider": true,
+                          "referencesProvider": true,
+                          "documentSymbolProvider": true,
+                          "codeActionProvider": {
+                          },
+                          "renameProvider": {
+                          },
+                          "foldingRangeProvider": true,
+                          "executeCommandProvider": {
+                              "commands": [
+                                  "als-named-parameters"
+                              ]
+                          },
+                          "alsCalledByProvider": true,
+                          "alsReferenceKinds": [
+                              "reference",
+                              "write",
+                              "call",
+                              "dispatching call",
+                              "parent",
+                              "child"
+                          ]
+                      }
+                  }
+              }
+          ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "initialized"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "settings": {
+                  "ada": {
+                     "scenarioVariables": {},
+                     "enableDiagnostics": false,
+                     "defaultCharset": "ISO-8859-1"
+                  }
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "workspace/didChangeConfiguration"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "text": "with Bar; use Bar;\n\nprocedure Main is\n   Obj : My_Int := (A => 10);\n\n   function Add (A, B : Integer) return Integer\n   is\n      (A + B);\n\n   A : Integer := 3;\nbegin\n   Obj\nend Main;\n",
+                  "version": 0,
+                  "uri": "$URI{src/main.adb}",
+                  "languageId": "Ada"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "text": "package Bar is\n\n   type My_Int is tagged record\n      A : Integer;\n   end record;\n\n   procedure Do_Nothing (Obj : My_Int; A :Integer) is null;\n\nend Bar;\n",
+                  "version": 0,
+                  "uri": "$URI{src/bar.ads}",
+                  "languageId": "Ada"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "error": {
+               "message": "Unknown method:window/workDoneProgress/create",
+               "code": -32601
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "contentChanges": [
+                  {
+                     "text": "with Bar; use Bar;\n\nprocedure Main is\n   Obj : My_Int := (A => 10);\n\n   function Add (A, B : Integer) return Integer\n   is\n      (A + B);\n\n   A : Integer := 3;\nbegin\n   Obj.\nend Main;\n"
+                  }
+               ],
+               "textDocument": {
+                  "version": 1,
+                  "uri": "$URI{src/main.adb}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "position": {
+                  "line": 11,
+                  "character": 7
+               },
+               "textDocument": {
+                  "uri": "$URI{src/main.adb}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "id": 4,
+            "method": "textDocument/completion"
+         },
+         "wait": [
+            {
+               "id": 4,
+               "result": {
+                  "isIncomplete": false,
+                  "items": [
+                     {
+                        "additionalTextEdits": [],
+                        "kind": 5,
+                        "documentation": "",
+                        "detail": "",
+                        "label": "A"
+                     },
+                     {
+                        "insertText": "Do_Nothing (${1:Integer : A})$0",
+                        "kind": 3,
+                        "documentation": "",
+                        "detail": "(subprogram) ",
+                        "label": "Do_Nothing",
+                        "additionalTextEdits": [],
+                        "insertTextFormat": 2
+                     }
+                  ]
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "contentChanges": [
+                  {
+                     "text": "with Bar; use Bar;\n\nprocedure Main is\n   Obj : My_Int := (A => 10);\n\n   function Add (A, B : Integer) return Integer\n   is\n      (A + B);\n\n   A : Integer := 3;\nbegin\n   Obj\nend Main;\n"
+                  }
+               ],
+               "textDocument": {
+                  "version": 2,
+                  "uri": "$URI{src/main.adb}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "contentChanges": [
+                  {
+                     "text": "with Bar; use Bar;\n\nprocedure Main is\n   Obj : My_Int := (A => 10);\n\n   function Add (A, B : Integer) return Integer\n   is\n      (A + B);\n\n   A : Integer := 3;\nbegin\n   Ob\nend Main;\n"
+                  }
+               ],
+               "textDocument": {
+                  "version": 3,
+                  "uri": "$URI{src/main.adb}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "contentChanges": [
+                  {
+                     "text": "with Bar; use Bar;\n\nprocedure Main is\n   Obj : My_Int := (A => 10);\n\n   function Add (A, B : Integer) return Integer\n   is\n      (A + B);\n\n   A : Integer := 3;\nbegin\n   O\nend Main;\n"
+                  }
+               ],
+               "textDocument": {
+                  "version": 4,
+                  "uri": "$URI{src/main.adb}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "contentChanges": [
+                  {
+                     "text": "with Bar; use Bar;\n\nprocedure Main is\n   Obj : My_Int := (A => 10);\n\n   function Add (A, B : Integer) return Integer\n   is\n      (A + B);\n\n   A : Integer := 3;\nbegin\n   \nend Main;\n"
+                  }
+               ],
+               "textDocument": {
+                  "version": 5,
+                  "uri": "$URI{src/main.adb}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "contentChanges": [
+                  {
+                     "text": "with Bar; use Bar;\n\nprocedure Main is\n   Obj : My_Int := (A => 10);\n\n   function Add (A, B : Integer) return Integer\n   is\n      (A + B);\n\n   A : Integer := 3;\nbegin\n   A\nend Main;\n"
+                  }
+               ],
+               "textDocument": {
+                  "version": 6,
+                  "uri": "$URI{src/main.adb}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "position": {
+                  "line": 11,
+                  "character": 4
+               },
+               "textDocument": {
+                  "uri": "$URI{src/main.adb}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "id": 6,
+            "method": "textDocument/completion"
+         },
+         "wait": [
+            {
+               "id": 6,
+               "result": {
+                  "isIncomplete": false,
+                  "items": [
+                     {
+                        "additionalTextEdits": [],
+                        "kind": 6,
+                        "documentation": "",
+                        "detail": "(var) Integer",
+                        "label": "A"
+                     },
+                     {
+                        "insertText": "Add (${1:Integer : A}, ${2:Integer : B})$0",
+                        "kind": 3,
+                        "documentation": "",
+                        "detail": "(subprogram) ",
+                        "label": "Add",
+                        "additionalTextEdits": [],
+                        "insertTextFormat": 2
+                     },
+                     {
+                        "additionalTextEdits": [],
+                        "kind": 9,
+                        "documentation": "",
+                        "detail": "(package) ",
+                        "label": "ASCII"
+                     }
+                  ]
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{src/bar.ads}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didClose"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{src/main.adb}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didClose"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": 10,
+            "method": "shutdown"
+         },
+         "wait": [
+            {
+               "id": 10,
+               "result": null
+            }
+         ]
+      }
+   },
+   {
+      "stop": {
+         "exit_code": 0
+      }
+   }
+]

--- a/testsuite/ada_lsp/completion.subp_parameters/test.yaml
+++ b/testsuite/ada_lsp/completion.subp_parameters/test.yaml
@@ -1,0 +1,1 @@
+title: 'completion.subp_parameters'


### PR DESCRIPTION
The ALS now sends snippets for subprogram completion items, listing
all the formal parameters of the given subprogram to help users
assigning a value for each of them.

An automatic test has been added and tester-macros.adb has been adapted
to avoid conflicts between the compeltion snippets format and our macros
format.