### PR TITLE
T319-027: Handle package prefixes for subp calls completion

### DIFF
--- a/source/ada/lsp-ada_documents.adb
+++ b/source/ada/lsp-ada_documents.adb
@@ -64,10 +64,10 @@ package body LSP.Ada_Documents is
 
    function Compute_Completion_Item
      (Context          : LSP.Ada_Contexts.Context;
-      Node             : Libadalang.Analysis.Ada_Node;
       BD               : Libadalang.Analysis.Basic_Decl;
       DN               : Libadalang.Analysis.Defining_Name;
-      Snippets_Enabled : Boolean)
+      Snippets_Enabled : Boolean;
+      Is_Dot_Call      : Boolean)
       return LSP.Messages.CompletionItem;
    --  Compute a completion item.
    --  Node is the node from which the completion starts (e.g: 'A' in 'A.').
@@ -75,6 +75,8 @@ package body LSP.Ada_Documents is
    --  that should be used to compute the completion item.
    --  When Snippets_Enabled is True, subprogram completion items are computed
    --  as snippets that list all the subprogram's formal parameters.
+   --  Is_Dot_Call is used to know if we should omit the first parameter
+   --  when computing subprogram snippets.
 
    function Compute_Completion_Detail
      (BD : Libadalang.Analysis.Basic_Decl) return LSP.Types.LSP_String;
@@ -1060,13 +1062,12 @@ package body LSP.Ada_Documents is
 
    function Compute_Completion_Item
      (Context          : LSP.Ada_Contexts.Context;
-      Node             : Libadalang.Analysis.Ada_Node;
       BD               : Libadalang.Analysis.Basic_Decl;
       DN               : Libadalang.Analysis.Defining_Name;
-      Snippets_Enabled : Boolean)
+      Snippets_Enabled : Boolean;
+      Is_Dot_Call      : Boolean)
       return LSP.Messages.CompletionItem
    is
-      use Libadalang.Common;
       use LSP.Messages;
       use LSP.Types;
 
@@ -1117,7 +1118,7 @@ package body LSP.Ada_Documents is
          All_Params  : constant Param_Spec_Array := Subp_Spec_Node.P_Params;
 
          Params      : constant Param_Spec_Array :=
-           (if Node.Kind in Ada_Dotted_Name_Range then
+           (if Is_Dot_Call then
                All_Params (All_Params'First + 1 .. All_Params'Last)
             else
                All_Params);
@@ -1261,12 +1262,11 @@ package body LSP.Ada_Documents is
 
                         Result.items.Append
                           (Compute_Completion_Item
-                             (Context => Context,
-                              Node    => Node,
-                              BD      => BD,
-                              DN      => DN,
-                              Snippets_Enabled =>
-                                Snippets_Enabled));
+                             (Context          => Context,
+                              BD               => BD,
+                              DN               => DN,
+                              Snippets_Enabled => Snippets_Enabled,
+                              Is_Dot_Call      => Is_Dot_Call (CI)));
                      end if;
                   end;
                end loop;

--- a/testsuite/ada_lsp/completion.subp_params_dotted_names/default.gpr
+++ b/testsuite/ada_lsp/completion.subp_params_dotted_names/default.gpr
@@ -1,0 +1,7 @@
+project Default is
+
+   for Languages use ("Ada");
+   for Source_Dirs use ("src");
+   for Main use ("main.adb");
+
+end Default;

--- a/testsuite/ada_lsp/completion.subp_params_dotted_names/src/bar.ads
+++ b/testsuite/ada_lsp/completion.subp_params_dotted_names/src/bar.ads
@@ -1,0 +1,9 @@
+package Bar is
+
+   type My_Int is tagged record
+      A : Integer;
+   end record;
+
+   procedure Do_Nothing (Obj : My_Int; A :Integer) is null;
+
+end Bar;

--- a/testsuite/ada_lsp/completion.subp_params_dotted_names/src/main.adb
+++ b/testsuite/ada_lsp/completion.subp_params_dotted_names/src/main.adb
@@ -1,0 +1,13 @@
+with Bar; use Bar;
+
+procedure Main is
+   Obj : My_Int := (A => 10);
+
+   function Add (A, B : Integer) return Integer
+   is
+      (A + B);
+
+   A : Integer := 3;
+begin
+   Bar.Do_
+end Main;

