### PR TITLE
T327-013: Display hover text for completion items too

### DIFF
--- a/source/ada/lsp-ada_documents.adb
+++ b/source/ada/lsp-ada_documents.adb
@@ -965,47 +965,9 @@ package body LSP.Ada_Documents is
    --------------------
 
    function Compute_Completion_Detail
-     (BD : Libadalang.Analysis.Basic_Decl) return LSP.Types.LSP_String
-   is
-      use Libadalang.Analysis;
-      use Libadalang.Common;
-      use LSP.Messages;
-      use LSP.Types;
-
-      Ret : LSP_String;
+     (BD : Libadalang.Analysis.Basic_Decl) return LSP.Types.LSP_String is
    begin
-      case Get_Decl_Kind (BD) is
-         when A_Function =>
-            Append (Ret, "(subprogram) ");
-
-         when Variable =>
-            case BD.Kind is
-               when Ada_Param_Spec =>
-                  Append (Ret, "(param) ");
-               when others =>
-                  Append (Ret, "(var) ");
-            end case;
-
-            declare
-               TE : constant Type_Expr := BD.As_Basic_Decl.P_Type_Expression;
-            begin
-               if not TE.Is_Null then
-                  Append
-                    (Ret,
-                     To_LSP_String (TE.Text));
-               end if;
-            end;
-         when LSP.Messages.Class =>
-
-            Append (Ret, "(type) ");
-
-         when LSP.Messages.A_Package =>
-            Append (Ret, "(package) ");
-
-         when others => null;
-      end case;
-
-      return Ret;
+      return LSP.Common.Get_Hover_Text (BD);
    end Compute_Completion_Detail;
 
    -----------------------------

--- a/source/ada/lsp-ada_handlers.adb
+++ b/source/ada/lsp-ada_handlers.adb
@@ -1581,7 +1581,6 @@ package body LSP.Ada_Handlers is
 
       Defining_Name_Node : Defining_Name;
       Decl               : Basic_Decl;
-      Subp_Spec_Node     : Base_Subp_Spec;
       Decl_Text          : LSP_String;
       Comments_Text      : LSP_String;
       Location_Text      : LSP_String;
@@ -1612,41 +1611,7 @@ package body LSP.Ada_Handlers is
          Decl := As_Enum_Literal_Decl (Decl).P_Enum_Type.As_Basic_Decl;
          Decl_Text := Get_Hover_Text (Decl);
       else
-
-         --  Try to retrieve the subprogram spec node, if any: if it's a
-         --  subprogram node that does not have any separate declaration we
-         --  only want to display its specification, not the body.
-         Subp_Spec_Node := Decl.P_Subp_Spec_Or_Null;
-
-         if Subp_Spec_Node /= No_Base_Subp_Spec then
-            Decl_Text := Get_Hover_Text (Subp_Spec_Node);
-
-            --  Append the aspects to the declaration text, if any.
-            declare
-               Aspects      : constant Aspect_Spec := Decl.F_Aspects;
-               Aspects_Text : LSP_String;
-            begin
-               if not Aspects.Is_Null then
-                  for Aspect of Aspects.F_Aspect_Assocs loop
-                     if Aspects_Text /= Empty_LSP_String then
-                        --  need to add "," for the highlighting
-                        Append (Aspects_Text, +",");
-                     end if;
-
-                     Append (Aspects_Text, Get_Hover_Text (Aspect));
-                  end loop;
-
-                  if Aspects_Text /= Empty_LSP_String then
-                     Decl_Text := Decl_Text
-                       & To_LSP_String (Line_Feed & "with")
-                       & Aspects_Text;
-                  end if;
-               end if;
-            end;
-
-         else
-            Decl_Text := Get_Hover_Text (Decl);
-         end if;
+         Decl_Text := Get_Hover_Text (Decl);
       end if;
 
       if Decl_Text = Empty_LSP_String then

--- a/source/ada/lsp-common.adb
+++ b/source/ada/lsp-common.adb
@@ -26,6 +26,11 @@ with Libadalang.Common;        use Libadalang.Common;
 
 package body LSP.Common is
 
+   function Get_Hover_Text_For_Node (Node : Ada_Node'Class) return LSP_String;
+   --  Return a pretty printed version of the node's text to be
+   --  displayed on hover requests, removing unnecessary indentation
+   --  whitespaces if needed and attaching extra information in some cases.
+
    ---------
    -- Log --
    ---------
@@ -43,11 +48,7 @@ package body LSP.Common is
                    & ASCII.LF & Symbolic_Traceback (E));
    end Log;
 
