### PR TITLE
Operators

### DIFF
--- a/integration/vscode/ada/CONTRIBUTING.md
+++ b/integration/vscode/ada/CONTRIBUTING.md
@@ -1,0 +1,35 @@
+# Contributing
+
+This document will describe the necessary information required to contribute to the [VS Code](https://code.visualstudio.com/) extension.
+
+## Terminology
+
+### Syntax Highlighter
+
+The editor component which is responsible for applying highlighting of syntax within the editor display. Information is supplied to the highlighter from the classifier or language server.
+
+### Classifier
+
+The extension component which is responsible for parsing and classifying tokens.
+
+### Language Server
+
+The extension component which is responsible for providing syntax completion and other features; it may optionally provide token classification.
+
+## How it works
+
+The classifier is given a JSON document which itself holds a number of "structured" Regex object. This is similar in concept to [Structural Regular Expressions](http://doc.cat-v.org/bell_labs/structural_regexps/se.pdf) but is not the same implementation.
+
+[VS Code](https://code.visualstudio.com/) utilizes a line oriented parser. This is done for performance reasons, and is very effective to that extent. It does, however, mean that `\s` will not match a new line, and `\n` is effectively meaningless as it will never match.
+
+Ada is a highly structured and "context sensitive" language. This does not necessarily, but can, mean a formal [Context-Sensitive Grammar](https://en.wikipedia.org/wiki/Context-sensitive_grammar), but does mean that keywords and other constructs may be best served by specific classifications based on the surrounding context.
+
+To accommodate Ada's grammar, the classifier itself uses a structured approach, rather than the typical "shotgun" approach often taken for less grammatically complex language. This means at the highest level, classifications are `meta.*` classes of structures, and continuously "drill down" into specific tokens. The repository of structured Regex objects closely follows the [Ada Reference Manual](http://ada-auth.org/standards/rm12_w_tc1/html/RM-TOC.html) [Annex P](http://ada-auth.org/standards/rm12_w_tc1/html/RM-P.html) in both naming and definitions.
+
+Ada's grammar is officially given in EBNF however, and structured Regex is not EBNF. Because of this and [VS Code](https://code.visualstudio.com/)'s line oriented nature, some concessions have to be made. As such, syntax definitions may not exactly match EBNF, and may use a localized "shotgun" approach at certain times. Certain keywords or constructs may need to be moved around. And there are certain places where allowing line breaks is remarkably difficult or even impossible.
+
+## New Classifications
+
+When supplying new classifications it is a good idea to keep everything as close to [Annex P](http://ada-auth.org/standards/rm12_w_tc1/html/RM-P.html) definitions as possible. Furthermore, check for regressions.
+
+Do not hesitate to ask for advice or help.

--- a/integration/vscode/ada/syntaxes/ada.tmLanguage.json
+++ b/integration/vscode/ada/syntaxes/ada.tmLanguage.json
@@ -61,6 +61,10 @@
 				{ "include": "#subtype_mark" }
 			]
 		},
+		"adding_operator": {
+			"name": "keyword.operator.adding.ada",
+			"match": "(\\+|-|\\&)"
+		},
 		"array_aggregate": {
 			"name": "meta.definition.array.aggregate.ada",
 			"begin": "\\(",
@@ -76,6 +80,23 @@
 				{ "include": "#positional_array_aggregate" },
 				{ "include": "#array_component_association" }
 			]
+		},
+		"array_component_association": {
+			"name": "meta.definition.array.aggregate.component.ada",
+			"match": "(?i)\\b([^(=>)]*)\\s*(=>)\\s*([^,\\)]+)",
+			"captures": {
+				"1": { "name": "variable.name.ada" },
+				"2": { "name": "keyword.other.ada" },
+				"3": {
+					"patterns": [
+						{
+							"name": "keyword.modifier.unknown.ada",
+							"match": "<>"
+						},
+						{ "include": "#expression" }
+					]
+				}
+			}
 		},
 		"array_dimensions": {
 			"name": "meta.declaration.type.definition.array.dimensions.ada",
@@ -383,6 +404,43 @@
 				"1": { "name": "entity.name.section.ada" }
 			}
 		},
+		"component_clause": {
+			"name": "meta.aspect.clause.record.representation.component.ada",
+			"begin": "(?i)\\b((?:\\w|\\d|_)+)\\b",
+			"beginCaptures": {
+				"0": { "name": "variable.name.ada" }
+			},
+			"end": ";",
+			"endCaptures": {
+				"0": { "name": "punctuation.ada" }
+			},
+			"patterns": [
+				{
+					"begin": "(?i)\\bat\\b",
+					"end": "(?i)\\b(?=range)\\b",
+					"beginCaptures": {
+						"0": { "name": "storage.modifier.ada" }
+					},
+					"patterns": [
+						{ "include": "#expression" }
+					]
+				},
+				{
+					"begin": "(?i)\\brange\\b",
+					"end": "(?=;)",
+					"beginCaptures": {
+						"0": { "name": "storage.modifier.ada" }
+					},
+					"patterns": [
+						{
+							"name": "keyword.ada",
+							"match": "\\.\\."
+						},
+						{ "include": "#expression" }
+					]
+				}
+			]
+		},
 		"component_declaration": {
 			"name": "meta.declaration.type.definition.record.component.ada",
 			"begin": "(?i)\\b((?:\\w|\\d|_)+(?:\\s*,\\s*(?:\\w|\\d|_)+)?)\\s*(:)",
@@ -673,7 +731,8 @@
 		"expression": {
 			"name": "meta.expression.ada",
 			"patterns": [
-				{ "include": "#value" }
+				{ "include": "#value" },
+				{ "include": "#operator" }
 			]
 		},
 		"fixed_point_definition": {
@@ -832,6 +891,10 @@
 				{}
 			]
 		},
+		"highest_precedence_operator": {
+			"name": "keyword.operator.highest-precedence.ada",
+			"match": "(?i)\\b(\\*\\*|abs|not)\\b"
+		},
 		"if_statement": {
 			"name": "meta.statement.if.ada",
 			"begin": "(?i)\\bif\\b",
@@ -958,6 +1021,10 @@
 				{ "include": "#expression" }
 			]
 		},
