### PR TITLE
Add support for subtype

### DIFF
--- a/integration/vscode/ada/syntaxes/ada.tmLanguage.json
+++ b/integration/vscode/ada/syntaxes/ada.tmLanguage.json
@@ -186,6 +186,7 @@
 		"basic_declaration": {
 			"patterns": [
 				{ "include": "#type_declaration" },
+				{ "include": "#subtype_declaration" },
 				{ "include": "#exception_declaration" },
 				{ "include": "#object_declaration" },
 				{ "include": "#subprogram_specification" }
@@ -1334,6 +1335,76 @@
 			"patterns": [
 				{ "include": "#procedure_specification" },
 				{ "include": "#function_specification" }
+			]
+		},
+		"subtype_declaration": {
+			"name": "meta.declaration.subtype.ada",
+			"begin": "(?i)\\b(subtype)\\s+((?:\\w|\\d|_)+)\\s+(is)\\b",
+			"end": ";",
+			"beginCaptures": {
+				"1": { "name": "keyword.ada" },
+				"2": { "patterns": [ { "include": "#subtype_mark" } ] },
+				"3": { "name": "keyword.ada" }
+			},
+			"endCaptures": {
+				"0": { "name": "punctuation.ada" }
+			},
+			"patterns": [
+				{
+					"name": "storage.modifier.ada",
+					"match": "(?i)\\b(not\\s+null)\\b"
+				},
+				{ "include": "#composite_constraint" },
+				{ "include": "#subtype_indication" }
+			]
+		},
+		"subtype_indication": {
+			"name": "meta.declaration.indication.subtype.ada",
+			"match": "(?i)\\b((?:\\w|\\d|_)+)(\\s+[^\\s\\(][^;]+)?\\b",
+			"captures": {
+				"1": { "patterns": [ { "include": "#subtype_mark" } ] },
+				"2": { "patterns": [ { "include": "#scalar_constraint" } ] }
+			}
+		},
+		"scalar_constraint": {
+			"name": "meta.declaration.constraint.scalar.ada",
+			"patterns": [
+				{
+					"name": "storage.modifier.ada",
+					"match": "(?i)\\b(digits|range|delta)\\b"
+				},
+				{
+					"name": "keyword.ada",
+					"match": "\\.\\."
+				},
+				{ "include": "#expression" }
+			]
+		},
+		"composite_constraint": {
+			"name": "meta.declaration.constraint.composite.ada",
+			"begin": "\\(",
+			"end": "\\)",
+			"captures": {
+				"0": { "name": "punctuation.ada" }
+			},
+			"patterns": [
+				{
+					"name": "punctuation.ada",
+					"match": ","
+				},
+				{
+					"name": "keyword.ada",
+					"match": "\\.\\."
+				},
+				{
+					"match": "(?i)\\b((?:\\w|\\d|_)+)\\s*(=>)\\s*([^,\\)])+\\b",
+					"captures": {
+						"1": { "name": "variable.name.ada" },
+						"2": { "name": "keyword.other.ada" },
+						"3": { "patterns": [ { "include": "#expression" } ] }
+					}
+				},
+				{ "include": "#expression" }
 			]
 		},
 		"subtype_mark": {

--- a/integration/vscode/ada/syntaxes/ada.tmLanguage.json
+++ b/integration/vscode/ada/syntaxes/ada.tmLanguage.json
@@ -1355,12 +1355,13 @@
 					"match": "(?i)\\b(not\\s+null)\\b"
 				},
 				{ "include": "#composite_constraint" },
+				{ "include": "#aspect_specification" },
 				{ "include": "#subtype_indication" }
 			]
 		},
 		"subtype_indication": {
 			"name": "meta.declaration.indication.subtype.ada",
-			"match": "(?i)\\b((?:\\w|\\d|_)+)(\\s+[^\\s\\(][^;]+)?\\b",
+			"match": "(?i)\\b((?:\\w|\\d|_)+)(\\s+[^\\s\\((with)][^;]+)?\\b",
 			"captures": {
 				"1": { "patterns": [ { "include": "#subtype_mark" } ] },
 				"2": { "patterns": [ { "include": "#scalar_constraint" } ] }


### PR DESCRIPTION
This PR is intended to add the support for `subtype` in the syntax highlighter of vscode. The syntax is based on the [Ada RM](https://www.adaic.org/resources/add_content/standards/05rm/html/RM-3-2-2.html). All the cases should have been taken into account.

The regex are not always very clean, and I would be happy to discuss to find something better.