-   --------------------
-   -- Get_Hover_Text --
-   --------------------
-
-   function Get_Hover_Text (Node : Ada_Node'Class) return LSP_String
+   function Get_Hover_Text_For_Node (Node : Ada_Node'Class) return LSP_String
    is
       Text   : constant String := Langkit_Support.Text.To_UTF8
         (Node.Text);
@@ -324,6 +325,7 @@ package body LSP.Common is
       end Get_Aspect_Hover_Text;
 
    begin
+
       case Node.Kind is
          when Ada_Package_Body =>
 
@@ -349,7 +351,55 @@ package body LSP.Common is
       end case;
 
       GNAT.Strings.Free (Lines);
+
       return Result;
+   end Get_Hover_Text_For_Node;
+
+   --------------------
+   -- Get_Hover_Text --
+   --------------------
+
+   function Get_Hover_Text (Decl : Basic_Decl'Class) return LSP_String is
+      Decl_Text      : LSP_String;
+      Subp_Spec_Node : Base_Subp_Spec;
+      Line_Feed      : constant String := "" & ASCII.LF;
+   begin
+      --  Try to retrieve the subprogram spec node, if any : if it's a
+      --  subprogram node that does not have any separate declaration we
+      --  only want to display its specification, not the body.
+      Subp_Spec_Node := Decl.P_Subp_Spec_Or_Null;
+
+      if Subp_Spec_Node /= No_Base_Subp_Spec then
+         Decl_Text := Get_Hover_Text_For_Node (Subp_Spec_Node);
+
+         --  Append the aspects to the declaration text, if any.
+         declare
+            Aspects      : constant Aspect_Spec := Decl.F_Aspects;
+            Aspects_Text : LSP_String;
+         begin
+            if not Aspects.Is_Null then
+               for Aspect of Aspects.F_Aspect_Assocs loop
+                  if Aspects_Text /= Empty_LSP_String then
+                     --  need to add "," for the highlighting
+                     Append (Aspects_Text, ",");
+                  end if;
+
+                  Append (Aspects_Text, Get_Hover_Text_For_Node (Aspect));
+               end loop;
+
+               if Aspects_Text /= Empty_LSP_String then
+                  Decl_Text := Decl_Text
+                    & To_LSP_String (Line_Feed & "with")
+                    & Aspects_Text;
+               end if;
+            end if;
+         end;
+
+      else
+         Decl_Text := Get_Hover_Text_For_Node (Decl);
+      end if;
+
+      return Decl_Text;
    end Get_Hover_Text;
 
 end LSP.Common;

--- a/source/ada/lsp-common.ads
+++ b/source/ada/lsp-common.ads
@@ -39,9 +39,9 @@ package LSP.Common is
       Message : String := "");
    --  Log an exception in the given traces, with an optional message
 
-   function Get_Hover_Text (Node : Ada_Node'Class) return LSP_String;
-   --  Return a pretty printed version of the node's text to be displayed on
-   --  hover requests, removing unnecessary indentation whitespaces if needed
-   --  and attaching extra information in some cases.
+   function Get_Hover_Text (Decl : Basic_Decl'Class) return LSP_String;
+   --  Return a pretty printed version of the declaration's text to be
+   --  displayed on hover requests, removing unnecessary indentation
+   --  whitespaces if needed and attaching extra information in some cases.
 
 end LSP.Common;

--- a/testsuite/ada_lsp/completion.subp_parameters/test.json
+++ b/testsuite/ada_lsp/completion.subp_parameters/test.json
@@ -231,14 +231,14 @@
                         "additionalTextEdits": [],
                         "kind": 5,
                         "documentation": "",
-                        "detail": "",
+                        "detail": "A : Integer;",
                         "label": "A"
                      },
                      {
                         "insertText": "Do_Nothing (${1:A : Integer})$0",
                         "kind": 3,
                         "documentation": "",
-                        "detail": "(subprogram) ",
+                        "detail": "procedure Do_Nothing (Obj : My_Int; A :Integer) is null",
                         "label": "Do_Nothing",
                         "additionalTextEdits": [],
                         "insertTextFormat": 2
@@ -375,14 +375,14 @@
                         "additionalTextEdits": [],
                         "kind": 6,
                         "documentation": "",
-                        "detail": "(var) Integer",
+                        "detail": "A : Integer := 3;",
                         "label": "A"
                      },
                      {
                         "insertText": "Add (${1:A : Integer}, ${2:B : Integer})$0",
                         "kind": 3,
                         "documentation": "",
-                        "detail": "(subprogram) ",
+                        "detail": "function Add (A, B : Integer) return Integer",
                         "label": "Add",
                         "additionalTextEdits": [],
                         "insertTextFormat": 2
@@ -391,7 +391,7 @@
                         "additionalTextEdits": [],
                         "kind": 9,
                         "documentation": "",
-                        "detail": "(package) ",
+                        "detail": "package ASCII ",
                         "label": "ASCII"
                      }
                   ]


### PR DESCRIPTION
Display the hover text of the completion item's declaration in the
'detail' field of the completion item.

This allows to distinguish more easily overloaded subprograms
for instance. This is also what other Microsoft's language servers
do (e.g: Python).