### PR TITLE
Add aspect_clause support

### DIFF
--- a/integration/vscode/ada/syntaxes/ada.tmLanguage.json
+++ b/integration/vscode/ada/syntaxes/ada.tmLanguage.json
@@ -183,6 +183,12 @@
 				"7": { "patterns": [ { "include": "#exponent_part" } ] }
 			}
 		},
+		"basic_declarative_item": {
+			"patterns": [
+				{ "include": "#basic_declaration" },
+				{ "include": "#aspect_clause" }
+			]
+		},
 		"basic_declaration": {
 			"patterns": [
 				{ "include": "#type_declaration" },
@@ -211,7 +217,7 @@
 						"0": { "name": "keyword.ada" }
 					},
 					"patterns": [
-						{ "include": "#basic_declaration" }
+						{ "include": "#basic_declarative_item" }
 					]
 				},
 				{
@@ -935,7 +941,7 @@
 			},
 			"patterns": [
 				{ "include": "#comment" },
-				{ "include": "#basic_declaration" }
+				{ "include": "#basic_declarative_item" }
 			]
 		},
 		"package_declaration": {
@@ -962,7 +968,7 @@
 			},
 			"patterns": [
 				{ "include": "#comment" },
-				{ "include": "#basic_declaration" }
+				{ "include": "#basic_declarative_item" }
 			]
 		},
 		"parameter_profile": {
@@ -1130,6 +1136,82 @@
 				{
 					"name": "entity.name.exception.ada",
 					"match": "\\b(\\w|\\d|_)+\\b"
+				}
+			]
+		},
+		"aspect_clause": {
+			"name": "meta.aspect.clause.ada",
+			"begin": "(?i)\\b(for)\\s+((?:\\w|\\d|_)+)(?:(\\')((?:\\w|\\d|_)+))?\\s+(use)\\b",
+			"end": ";",
+			"beginCaptures": {
+				"1": { "name": "keyword.ada" },
+				"2": { "patterns": [ { "include": "#subtype_mark" } ] },
+				"3": { "name": "punctuation.ada" },
+				"5": { "name": "keyword.ada" }
+			},
+			"endCaptures": {
+				"0": { "name": "punctuation.ada" }
+			},
+			"patterns": [
+				{ "include": "#array_aggregate" }
+			]
+		},
+		"array_aggregate": {
+			"name": "meta.definition.array.aggregate.ada",
+			"begin": "\\(",
+			"end": "\\)",
+			"captures": {
+				"0": { "name": "punctuation.ada" }
+			},
+			"patterns": [
+				{
+					"name": "punctuation.ada",
+					"match": ","
+				},
+				{ "include": "#positional_array_aggregate" },
+				{ "include": "#array_component_association" }
+			]
+		},
+		"positional_array_aggregate": {
+			"name": "meta.definition.array.aggregate.positional.ada",
+			"patterns": [
+				{
+					"match": "(?i)\\b(others)\\s*(=>)\\s*([^,\\)]+)",
+					"captures": {
+						"1": { "name": "keyword.ada" },
+						"2": { "name": "keyword.other.ada" },
+						"3": {
+							"patterns": [
+								{
+									"name": "keyword.modifier.unknown.ada",
+									"match": "<>"
+								},
+								{ "include": "#expression" }
+							]
+						}
+					}
+				},
+				{ "include": "#expression" }
+			]
+		},
+		"array_component_association": {
+			"name": "meta.definition.array.aggregate.component.ada",
+			"patterns": [
+				{
+					"match": "(?i)\\b([^(=>)]*)\\s*(=>)\\s*([^,\\)]+)",
+					"captures": {
+						"1": { "name": "variable.name.ada" },
+						"2": { "name": "keyword.other.ada" },
+						"3": {
+							"patterns": [
+								{
+									"name": "keyword.modifier.unknown.ada",
+									"match": "<>"
+								},
+								{ "include": "#expression" }
+							]
+						}
+					}
 				}
 			]
 		},

--- a/integration/vscode/ada/syntaxes/ada.tmLanguage.json
+++ b/integration/vscode/ada/syntaxes/ada.tmLanguage.json
@@ -1153,7 +1153,9 @@
 				"0": { "name": "punctuation.ada" }
 			},
 			"patterns": [
-				{ "include": "#array_aggregate" }
+				{ "include": "#record_representation_clause" },
+				{ "include": "#array_aggregate" },
+				{ "include": "#expression" }
 			]
 		},
 		"array_aggregate": {
@@ -1213,6 +1215,46 @@
 						}
 					}
 				}