--- a/testsuite/ada_lsp/completion.subp_params_dotted_names/test.json
+++ b/testsuite/ada_lsp/completion.subp_params_dotted_names/test.json
@@ -1,0 +1,256 @@
+[
+   {
+      "comment": [
+          "This test checks that completion snippets work fine on ",
+          "subprogram calls that are prefixed by a package name."
+      ]
+   },
+   {
+      "start": {
+         "cmd": [
+            "${ALS}"
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "processId": 10461,
+               "capabilities": {
+                  "textDocument": {
+                     "completion": {
+                        "completionItem": {
+                           "documentationFormat": [
+                              "plaintext",
+                              "markdown"
+                           ],
+                           "snippetSupport": true
+                        },
+                        "completionItemKind": {},
+                        "dynamicRegistration": true
+                     },
+                     "definition": {},
+                     "hover": {},
+                     "codeLens": {},
+                     "selectionRange": {},
+                     "implementation": {},
+                     "formatting": {},
+                     "typeDefinition": {},
+                     "documentHighlight": {},
+                     "documentSymbol": {
+                        "symbolKind": {},
+                        "hierarchicalDocumentSymbolSupport": true
+                     },
+                     "synchronization": {},
+                     "references": {},
+                     "rangeFormatting": {},
+                     "onTypeFormatting": {},
+                     "declaration": {},
+                     "foldingRange": {
+                        "lineFoldingOnly": true
+                     },
+                     "colorProvider": {}
+                  },
+                  "workspace": {
+                     "applyEdit": true,
+                     "executeCommand": {},
+                     "didChangeWatchedFiles": {},
+                     "workspaceEdit": {},
+                     "didChangeConfiguration": {}
+                  }
+               },
+               "rootUri": "$URI{.}"
+            },
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize"
+         },
+          "wait": [
+              {
+                  "jsonrpc": "2.0",
+                  "id": 1,
+                  "result": {
+                      "capabilities": {
+                          "textDocumentSync": 2,
+                          "completionProvider": {
+                              "resolveProvider": false,
+                              "triggerCharacters": [
+                                  "."
+                              ]
+                          },
+                          "hoverProvider": true,
+                          "declarationProvider": true,
+                          "definitionProvider": true,
+                          "typeDefinitionProvider": true,
+                          "implementationProvider": true,
+                          "referencesProvider": true,
+                          "documentSymbolProvider": true,
+                          "codeActionProvider": {
+                          },
+                          "renameProvider": {
+                          },
+                          "foldingRangeProvider": true,
+                          "executeCommandProvider": {
+                              "commands": [
+                                  "als-named-parameters"
+                              ]
+                          },
+                          "alsCalledByProvider": true,
+                          "alsReferenceKinds": [
+                              "reference",
+                              "write",
+                              "call",
+                              "dispatching call",
+                              "parent",
+                              "child"
+                          ]
+                      }
+                  }
+              }
+          ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "initialized"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "settings": {
+                  "ada": {
+                     "scenarioVariables": {},
+                     "enableDiagnostics": false,
+                     "defaultCharset": "ISO-8859-1"
+                  }
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "workspace/didChangeConfiguration"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "text": "with Bar; use Bar;\n\nprocedure Main is\n   Obj : My_Int := (A => 10);\n\n   function Add (A, B : Integer) return Integer\n   is\n      (A + B);\n\n   A : Integer := 3;\nbegin\n   Bar.Do_\nend Main;\n",
+                  "version": 0,
+                  "uri": "$URI{src/main.adb}",
+                  "languageId": "Ada"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "contentChanges": [
+                  {
+                     "text": "with Bar; use Bar;\n\nprocedure Main is\n   Obj : My_Int := (A => 10);\n\n   function Add (A, B : Integer) return Integer\n   is\n      (A + B);\n\n   A : Integer := 3;\nbegin\n   Bar.Do_N\nend Main;\n"
+                  }
+               ],
+               "textDocument": {
+                  "version": 1,
+                  "uri": "$URI{src/main.adb}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "position": {
+                  "line": 11,
+                  "character": 11
+               },
+               "textDocument": {
+                  "uri": "$URI{src/main.adb}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "textDocument/completion"
+         },
+         "wait": [
+            {
+               "id": 2,
+               "result": {
+                  "isIncomplete": false,
+                  "items": [
+                     {
+                        "insertText": "Do_Nothing (${1:Obj : My_Int}, ${2:A : Integer})$0",
+                        "kind": 3,
+                        "documentation": "",
+                        "detail": "procedure Do_Nothing (Obj : My_Int; A :Integer) is null",
+                        "label": "Do_Nothing",
+                        "additionalTextEdits": [],
+                        "insertTextFormat": 2
+                     },
+                     {
+                        "additionalTextEdits": [],
+                        "kind": 18,
+                        "documentation": "",
+                        "detail": "type My_Int is tagged record\n   A : Integer;\nend record;",
+                        "label": "My_Int"
+                     }
+                  ]
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{src/main.adb}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didClose"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "shutdown"
+         },
+         "wait": [
+            {
+               "id": 3,
+               "result": null
+            }
+         ]
+      }
+   },
+   {
+      "stop": {
+         "exit_code": 0
+      }
+   }
+]

--- a/testsuite/ada_lsp/completion.subp_params_dotted_names/test.yaml
+++ b/testsuite/ada_lsp/completion.subp_params_dotted_names/test.yaml
@@ -1,0 +1,1 @@
+title: 'completion.subp_params_dotted_names'


### PR DESCRIPTION
We now use the new libadalang Is_Dot_Call function on the returned
compeltion items to know if we are dealing with a dotted subporgram call
or not, allowing us to distiguish dotted calls, for which we should omit
the first parameter in the returned completion snippets, from subprogram
calls that are prefixed by a package names (e.g: Ada.Text_IO.Put_Line).

An automatic test has also been added.