### PR TITLE
Adapt to new compiler rules for type visibility

### DIFF
--- a/source/ada/lsp-ada_documents.adb
+++ b/source/ada/lsp-ada_documents.adb
@@ -23,6 +23,7 @@ with GNATCOLL.Utils;
 
 with Langkit_Support.Slocs;
 with Langkit_Support.Text;
+with Libadalang.Analysis; use Libadalang.Analysis;
 with Libadalang.Common;
 with Libadalang.Doc_Utils;
 with Libadalang.Iterators;
@@ -285,8 +286,6 @@ package body LSP.Ada_Documents is
       begin
          if Node.Kind in Libadalang.Common.Ada_Basic_Decl then
             declare
-               use type Libadalang.Analysis.Defining_Name;
-
                Decl : constant Libadalang.Analysis.Basic_Decl :=
                  Node.As_Basic_Decl;
 
@@ -404,7 +403,6 @@ package body LSP.Ada_Documents is
       Position : LSP.Messages.Position)
       return Libadalang.Analysis.Ada_Node
    is
-      use Libadalang.Analysis;
       use Langkit_Support.Slocs;
 
       Unit : constant Libadalang.Analysis.Analysis_Unit :=
@@ -430,7 +428,6 @@ package body LSP.Ada_Documents is
       Result     : out LSP.Messages.FoldingRange_Vector)
    is
       use Libadalang.Common;
-      use Libadalang.Analysis;
 
       Location     : LSP.Messages.Location;
       foldingRange : LSP.Messages.FoldingRange;
@@ -759,7 +756,6 @@ package body LSP.Ada_Documents is
      (Node : Libadalang.Analysis.Basic_Decl) return LSP.Types.LSP_String
    is
       use Ada.Strings.Wide_Wide_Unbounded;
-      use Libadalang.Analysis;
       use Libadalang.Common;
 
       function To_Text (Node : Ada_Node'Class) return Wide_Wide_String;
@@ -967,7 +963,6 @@ package body LSP.Ada_Documents is
    function Compute_Completion_Detail
      (BD : Libadalang.Analysis.Basic_Decl) return LSP.Types.LSP_String
    is
-      use Libadalang.Analysis;
       use Libadalang.Common;
    begin
 
@@ -993,7 +988,6 @@ package body LSP.Ada_Documents is
       Snippets_Enabled : Boolean)
       return LSP.Messages.CompletionItem
    is
-      use Libadalang.Analysis;
       use Libadalang.Common;
       use LSP.Messages;
       use LSP.Types;
@@ -1117,7 +1111,6 @@ package body LSP.Ada_Documents is
       Snippets_Enabled : Boolean;
       Result           : out LSP.Messages.CompletionList)
    is
-      use Libadalang.Analysis;
       use Libadalang.Common;
       use LSP.Messages;
       use LSP.Types;

--- a/source/ada/lsp-ada_handlers.adb
+++ b/source/ada/lsp-ada_handlers.adb
@@ -30,7 +30,8 @@ with GNATCOLL.JSON;
 with GNATCOLL.Utils;             use GNATCOLL.Utils;
 with GNATCOLL.VFS_Utils;         use GNATCOLL.VFS_Utils;
 
-with LSP.Ada_Contexts; use LSP.Ada_Contexts;
+with LSP.Ada_Documents; use LSP.Ada_Documents;
+with LSP.Ada_Contexts;  use LSP.Ada_Contexts;
 with LSP.Ada_Handlers.Named_Parameters_Commands;
 with LSP.Commands;
 with LSP.Common;       use LSP.Common;
@@ -44,7 +45,7 @@ with Langkit_Support.Slocs;
 with Langkit_Support.Text;
 
 with Libadalang.Analysis;
-with Libadalang.Common;
+with Libadalang.Common;    use Libadalang.Common;
 with Libadalang.Doc_Utils;
 
 with URIs;
@@ -851,7 +852,7 @@ package body LSP.Ada_Handlers is
 
       Found : Boolean := False;
    begin
-      if Document in null then
+      if Document = null then
          return Response;
       end if;
 
@@ -1485,8 +1486,6 @@ package body LSP.Ada_Handlers is
       Request : LSP.Messages.Server_Requests.Folding_Range_Request)
       return LSP.Messages.Server_Responses.FoldingRange_Response
    is
-      use type LSP.Ada_Documents.Document_Access;
-
       Value : LSP.Messages.FoldingRangeParams renames
         Request.params;
 
@@ -1572,7 +1571,6 @@ package body LSP.Ada_Handlers is
       return LSP.Messages.Server_Responses.Hover_Response
    is
       use Libadalang.Analysis;
-      use Libadalang.Common;
 
       Value    : LSP.Messages.TextDocumentPositionParams renames
         Request.params;
@@ -1672,7 +1670,6 @@ package body LSP.Ada_Handlers is
       return LSP.Messages.Server_Responses.Location_Response
    is
       use Libadalang.Analysis;
-      use Libadalang.Common;
 
       Value      : LSP.Messages.ReferenceParams renames Request.params;
       Response   : LSP.Messages.Server_Responses.Location_Response
@@ -2083,8 +2080,6 @@ package body LSP.Ada_Handlers is
       Request : LSP.Messages.Server_Requests.Document_Symbols_Request)
       return LSP.Messages.Server_Responses.Symbol_Response
    is
-      use type LSP.Ada_Documents.Document_Access;
-
       --  The list of symbols for one document shouldn't depend
       --  on the project: we can just choose the best context for this.
       Value    : LSP.Messages.DocumentSymbolParams renames Request.params;
