### PR TITLE
SA21-029: Enhancements for DocumentSymbols

### DIFF
--- a/testsuite/ada_lsp/SA21-029.documentSymbol.with/foo.adb
+++ b/testsuite/ada_lsp/SA21-029.documentSymbol.with/foo.adb
@@ -1,0 +1,15 @@
+with Ada.Text_IO; --  With statement => visible
+
+procedure Foo is
+   I : Integer; --  Nested level = 1 => visible
+
+   procedure Bar;
+
+   procedure Bar is
+      J : Integer; --  Nested level = 2 => invisible
+   begin
+      Ada.Text_IO.Put_Line ("Bar");
+   end Bar;
+begin
+   Ada.Text_IO.Put_Line ("Foo");
+end Foo;

--- a/testsuite/ada_lsp/SA21-029.documentSymbol.with/test.json
+++ b/testsuite/ada_lsp/SA21-029.documentSymbol.with/test.json
@@ -1,0 +1,244 @@
+[
+    {
+      "comment": [
+          "test check the documentSymbol content: global variables and with",
+          " clauses"
+      ]
+    },
+    {
+        "start": {
+            "cmd": ["${ALS}"]
+        }
+    },  {
+        "send": {
+            "request": {
+                "jsonrpc":"2.0","id":0,"method":"initialize",
+                "params":{
+                    "processId":1,
+                    "rootUri":"$URI{.}",
+                    "capabilities":{
+                        "textDocument": {
+                            "documentSymbol":{
+                                "hierarchicalDocumentSymbolSupport":true
+                            }
+                        }
+                    }
+                }
+            },
+            "wait":[{ "id": 0,
+                      "result":{
+                          "capabilities":{
+                              "textDocumentSync": 2,
+                              "documentSymbolProvider":true
+                          }
+                      }
+            }]
+        }
+    },  {
+        "send": {
+            "request": {
+                "jsonrpc":"2.0",
+                "method":"workspace/didChangeConfiguration",
+                "params":{
+                    "settings":{
+                        "ada":{
+                        }
+                    }
+                }
+            },
+            "wait":[]
+        }
+    },  {
+        "send": {
+            "request": {
+                "jsonrpc":"2.0",
+                "method":"textDocument/didOpen",
+                "params":{
+                    "textDocument": {
+                        "uri": "$URI{foo.adb}",
+                        "languageId": "ada",
+                        "version": 1,
+                        "text": "with Ada.Text_IO; --  With statement => visible\n\nprocedure Foo is\n   I : Integer; --  Nested level = 1 => visible\n\n   procedure Bar;\n\n   procedure Bar is\n      J : Integer; --  Nested level = 2 => invisible\n   begin\n      Ada.Text_IO.Put_Line (\"Bar\");\n   end Bar;\nbegin\n   Ada.Text_IO.Put_Line (\"Foo\");\nend Foo;\n"
+                    }
+                }
+            },
+            "wait":[]
+        }
+    },  {
+        "send": {
+            "request": {
+                "jsonrpc":"2.0",
+                "id":"docSymbol",
+                "method":"textDocument/documentSymbol",
+                "params":{
+                    "textDocument": {
+                        "uri": "$URI{foo.adb}"
+                    }
+                }
+            },
+            "wait":[{
+                     "jsonrpc": "2.0",
+                     "id": "docSymbol",
+                     "result": [
+                       {
+                     "range": {
+                        "start": {
+                           "line": 0, 
+                           "character": 0
+                        }, 
+                        "end": {
+                           "line": 0, 
+                           "character": 17
+                        }
+                     }, 
+                     "kind": 3, 
+                     "name": "Ada.Text_IO", 
+                     "selectionRange": {
+                        "start": {
+                           "line": 0, 
+                           "character": 5
+                        }, 
+                        "end": {
+                           "line": 0, 
+                           "character": 16
+                        }
+                     }
+                  }, 
+                  {
+                     "kind": 12, 
+                     "name": "Foo", 
+                     "selectionRange": {
+                        "start": {
+                           "line": 2, 
+                           "character": 10
+                        }, 
+                        "end": {
+                           "line": 2, 
+                           "character": 13
+                        }
+                     }, 
+                     "alsVisibility": 1, 
+                     "alsIsDeclaration": false, 
+                     "detail": "", 
+                     "range": {
+                        "start": {
+                           "line": 2, 
+                           "character": 0
+                        }, 
+                        "end": {
+                           "line": 14, 
+                           "character": 8
+                        }
+                     }, 
+                     "children": [
+                        {
+                           "kind": 13, 
+                           "name": "I", 
+                           "selectionRange": {
+                              "start": {
+                                 "line": 3, 
+                                 "character": 3
+                              }, 
+                              "end": {
+                                 "line": 3, 
+                                 "character": 4
+                              }
+                           }, 
+                           "alsVisibility": 1, 
+                           "alsIsDeclaration": false, 
+                           "detail": "", 
+                           "range": {
+                              "start": {
+                                 "line": 3, 
+                                 "character": 3
+                              }, 
+                              "end": {
+                                 "line": 3, 
+                                 "character": 15
+                              }
+                           }, 
+                           "children": []
+                        }, 
+                        {
+                           "kind": 12, 
+                           "name": "Bar", 
+                           "selectionRange": {
+                              "start": {
+                                 "line": 5, 
+                                 "character": 13
+                              }, 
+                              "end": {
+                                 "line": 5, 
+                                 "character": 16
+                              }
+                           }, 
+                           "alsVisibility": 1, 
+                           "alsIsDeclaration": true, 
+                           "detail": "", 
+                           "range": {
+                              "start": {
+                                 "line": 5, 
+                                 "character": 3
+                              }, 
+                              "end": {
+                                 "line": 5, 
+                                 "character": 17
+                              }
+                           }, 
+                           "children": []
+                        }, 
+                        {
+                           "kind": 12, 
+                           "name": "Bar", 
+                           "selectionRange": {
+                              "start": {
+                                 "line": 7, 
+                                 "character": 13
+                              }, 
+                              "end": {
+                                 "line": 7, 
+                                 "character": 16
+                              }
+                           }, 
+                           "alsVisibility": 1, 
+                           "alsIsDeclaration": false, 
+                           "detail": "", 
+                           "range": {
+                              "start": {
+                                 "line": 7, 
+                                 "character": 3
+                              }, 
+                              "end": {
+                                 "line": 11, 
+                                 "character": 11
+                              }
+                           }, 
+                           "children": []
+                        }
+                     ]
+                  }
+               ]
+            }
+         ]
+        }
+    },  {
+        "send": {
+            "request": {
+                "jsonrpc":"2.0",
+                "id": "shutdown",
+                "method":"shutdown",
+                "params":null
+            },
+            "wait":[{ "id": "shutdown", "result": null }]
+        }
+    },  {
+        "send": {
+            "request": {"jsonrpc":"2.0", "method":"exit", "params":{}},
+            "wait":[]
+        }
+    }, {
+        "stop": {
+            "exit_code": 0
+        }
+    }
+]

