### PR TITLE
R519-005: Add a completion test for complex renames

### DIFF
--- a/testsuite/ada_lsp/completion.complex_renames/default.gpr
+++ b/testsuite/ada_lsp/completion.complex_renames/default.gpr
@@ -1,0 +1,10 @@
+project Default is
+
+   package Compiler is
+      for Switches ("Ada") use ("-g", "-O2");
+   end Compiler;
+
+   for Main use ("main.adb") & project'Main;
+
+end Default;
+

--- a/testsuite/ada_lsp/completion.complex_renames/main.adb
+++ b/testsuite/ada_lsp/completion.complex_renames/main.adb
@@ -1,0 +1,8 @@
+with Parent.Children;
+
+procedure Main is
+   package Wl renames Parent.Children;
+   Child : Wl.Child;
+begin
+   Child
+end Main;

--- a/testsuite/ada_lsp/completion.complex_renames/parent-children.ads
+++ b/testsuite/ada_lsp/completion.complex_renames/parent-children.ads
@@ -1,0 +1,15 @@
+package Parent.Children is
+
+   type Child;
+   
+   type Child is tagged limited private;
+   
+   procedure Do_Someting (D : Children.Child) is null;
+   
+private 
+   
+   type Child is tagged limited record 
+      A : Integer;
+   end record;
+   
+end Parent.Children;

--- a/testsuite/ada_lsp/completion.complex_renames/parent.ads
+++ b/testsuite/ada_lsp/completion.complex_renames/parent.ads
@@ -1,0 +1,3 @@
+package Parent is
+
+end Parent;

--- a/testsuite/ada_lsp/completion.complex_renames/test.json
+++ b/testsuite/ada_lsp/completion.complex_renames/test.json
@@ -1,0 +1,246 @@
+[
+   {
+      "comment": [
+         "This test checks that completion works fine on renamed packages."
+      ]
+   },
+   {
+      "start": {
+         "cmd": [
+            "${ALS}"
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "processId": 14502,
+               "capabilities": {
+                  "textDocument": {
+                     "completion": {
+                        "completionItem": {
+                           "documentationFormat": [
+                              "plaintext",
+                              "markdown"
+                           ],
+                           "snippetSupport": true
+                        },
+                        "completionItemKind": {},
+                        "dynamicRegistration": true
+                     },
+                     "definition": {},
+                     "hover": {},
+                     "codeLens": {},
+                     "selectionRange": {},
+                     "implementation": {},
+                     "formatting": {},
+                     "typeDefinition": {},
+                     "documentHighlight": {},
+                     "documentSymbol": {
+                        "symbolKind": {},
+                        "hierarchicalDocumentSymbolSupport": true
+                     },
+                     "synchronization": {},
+                     "references": {},
+                     "rangeFormatting": {},
+                     "onTypeFormatting": {},
+                     "declaration": {},
+                     "foldingRange": {
+                        "lineFoldingOnly": true
+                     },
+                     "colorProvider": {}
+                  },
+                  "workspace": {
+                     "applyEdit": true,
+                     "executeCommand": {},
+                     "didChangeWatchedFiles": {},
+                     "workspaceEdit": {},
+                     "didChangeConfiguration": {}
+                  }
+               },
+               "rootUri": "$URI{.}"
+            },
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize"
+         },
+         "wait": [
+             {
+                 "jsonrpc": "2.0",
+                 "id": 1,
+                 "result": {
+                     "capabilities": {
+                         "textDocumentSync": 2,
+                         "completionProvider": {
+                             "resolveProvider": false,
+                             "triggerCharacters": [
+                                 "."
+                             ]
+                         },
+                         "hoverProvider": true,
+                         "declarationProvider": true,
+                         "definitionProvider": true,
+                         "typeDefinitionProvider": true,
+                         "implementationProvider": true,
+                         "referencesProvider": true,
+                         "documentSymbolProvider": true,
+                         "codeActionProvider": {
+                         },
+                         "renameProvider": {
+                         },
+                         "foldingRangeProvider": true,
+                         "executeCommandProvider": {
+                             "commands": [
+                                 "als-named-parameters"
+                             ]
+                         },
+                         "alsCalledByProvider": true,
+                         "alsReferenceKinds": [
+                             "reference",
+                             "write",
+                             "call",
+                             "dispatching call",
+                             "parent",
+                             "child"
+                         ]
+                     }
+                 }
+             }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "initialized"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "settings": {
+                  "ada": {
+                     "scenarioVariables": {},
+                     "enableDiagnostics": false,
+                     "defaultCharset": "ISO-8859-1"
+                  }
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "workspace/didChangeConfiguration"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "text": "with Parent.Children;\n\nprocedure Main is\n   package Wl renames Parent.Children;\n   Child : Wl.Child;\nbegin\n   Child\nend Main;\n",
+                  "version": 0,
+                  "uri": "$URI{main.adb}",
+                  "languageId": "Ada"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "contentChanges": [
+                  {
+                     "text": "with Parent.Children;\n\nprocedure Main is\n   package Wl renames Parent.Children;\n   Child : Wl.Child;\nbegin\n   Child.\nend Main;\n"
+                  }
+               ],
+               "textDocument": {
+                  "version": 1,
+                  "uri": "$URI{main.adb}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "position": {
+                  "line": 6,
+                  "character": 9
+               },
+               "textDocument": {
+                  "uri": "$URI{main.adb}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "textDocument/completion"
+         },
+         "wait": [
+            {
+               "id": 2,
+               "result": {
+                  "isIncomplete": false,
+                  "items": [
+                     {
+                        "additionalTextEdits": [],
+                        "kind": 3,
+                        "documentation": "",
+                        "detail": "procedure Do_Someting (D : Children.Child) is null",
+                        "label": "Do_Someting"
+                     }
+                  ]
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{main.adb}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didClose"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "shutdown"
+         },
+         "wait": [
+            {
+               "id": 3,
+               "result": null
+            }
+         ]
+      }
+   },
+   {
+      "stop": {
+         "exit_code": 0
+      }
+   }
+]

--- a/testsuite/ada_lsp/completion.complex_renames/test.yaml
+++ b/testsuite/ada_lsp/completion.complex_renames/test.yaml
@@ -1,0 +1,1 @@
+title: 'completion.complex_renames'


### PR DESCRIPTION
This was not working with the old GNAT Studio completion engine
but now works with the ALS.