@@ -2164,8 +2159,6 @@ package body LSP.Ada_Handlers is
            (Node : Ada_Node;
             Uri  : LSP.Messages.DocumentUri)
          is
-            use Libadalang.Common;
-
             Token     : Token_Reference := First_Token (Node.Unit);
             Name      : constant Wide_Wide_String :=
               Ada.Strings.Wide_Wide_Unbounded.To_Wide_Wide_String

--- a/source/client/lsp-raw_clients.adb
+++ b/source/client/lsp-raw_clients.adb
@@ -16,11 +16,13 @@
 ------------------------------------------------------------------------------
 
 with Ada.Characters.Latin_1;
-with Ada.Streams;
+with Ada.Streams;            use Ada.Streams;
 with Ada.Strings.Fixed;
 with Ada.Text_IO;
 
 with GNAT.OS_Lib;
+
+with Spawn.Processes; use Spawn.Processes;
 
 package body LSP.Raw_Clients is
 

--- a/source/protocol/lsp-generic_optional.adb
+++ b/source/protocol/lsp-generic_optional.adb
@@ -15,7 +15,7 @@
 -- of the license.                                                          --
 ------------------------------------------------------------------------------
 
-with GNATCOLL.JSON;
+with GNATCOLL.JSON;    use GNATCOLL.JSON;
 with LSP.JSON_Streams;
 
 package body LSP.Generic_Optional is

--- a/source/protocol/lsp-messages.adb
+++ b/source/protocol/lsp-messages.adb
@@ -15,11 +15,12 @@
 -- of the license.                                                          --
 ------------------------------------------------------------------------------
 
+with Ada.Tags;  use Ada.Tags;
 with Ada.Tags.Generic_Dispatching_Constructor;
 with Ada.Strings.Unbounded; use Ada.Strings.Unbounded;
 with Ada.Strings.Wide_Unbounded;
 
-with GNATCOLL.JSON;
+with GNATCOLL.JSON;    use GNATCOLL.JSON;
 with LSP.JSON_Streams;
 
 package body LSP.Messages is
@@ -2207,8 +2208,6 @@ package body LSP.Messages is
      (S : access Ada.Streams.Root_Stream_Type'Class;
       V : out Provider_Options)
    is
-      use type GNATCOLL.JSON.JSON_Value_Type;
-
       JS : LSP.JSON_Streams.JSON_Stream'Class renames
         LSP.JSON_Streams.JSON_Stream'Class (S.all);
 

--- a/source/protocol/lsp-types.adb
+++ b/source/protocol/lsp-types.adb
@@ -97,8 +97,6 @@ package body LSP.Types is
      (S : access Ada.Streams.Root_Stream_Type'Class;
       V : out LSP_Boolean_Or_String)
    is
-      use type GNATCOLL.JSON.JSON_Value_Type;
-
       JS : LSP.JSON_Streams.JSON_Stream'Class renames
         LSP.JSON_Streams.JSON_Stream'Class (S.all);
       Value : constant GNATCOLL.JSON.JSON_Value := JS.Read;

--- a/source/protocol/lsp-types.ads
+++ b/source/protocol/lsp-types.ads
@@ -21,7 +21,7 @@ with Ada.Containers.Vectors;
 with Ada.Streams;
 with Ada.Strings.UTF_Encoding;
 with Ada.Strings.Wide_Unbounded.Wide_Hash;
-with GNATCOLL.JSON;
+with GNATCOLL.JSON;        use GNATCOLL.JSON;
 with LSP.Generic_Optional;
 
 limited with LSP.JSON_Streams;

--- a/source/server/lsp-servers-decode_notification.adb
+++ b/source/server/lsp-servers-decode_notification.adb
@@ -15,6 +15,7 @@
 -- of the license.                                                          --
 ------------------------------------------------------------------------------
 
+with Ada.Tags; use Ada.Tags;
 with Ada.Strings.UTF_Encoding;
 with Ada.Tags.Generic_Dispatching_Constructor;
 

--- a/source/server/lsp-servers-decode_request.adb
+++ b/source/server/lsp-servers-decode_request.adb
@@ -15,6 +15,7 @@
 -- of the license.                                                          --
 ------------------------------------------------------------------------------
 
+with Ada.Tags; use Ada.Tags;
 with Ada.Strings.UTF_Encoding;
 with Ada.Tags.Generic_Dispatching_Constructor;
 

--- a/source/tester/tester-tests.adb
+++ b/source/tester/tester-tests.adb
@@ -22,6 +22,7 @@ with Ada.Strings.Unbounded; use Ada.Strings.Unbounded;
 with GNAT.OS_Lib;           use GNAT.OS_Lib;
 
 with GNATCOLL.Utils; use GNATCOLL.Utils;
+with GNATCOLL.JSON;  use GNATCOLL.JSON;
 
 with Spawn.Processes.Monitor_Loop;
 
@@ -236,8 +237,6 @@ package body Tester.Tests is
      (Self : in out Test;
       Data : Ada.Strings.Unbounded.Unbounded_String)
    is
-      use type GNATCOLL.JSON.JSON_Value_Type;
-
       procedure Sweep_Waits (JSON : GNATCOLL.JSON.JSON_Value);
       --  Find matching wait if any and delete it from Test.Waits
 
@@ -258,8 +257,6 @@ package body Tester.Tests is
       -----------
 
       function Match (Left, Right : GNATCOLL.JSON.JSON_Value) return Boolean is
-
-         use type GNATCOLL.JSON.JSON_Value;
 
          procedure Match_Property
            (Name  : String;


### PR DESCRIPTION
Addresses a number of compiler errors of the form
   (sloc): use clause would make operation legal
   (sloc): operator for type "(type)" defined at
in the most recent version of GNAT.