### PR TITLE
SA21-029: Ignore the Enum type values in Document Symbols

### DIFF
--- a/source/ada/lsp-ada_documents.adb
+++ b/source/ada/lsp-ada_documents.adb
@@ -730,7 +730,9 @@ package body LSP.Ada_Documents is
             return LSP.Messages.Number;
 
          when Ada_Enum_Literal_Decl =>
-            return LSP.Messages.Enum;
+            return (if Ignore_Local
+                    then LSP.Messages.A_Null
+                    else LSP.Messages.Enum);
 
          when Ada_Exception_Decl =>
             return LSP.Messages.String;

--- a/testsuite/ada_lsp/get_symbol_hier/test.json
+++ b/testsuite/ada_lsp/get_symbol_hier/test.json
@@ -133,66 +133,7 @@
                              },
                              "alsIsDeclaration": true,
                              "alsVisibility": 1,
-                             "children": [
-                               {
-                                 "name": "A",
-                                 "detail": "",
-                                 "kind": 10,
-                                 "range": {
-                                   "start": {
-                                     "line": 1,
-                                     "character": 17
-                                   },
-                                   "end": {
-                                     "line": 1,
-                                     "character": 18
-                                   }
-                                 },
-                                 "selectionRange": {
-                                   "start": {
-                                     "line": 1,
-                                     "character": 17
-                                   },
-                                   "end": {
-                                     "line": 1,
-                                     "character": 18
-                                   }
-                                 },
-                                 "alsIsDeclaration": false,
-                                 "alsVisibility": 1,
-                                 "children": [
-                                 ]
-                               },
-                               {
-                                 "name": "B",
-                                 "detail": "",
-                                 "kind": 10,
-                                 "range": {
-                                   "start": {
-                                     "line": 1,
-                                     "character": 20
-                                   },
-                                   "end": {
-                                     "line": 1,
-                                     "character": 21
-                                   }
-                                 },
-                                 "selectionRange": {
-                                   "start": {
-                                     "line": 1,
-                                     "character": 20
-                                   },
-                                   "end": {
-                                     "line": 1,
-                                     "character": 21
-                                   }
-                                 },
-                                 "alsIsDeclaration": false,
-                                 "alsVisibility": 1,
-                                 "children": [
-                                 ]
-                               }
-                             ]
+                             "children": []
                            },
                            {
                              "name": "Nested_Package",


### PR DESCRIPTION
For the following enum type:

type Hello_World is (Hello, World);

Don't return "Hello" and "World" in the Document Symbols request,
we are only interested on the type declaration, I.E. "Hello_World".