+		"multiplying_operator": {
+			"name": "keyword.operator.multiplying.ada",
+			"match": "(?i)\\b(\\*|/|mod|rem)\\b"
+		},
 		"null_statement": {
 			"name": "meta.statement.null.ada",
 			"match": "(?i)\\b(null)\\s*(;)",
@@ -1014,6 +1081,15 @@
 						{ "include": "#expression" }
 					]
 				}
+			]
+		},
+		"operator": {
+			"patterns": [
+				{ "include": "#highest_precedence_operator" },
+				{ "include": "#multiplying_operator" },
+				{ "include": "#adding_operator" },
+				{ "include": "#relational_operator" },
+				{ "include": "#logical_operator" }
 			]
 		},
 		"package_body": {
@@ -1179,6 +1255,28 @@
 				{ "include": "#parameter_profile" }
 			]
 		},
+		"positional_array_aggregate": {
+			"name": "meta.definition.array.aggregate.positional.ada",
+			"patterns": [
+				{
+					"match": "(?i)\\b(others)\\s*(=>)\\s*([^,\\)]+)",
+					"captures": {
+						"1": { "name": "keyword.ada" },
+						"2": { "name": "keyword.other.ada" },
+						"3": {
+							"patterns": [
+								{
+									"name": "keyword.modifier.unknown.ada",
+									"match": "<>"
+								},
+								{ "include": "#expression" }
+							]
+						}
+					}
+				},
+				{ "include": "#expression" }
+			]
+		},
 		"raise_statement": {
 			"name": "meta.statement.raise.ada",
 			"begin": "(?i)\\braise\\b",
@@ -1230,44 +1328,9 @@
 				}
 			]
 		},