--- a/testsuite/ada_lsp/SA21-029.documentSymbol.with/test.yaml
+++ b/testsuite/ada_lsp/SA21-029.documentSymbol.with/test.yaml
@@ -1,0 +1,1 @@
+title: 'SA21-029.documentSymbol.with'

--- a/testsuite/ada_lsp/get_symbol_hier/test.json
+++ b/testsuite/ada_lsp/get_symbol_hier/test.json
@@ -136,6 +136,35 @@
                              "children": []
                            },
                            {
+                            "name": "Variable",
+                            "detail": "",
+                            "kind": 13,
+                            "range": {
+                              "start": {
+                                "line": 2,
+                                "character": 3
+                              },
+                              "end": {
+                                "line": 2,
+                                "character": 19
+                              }
+                            },
+                            "selectionRange": {
+                              "start": {
+                                "line": 2,
+                                "character": 3
+                              },
+                              "end": {
+                                "line": 2,
+                                "character": 11
+                              }
+                            },
+                            "alsIsDeclaration": false,
+                            "alsVisibility": 1,
+                            "children": [
+                            ]
+                           },
+                           {
                              "name": "Nested_Package",
                              "detail": "",
                              "kind": 4,


### PR DESCRIPTION
Add Global variables in DocumentSymbols request.
Defensive code when walking through empty nodes.
Add "with" clauses.