+			]
+		},
+		"record_representation_clause": {
+			"name": "meta.aspect.clause.record.representation.ada",
+			"begin": "(?i)\\b(record)\\b",
+			"end": "(?i)\\b(end)\\s+(record)\\b",
+			"beginCaptures": {
+				"1": { "name": "storage.modifier.ada" }
+			},
+			"endCaptures": {
+				"1": { "name": "keyword.ada" },
+				"2": { "name": "storage.modifier.ada" }
+			},
+			"patterns": [
+				{ "include": "#component_clause" },
+				{ "include": "#comment" }
+			]
+		},
+		"component_clause": {
+			"name": "meta.aspect.clause.record.representation.component.ada",
+			"begin": "(?i)\\b((?:\\w|\\d|_)+)\\s+(at)\\s+((?:(?!range).)*)\\b",
+			"beginCaptures": {
+				"1": { "name": "variable.name.ada" },
+				"2": { "name": "keyword.ada" },
+				"3": { "patterns": [ { "include": "#expression" } ] }
+			},
+			"end": ";",
+			"endCaptures": {
+				"0": { "name": "puunctuation.ada" }
+			},
+			"patterns": [
+				{
+					"name": "storage.modifier.ada",
+					"match": "(?i)\\b(range)\\b"
+				},
+				{
+					"name": "keyword.ada",
+					"match": "\\.\\."
+				},
+				{ "include": "#expression" }
 			]
 		},
 		"real_type_definition": {

--- a/integration/vscode/ada/syntaxes/ada.tmLanguage.json
+++ b/integration/vscode/ada/syntaxes/ada.tmLanguage.json
@@ -1141,7 +1141,7 @@
 		},
 		"aspect_clause": {
 			"name": "meta.aspect.clause.ada",
-			"begin": "(?i)\\b(for)\\s+((?:\\w|\\d|_)+)(?:(\\')((?:\\w|\\d|_)+))?\\s+(use)\\b",
+			"begin": "(?i)\\b(for)\\b",
 			"end": ";",
 			"beginCaptures": {
 				"1": { "name": "keyword.ada" },
@@ -1153,9 +1153,37 @@
 				"0": { "name": "punctuation.ada" }
 			},
 			"patterns": [
-				{ "include": "#record_representation_clause" },
-				{ "include": "#array_aggregate" },
-				{ "include": "#expression" }
+				{
+					"begin": "(?i)\\buse\\b",
+					"end": "(?=;)",
+					"beginCaptures": {
+						"0": {"name": "keyword.ada" }
+					},
+					"endCaptures": {
+						"0": { "name": "punctuation.ada" }
+					},
+					"patterns": [
+						{ "include": "#record_representation_clause" },
+						{ "include": "#array_aggregate" },
+						{ "include": "#expression" }
+					]
+				},
+				{
+					"begin": "(?i)(?<=for)",
+					"end": "(?i)(?=use)",
+					"captures": {
+						"0": { "name": "keyword.ada" }
+					},
+					"patterns": [
+						{
+							"match": "((?:\\w|\\d|_)+)('((?:\\w|\\d|_)+))?",
+							"captures": {
+								"1": { "patterns": [ { "include": "#subtype_mark" } ] },
+								"2": { "patterns": [ { "include": "#attribute" } ] }
+							}
+						}
+					]
+				}
 			]
 		},
 		"array_aggregate": {
@@ -1198,24 +1226,20 @@
 		},
 		"array_component_association": {
 			"name": "meta.definition.array.aggregate.component.ada",
-			"patterns": [
-				{
-					"match": "(?i)\\b([^(=>)]*)\\s*(=>)\\s*([^,\\)]+)",
-					"captures": {
-						"1": { "name": "variable.name.ada" },
-						"2": { "name": "keyword.other.ada" },
-						"3": {
-							"patterns": [
-								{
-									"name": "keyword.modifier.unknown.ada",
-									"match": "<>"
-								},
-								{ "include": "#expression" }
-							]
-						}
-					}
+			"match": "(?i)\\b([^(=>)]*)\\s*(=>)\\s*([^,\\)]+)",
+			"captures": {
+				"1": { "name": "variable.name.ada" },
+				"2": { "name": "keyword.other.ada" },
+				"3": {
+					"patterns": [
+						{
+							"name": "keyword.modifier.unknown.ada",
+							"match": "<>"
+						},
+						{ "include": "#expression" }
+					]
 				}
-			]
+			}
 		},
 		"record_representation_clause": {
 			"name": "meta.aspect.clause.record.representation.ada",
@@ -1235,26 +1259,39 @@
 		},
 		"component_clause": {
 			"name": "meta.aspect.clause.record.representation.component.ada",
-			"begin": "(?i)\\b((?:\\w|\\d|_)+)\\s+(at)\\s+((?:(?!range).)*)\\b",
+			"begin": "(?i)\\b((?:\\w|\\d|_)+)\\b",
 			"beginCaptures": {
-				"1": { "name": "variable.name.ada" },
-				"2": { "name": "keyword.ada" },
-				"3": { "patterns": [ { "include": "#expression" } ] }
+				"0": { "name": "variable.name.ada" }
 			},
 			"end": ";",
 			"endCaptures": {
-				"0": { "name": "puunctuation.ada" }
+				"0": { "name": "punctuation.ada" }
 			},
 			"patterns": [
 				{
-					"name": "storage.modifier.ada",
-					"match": "(?i)\\b(range)\\b"
+					"begin": "(?i)\\bat\\b",
+					"end": "(?i)\\b(?=range)\\b",
+					"beginCaptures": {
+						"0": { "name": "storage.modifier.ada" }
+					},
+					"patterns": [
+						{ "include": "#expression" }
+					]
 				},
 				{
-					"name": "keyword.ada",
-					"match": "\\.\\."
-				},
-				{ "include": "#expression" }
+					"begin": "(?i)\\brange\\b",
+					"end": "(?=;)",
+					"beginCaptures": {
+						"0": { "name": "storage.modifier.ada" }
+					},
+					"patterns": [
+						{
+							"name": "keyword.ada",
+							"match": "\\.\\."
+						},
+						{ "include": "#expression" }
+					]
+				}
 			]
 		},
 		"real_type_definition": {


### PR DESCRIPTION
I have added a partial support for the syntax highlighting of `aspect_clause`s.

**Limitations**:

- The support is not complete. The `at_clause` construction is not supported by this work (cf. [here](https://www.adaic.org/resources/add_content/standards/05rm/html/RM-13-1.html#I4417)) because I'm not enough familiar with Ada to know how it is used.

- Moreover, in the following construction, I don't know what scope I should give to `attribute_designator` in `for local_name'attribute_designator use expression;`. Then no scope is assigned to it.