-		"positional_array_aggregate": {
-			"name": "meta.definition.array.aggregate.positional.ada",
-			"patterns": [
-				{
-					"match": "(?i)\\b(others)\\s*(=>)\\s*([^,\\)]+)",
-					"captures": {
-						"1": { "name": "keyword.ada" },
-						"2": { "name": "keyword.other.ada" },
-						"3": {
-							"patterns": [
-								{
-									"name": "keyword.modifier.unknown.ada",
-									"match": "<>"
-								},
-								{ "include": "#expression" }
-							]
-						}
-					}
-				},
-				{ "include": "#expression" }
-			]
-		},
-		"array_component_association": {
-			"name": "meta.definition.array.aggregate.component.ada",
-			"match": "(?i)\\b([^(=>)]*)\\s*(=>)\\s*([^,\\)]+)",
-			"captures": {
-				"1": { "name": "variable.name.ada" },
-				"2": { "name": "keyword.other.ada" },
-				"3": {
-					"patterns": [
-						{
-							"name": "keyword.modifier.unknown.ada",
-							"match": "<>"
-						},
-						{ "include": "#expression" }
-					]
-				}
-			}
+		"relational_operator": {
+			"name": "keyword.operator.relational.ada",
+			"match": "(=|/=|<|<=|>|>=)"
 		},
 		"record_representation_clause": {
 			"name": "meta.aspect.clause.record.representation.ada",
@@ -1283,43 +1346,6 @@
 			"patterns": [
 				{ "include": "#component_clause" },
 				{ "include": "#comment" }
-			]
-		},
-		"component_clause": {
-			"name": "meta.aspect.clause.record.representation.component.ada",
-			"begin": "(?i)\\b((?:\\w|\\d|_)+)\\b",
-			"beginCaptures": {
-				"0": { "name": "variable.name.ada" }
-			},
-			"end": ";",
-			"endCaptures": {
-				"0": { "name": "punctuation.ada" }
-			},
-			"patterns": [
-				{
-					"begin": "(?i)\\bat\\b",
-					"end": "(?i)\\b(?=range)\\b",
-					"beginCaptures": {
-						"0": { "name": "storage.modifier.ada" }
-					},
-					"patterns": [
-						{ "include": "#expression" }
-					]
-				},
-				{
-					"begin": "(?i)\\brange\\b",
-					"end": "(?=;)",
-					"beginCaptures": {
-						"0": { "name": "storage.modifier.ada" }
-					},
-					"patterns": [
-						{
-							"name": "keyword.ada",
-							"match": "\\.\\."
-						},
-						{ "include": "#expression" }
-					]
-				}
 			]
 		},
 		"real_type_definition": {

--- a/integration/vscode/ada/syntaxes/ada.tmLanguage.json
+++ b/integration/vscode/ada/syntaxes/ada.tmLanguage.json
@@ -237,7 +237,7 @@
 			"end": ";",
 			"beginCaptures": {
 				"1": { "name": "variable.name.ada" },
-				"2": { "name": "punctuation.ada" }
+				"2": { "name": "keyword.operator.new.ada" }
 			},
 			"endCaptures": {
 				"0": { "name": "punctuation.ada" }
@@ -467,7 +467,7 @@
 				{
 					"patterns": [
 						{
-							"name": "punctuation.ada",
+							"name": "keyword.operator.new.ada",
 							"match": ":="
 						},
 						{ "include": "#expression" }
@@ -637,7 +637,7 @@
 					"begin": ":=",
 					"end": "(?=(;|\\)))",
 					"beginCaptures": {
-						"0": { "name": "punctuation.ada" }
+						"0": { "name": "keyword.operator.new.ada" }
 					},
 					"patterns": [
 						{ "include": "#expression" }
@@ -1060,7 +1060,7 @@
 					"begin": "(?<=:)",
 					"end": "((?=;)|:=)",
 					"endCaptures": {
-						"0": { "name": "punctuation.ada" }
+						"0": { "name": "keyword.operator.new.ada" }
 					},
 					"patterns": [
 						{
@@ -1177,7 +1177,7 @@
 					"begin": ":=",
 					"end": "(?=[:;)])",
 					"beginCaptures": {
-						"0": { "name": "punctuation.ada" }
+						"0": { "name": "keyword.operator.new.ada" }
 					},
 					"patterns": [
 						{ "include": "#expression" }

--- a/integration/vscode/ada/syntaxes/ada.tmLanguage.json
+++ b/integration/vscode/ada/syntaxes/ada.tmLanguage.json
@@ -893,7 +893,7 @@
 		},
 		"highest_precedence_operator": {
 			"name": "keyword.operator.highest-precedence.ada",
-			"match": "(?i)\\b(\\*\\*|abs|not)\\b"
+			"match": "(?i)(\\*\\*|\\babs\\b|\\bnot\\b)"
 		},
 		"if_statement": {
 			"name": "meta.statement.if.ada",
@@ -1023,7 +1023,7 @@
 		},
 		"multiplying_operator": {
 			"name": "keyword.operator.multiplying.ada",
-			"match": "(?i)\\b(\\*|/|mod|rem)\\b"
+			"match": "(?i)(\\*|/|\\bmod\\b|\\brem\\b)"
 		},
 		"null_statement": {
 			"name": "meta.statement.null.ada",

--- a/integration/vscode/ada/syntaxes/ada.tmLanguage.json
+++ b/integration/vscode/ada/syntaxes/ada.tmLanguage.json
@@ -61,6 +61,22 @@
 				{ "include": "#subtype_mark" }
 			]
 		},
+		"array_aggregate": {
+			"name": "meta.definition.array.aggregate.ada",
+			"begin": "\\(",
+			"end": "\\)",
+			"captures": {
+				"0": { "name": "punctuation.ada" }
+			},
+			"patterns": [
+				{
+					"name": "punctuation.ada",
+					"match": ","
+				},
+				{ "include": "#positional_array_aggregate" },
+				{ "include": "#array_component_association" }
+			]
+		},
 		"array_dimensions": {
 			"name": "meta.declaration.type.definition.array.dimensions.ada",
 			"begin": "\\(",
@@ -109,6 +125,53 @@
 				},
 				{ "include": "#access_definition" },
 				{ "include": "#subtype_mark" }
+			]
+		},
+		"aspect_clause": {
+			"name": "meta.aspect.clause.ada",
+			"begin": "(?i)\\b(for)\\b",
+			"end": ";",
+			"beginCaptures": {
+				"1": { "name": "keyword.ada" },
+				"2": { "patterns": [ { "include": "#subtype_mark" } ] },
+				"3": { "name": "punctuation.ada" },
+				"5": { "name": "keyword.ada" }
+			},
+			"endCaptures": {
+				"0": { "name": "punctuation.ada" }
+			},
+			"patterns": [
+				{
+					"begin": "(?i)\\buse\\b",
+					"end": "(?=;)",
+					"beginCaptures": {
+						"0": {"name": "keyword.ada" }
+					},
+					"endCaptures": {
+						"0": { "name": "punctuation.ada" }
+					},
+					"patterns": [
+						{ "include": "#record_representation_clause" },
+						{ "include": "#array_aggregate" },
+						{ "include": "#expression" }
+					]
+				},
+				{
+					"begin": "(?i)(?<=for)",
+					"end": "(?i)(?=use)",
+					"captures": {
+						"0": { "name": "keyword.ada" }
+					},
+					"patterns": [
+						{
+							"match": "((?:\\w|\\d|_)+)('((?:\\w|\\d|_)+))?",
+							"captures": {
+								"1": { "patterns": [ { "include": "#subtype_mark" } ] },
+								"2": { "patterns": [ { "include": "#attribute" } ] }
+							}
+						}
+					]
+				}
 			]
 		},
 		"aspect_definition": {
@@ -368,6 +431,33 @@
 		"component_item": {
 			"patterns": [
 				{ "include": "#component_declaration" }
+			]
+		},
+		"composite_constraint": {
+			"name": "meta.declaration.constraint.composite.ada",
+			"begin": "\\(",
+			"end": "\\)",
+			"captures": {
+				"0": { "name": "punctuation.ada" }
+			},
+			"patterns": [
+				{
+					"name": "punctuation.ada",
+					"match": ","
+				},
+				{
+					"name": "keyword.ada",
+					"match": "\\.\\."
+				},
+				{
+					"match": "(?i)\\b((?:\\w|\\d|_)+)\\s*(=>)\\s*([^,\\)])+\\b",
+					"captures": {
+						"1": { "name": "variable.name.ada" },
+						"2": { "name": "keyword.other.ada" },
+						"3": { "patterns": [ { "include": "#expression" } ] }
+					}
+				},
+				{ "include": "#expression" }
 			]
 		},
 		"decimal_literal": {
@@ -1140,69 +1230,6 @@
 				}
 			]
 		},
-		"aspect_clause": {
-			"name": "meta.aspect.clause.ada",
-			"begin": "(?i)\\b(for)\\b",
-			"end": ";",
-			"beginCaptures": {
-				"1": { "name": "keyword.ada" },
-				"2": { "patterns": [ { "include": "#subtype_mark" } ] },
-				"3": { "name": "punctuation.ada" },
-				"5": { "name": "keyword.ada" }
-			},
-			"endCaptures": {
-				"0": { "name": "punctuation.ada" }
-			},
-			"patterns": [
-				{
-					"begin": "(?i)\\buse\\b",
-					"end": "(?=;)",
-					"beginCaptures": {
-						"0": {"name": "keyword.ada" }
-					},
-					"endCaptures": {
-						"0": { "name": "punctuation.ada" }
-					},
-					"patterns": [
-						{ "include": "#record_representation_clause" },
-						{ "include": "#array_aggregate" },
-						{ "include": "#expression" }
-					]
-				},
-				{
-					"begin": "(?i)(?<=for)",
-					"end": "(?i)(?=use)",
-					"captures": {
-						"0": { "name": "keyword.ada" }
-					},
-					"patterns": [
-						{
-							"match": "((?:\\w|\\d|_)+)('((?:\\w|\\d|_)+))?",
-							"captures": {
-								"1": { "patterns": [ { "include": "#subtype_mark" } ] },
-								"2": { "patterns": [ { "include": "#attribute" } ] }
-							}
-						}
-					]
-				}
-			]
-		},
-		"array_aggregate": {
-			"name": "meta.definition.array.aggregate.ada",
-			"begin": "\\(",
-			"end": "\\)",
-			"captures": {
-				"0": { "name": "punctuation.ada" }
-			},
-			"patterns": [
-				{
-					"name": "punctuation.ada",
-					"match": ","
-				},
-				{ "include": "#positional_array_aggregate" },
-				{ "include": "#array_component_association" }
-			]
-		},
 		"positional_array_aggregate": {
 			"name": "meta.definition.array.aggregate.positional.ada",
 			"patterns": [
@@ -1423,6 +1450,20 @@
 				{ "include": "#expression" }
 			]
 		},
+		"scalar_constraint": {
+			"name": "meta.declaration.constraint.scalar.ada",
+			"patterns": [
+				{
+					"name": "storage.modifier.ada",
+					"match": "(?i)\\b(digits|range|delta)\\b"
+				},
+				{
+					"name": "keyword.ada",
+					"match": "\\.\\."
+				},
+				{ "include": "#expression" }
+			]
+		},
 		"signed_integer_type_definition": {
 			"begin": "(?i)\\b(is)\\s+(range)\\b",
 			"end": "(?i)(?=(with|;))",
@@ -1527,47 +1568,6 @@
 				"1": { "patterns": [ { "include": "#subtype_mark" } ] },
 				"2": { "patterns": [ { "include": "#scalar_constraint" } ] }
 			}
-		},
-		"scalar_constraint": {
-			"name": "meta.declaration.constraint.scalar.ada",
-			"patterns": [
-				{
-					"name": "storage.modifier.ada",
-					"match": "(?i)\\b(digits|range|delta)\\b"
-				},
-				{
-					"name": "keyword.ada",
-					"match": "\\.\\."
-				},
-				{ "include": "#expression" }
-			]
-		},
-		"composite_constraint": {
-			"name": "meta.declaration.constraint.composite.ada",
-			"begin": "\\(",
-			"end": "\\)",
-			"captures": {
-				"0": { "name": "punctuation.ada" }
-			},
-			"patterns": [
-				{
-					"name": "punctuation.ada",
-					"match": ","
-				},
-				{
-					"name": "keyword.ada",
-					"match": "\\.\\."
-				},
-				{
-					"match": "(?i)\\b((?:\\w|\\d|_)+)\\s*(=>)\\s*([^,\\)])+\\b",
-					"captures": {
-						"1": { "name": "variable.name.ada" },
-						"2": { "name": "keyword.other.ada" },
-						"3": { "patterns": [ { "include": "#expression" } ] }
-					}
-				},
-				{ "include": "#expression" }
-			]
 		},
 		"subtype_mark": {
 			"name": "entity.name.type.ada",


### PR DESCRIPTION
Adds back classification of operators, with specific designations for groups, if themes get specific. `:=` has also been classified as `keyword.operator.new.ada` instead of `punctuation.ada`, since it's much closer in semantics to an operator than a delimiter.