### PR TITLE
Initial revision of a testsuite for the VS Code grammars

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,9 @@ vscode:
 	@echo Now run:
 	@echo code --extensionDevelopmentPath=`pwd`/integration/vscode/ada/ `pwd`
 
+vscode-test:
+	cd integration/vscode/ada; npm run compile && node out/runTests.js
+
 check: all
 	set -e; \
         if [ `python -c "import sys;print 'e3' in sys.modules"` = "True" ]; then\

--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,12 @@ vscode:
 	@echo code --extensionDevelopmentPath=`pwd`/integration/vscode/ada/ `pwd`
 
 vscode-test:
-	cd integration/vscode/ada; npm run compile && node out/runTests.js
+	# Run the VS Code grammar testsuite
+	cd integration/vscode/ada ; ./run_grammar_tests.sh
+
+	# Run the VS Code integration testsuite.
+	# This contains no useful test, so deactivated for now.
+	# cd integration/vscode/ada; npm run compile && node out/runTests.js
 
 check: all
 	set -e; \

--- a/doc/HACKING.md
+++ b/doc/HACKING.md
@@ -56,10 +56,30 @@ To write a functional test for Ada Language Server:
  * to run an individual test, go to `testsuite` and run `sh run.sh ada_lsp/<testname>`
     (you will need `https://github.com/AdaCore/e3-testsuite` installed to do this)
 
-
 ### VS Code integration tests
 
 Run `make vscode-test` to run the VS Code testsuite.
+
+### VS Code grammar tests
+
+The following is under `integration/vscode/ada/`.
+
+Tests for the Ada grammar are in `testsuite_grammar`, with one test per subdirectory.
+
+ * To run the full testsuite, call `./run_grammar_tests.sh`
+ * To run one individual test, pass its directory as parameter to
+   that script, for instance `./run_grammar_tests.sh testsuite_grammar/hello`
+
+To create new tests, do the following:
+
+  * Create a directory for it, for instance `testsuite_grammar/newtest`
+  * Add `.ads` and/or `.adb` sources in that directory
+  * Run the driver: the first run will create the baselines under the form
+    of `.snap` files.
+
+The engine for the test driver is implemented using
+[vscode-tmgrammartest](https://github.com/PanAeon/vscode-tmgrammar-test):
+see the full documentation there.
 
 ### Other tests
 

--- a/doc/HACKING.md
+++ b/doc/HACKING.md
@@ -56,6 +56,11 @@ To write a functional test for Ada Language Server:
  * to run an individual test, go to `testsuite` and run `sh run.sh ada_lsp/<testname>`
     (you will need `https://github.com/AdaCore/e3-testsuite` installed to do this)
 
+
+### VS Code integration tests
+
+Run `make vscode-test` to run the VS Code testsuite.
+
 ### Other tests
 
 See more about the project testsuite [here](../testsuite/README.md).

--- a/doc/HACKING.md
+++ b/doc/HACKING.md
@@ -73,7 +73,7 @@ Tests for the Ada grammar are in `testsuite_grammar`, with one test per subdirec
 To create new tests, do the following:
 
   * Create a directory for it, for instance `testsuite_grammar/newtest`
-  * Add `.ads` and/or `.adb` sources in that directory
+  * Add `.ads`, `.adb` or `.gpr` sources in that directory
   * Run the driver: the first run will create the baselines under the form
     of `.snap` files.
 

--- a/integration/travis/travis.sh
+++ b/integration/travis/travis.sh
@@ -37,6 +37,14 @@ function linux_script()
     TAG=${TRAVIS_TAG:-latest}
     sed -i -e "s/VERSION/$TAG/g" integration/travis/bintray.json
     make LIBRARY_TYPE=relocatable check
+
+    # Make the VS Code plugin
+    make vscode
+
+    # Test the VS Code plugin
+    /usr/bin/Xvfb :101 -screen 0 1024x768x24 > /dev/null 2>&1 &
+    DISPLAY=:101 make vscode-test
+
     integration/travis/deploy.sh linux
 }
 

--- a/integration/vscode/ada/.vscode/launch.json
+++ b/integration/vscode/ada/.vscode/launch.json
@@ -8,6 +8,18 @@
             "request": "launch",
             "runtimeExecutable": "${execPath}",
             "args": ["--extensionDevelopmentPath=${workspaceRoot}" ]
-        }
+        },
+	{
+	"name": "Run Extension Tests",
+	"type": "extensionHost",
+	"request": "launch",
+	"runtimeExecutable": "${execPath}",
+	"args": [
+		"--extensionDevelopmentPath=${workspaceFolder}",
+		"--extensionTestsPath=${workspaceFolder}/out"
+		],
+		"outFiles": ["${workspaceFolder}/out/test/**/*.js"],
+		"preLaunchTask": "npm: watch"
+	}
     ]
 }

--- a/integration/vscode/ada/package.json
+++ b/integration/vscode/ada/package.json
@@ -175,14 +175,18 @@
         ]
     },
     "devDependencies": {
+	"@types/glob": "^7.1.1",
         "@types/mocha": "^2.2.42",
         "@types/node": "^6.0.88",
         "vscode": "^1.1.35",
         "eslint": "^4.6.1",
-        "typescript": "^2.5.2"
+	"typescript": "^3.8.3",
+	"glob": "^7.1.4",
+	"vscode-test": "^1.3.0"
     },
     "scripts": {
-        "postinstall": "vscode-install"
+        "postinstall": "vscode-install",
+        "compile": "tsc -p ./"
     },
     "dependencies": {
         "vscode-languageclient": "^6.0.1",

--- a/integration/vscode/ada/package.json
+++ b/integration/vscode/ada/package.json
@@ -175,18 +175,20 @@
         ]
     },
     "devDependencies": {
-	"@types/glob": "^7.1.1",
+        "@types/glob": "^7.1.1",
         "@types/mocha": "^2.2.42",
         "@types/node": "^6.0.88",
         "vscode": "^1.1.35",
         "eslint": "^4.6.1",
-	"typescript": "^3.8.3",
-	"glob": "^7.1.4",
-	"vscode-test": "^1.3.0"
+        "typescript": "^3.8.3",
+        "glob": "^7.1.4",
+        "vscode-test": "^1.3.0",
+        "vscode-tmgrammar-test": "0.0.9"
     },
     "scripts": {
         "postinstall": "vscode-install",
-        "compile": "tsc -p ./"
+        "compile": "tsc -p ./",
+        "watch": "tsc -watch -p ./"
     },
     "dependencies": {
         "vscode-languageclient": "^6.0.1",

--- a/integration/vscode/ada/run_grammar_tests.sh
+++ b/integration/vscode/ada/run_grammar_tests.sh
@@ -10,9 +10,24 @@ testpath=$1
 
 run_test(){
     dir=$1
-   ./node_modules/.bin/vscode-tmgrammar-snap -g syntaxes/ada.tmLanguage.json \
-     -s source.ada \
-     -t "$dir/*.ad?"
+    _err=0
+
+    ada_files=`find $dir -name "*.ad?"`
+    gpr_files=`find $dir -name "*.gpr"`
+
+    if [ "$ada_files" != "" ]; then
+      ./node_modules/.bin/vscode-tmgrammar-snap -g syntaxes/ada.tmLanguage.json \
+        -s source.ada \
+        -t "$dir/*.ad?" || _err=1
+    fi
+
+    if [ "$gpr_files" != "" ]; then
+      ./node_modules/.bin/vscode-tmgrammar-snap -g syntaxes/gpr.tmLanguage.json \
+        -s source.gpr \
+        -t "$dir/*.gpr" || _err=1
+    fi
+
+    return $_err
 }
 
 error=0

--- a/integration/vscode/ada/run_grammar_tests.sh
+++ b/integration/vscode/ada/run_grammar_tests.sh
@@ -1,0 +1,28 @@
+# Very crude driver for the grammar tests.
+#
+# Usage:
+#     ./run_grammar_tests.sh  [path_to_test]
+#
+# Where path_to_test is the path to one testcase. If omitted,
+# process all tests under testsuite_grammar
+
+testpath=$1
+
+run_test(){
+    dir=$1
+   ./node_modules/.bin/vscode-tmgrammar-snap -g syntaxes/ada.tmLanguage.json \
+     -s source.ada \
+     -t "$dir/*.ad?"
+}
+
+error=0
+
+if [ "$testpath" != "" ]; then
+   run_test $testpath || error=1
+else
+   for dir in `ls testsuite_grammar`; do
+      run_test testsuite_grammar/$dir || error=1
+   done
+fi
+    
+exit $error

--- a/integration/vscode/ada/testsuite/index.ts
+++ b/integration/vscode/ada/testsuite/index.ts
@@ -1,0 +1,37 @@
+import * as path from 'path';
+import * as Mocha from 'mocha';
+import * as glob from 'glob';
+
+export function run(): Promise<void> {
+  // Create the mocha test
+  const mocha = new Mocha({
+    ui: 'tdd'
+  });
+  mocha.useColors(true);
+
+  const testsRoot = path.resolve(__dirname, 'tests');
+
+  return new Promise((c, e) => {
+    glob('**/**.test.js', { cwd: testsRoot }, (err, files) => {
+      if (err) {
+        return e(err);
+      }
+
+      // Add files to the test suite
+      files.forEach(f => mocha.addFile(path.resolve(testsRoot, f)));
+
+      try {
+        // Run the mocha test
+        mocha.run(failures => {
+          if (failures > 0) {
+            e(new Error(`${failures} tests failed.`));
+          } else {
+            c();
+          }
+        });
+      } catch (err) {
+        e(err);
+      }
+    });
+  });
+}

--- a/integration/vscode/ada/testsuite/runTests.ts
+++ b/integration/vscode/ada/testsuite/runTests.ts
@@ -1,0 +1,25 @@
+import * as path from 'path';
+
+import { runTests } from 'vscode-test';
+
+async function main() {
+	try {
+		// The folder containing the Extension Manifest package.json
+		// Passed to `--extensionDevelopmentPath`
+		const extensionDevelopmentPath = path.resolve(__dirname, '..');
+                console.log(extensionDevelopmentPath);
+
+		// The path to the extension test script
+		// Passed to --extensionTestsPath
+		const extensionTestsPath = path.resolve(__dirname);
+                console.log(extensionTestsPath);
+
+		// Download VS Code, unzip it and run the integration test
+		await runTests({ extensionDevelopmentPath, extensionTestsPath });
+	} catch (err) {
+		console.error('Failed to run tests');
+		process.exit(1);
+	}
+}
+
+main();

--- a/integration/vscode/ada/testsuite/tests/simple/simple.test.ts
+++ b/integration/vscode/ada/testsuite/tests/simple/simple.test.ts
@@ -1,0 +1,15 @@
+import * as assert from 'assert';
+
+// You can import and use all API from the 'vscode' module
+// as well as import your extension to test it
+import * as vscode from 'vscode';
+// import * as myExtension from '../../extension';
+
+suite('Extension Test Suite', () => {
+	vscode.window.showInformationMessage('Start all tests.');
+
+	test('Sample test', () => {
+		assert.equal(1, 1);
+
+	});
+});

--- a/integration/vscode/ada/testsuite_grammar/gpr_base/http_cyclone.gpr
+++ b/integration/vscode/ada/testsuite_grammar/gpr_base/http_cyclone.gpr
@@ -1,0 +1,15 @@
+with "Ada_Drivers_Library/boards/stm32f769_discovery/stm32f769_discovery_sfp.gpr";
+
+project HTTP_Cyclone extends "Ada_Drivers_Library/examples/shared/common/common.gpr" is
+
+
+   for Runtime ("Ada") use STM32F769_Discovery_sfp'Runtime("Ada");
+   for Target use "arm-eabi";
+   for Object_Dir use "obj";
+   for Create_Missing_Dirs use "True";
+
+   for Source_Dirs use ("src/**");
+
+   package Compiler renames STM32F769_Discovery_SFP.Compiler;
+
+end HTTP_Cyclone;

--- a/integration/vscode/ada/testsuite_grammar/gpr_base/http_cyclone.gpr.snap
+++ b/integration/vscode/ada/testsuite_grammar/gpr_base/http_cyclone.gpr.snap
@@ -1,0 +1,109 @@
+>with "Ada_Drivers_Library/boards/stm32f769_discovery/stm32f769_discovery_sfp.gpr";
+#^^^^ source.gpr meta.clause.with.gpr keyword.gpr
+#    ^ source.gpr meta.clause.with.gpr
+#     ^ source.gpr meta.clause.with.gpr string.quoted.double.gpr punctuation.definition.string.gpr
+#      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.gpr meta.clause.with.gpr string.quoted.double.gpr
+#                                                                                ^ source.gpr meta.clause.with.gpr string.quoted.double.gpr punctuation.definition.string.gpr
+#                                                                                 ^ source.gpr meta.clause.with.gpr punctuation.gpr
+>
+>project HTTP_Cyclone extends "Ada_Drivers_Library/examples/shared/common/common.gpr" is
+#^^^^^^^ source.gpr meta.project.gpr keyword.gpr
+#       ^ source.gpr meta.project.gpr
+#        ^^^^^^^^^^^^ source.gpr meta.project.gpr entity.name.project.gpr
+#                    ^ source.gpr meta.project.gpr
+#                     ^^^^^^^ source.gpr meta.project.gpr keyword.gpr
+#                            ^ source.gpr meta.project.gpr
+#                             ^ source.gpr meta.project.gpr string.quoted.double.gpr punctuation.definition.string.gpr
+#                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.gpr meta.project.gpr string.quoted.double.gpr
+#                                                                                   ^ source.gpr meta.project.gpr string.quoted.double.gpr punctuation.definition.string.gpr
+#                                                                                    ^ source.gpr meta.project.gpr
+#                                                                                     ^^ source.gpr meta.project.gpr keyword.gpr
+>
+>
+>   for Runtime ("Ada") use STM32F769_Discovery_sfp'Runtime("Ada");
+#^^^ source.gpr meta.project.gpr
+#   ^^^ source.gpr meta.project.gpr meta.attribute.gpr keyword.gpr
+#      ^ source.gpr meta.project.gpr meta.attribute.gpr
+#       ^^^^^^^ source.gpr meta.project.gpr meta.attribute.gpr entity.other.attribute-name.gpr
+#              ^^ source.gpr meta.project.gpr meta.attribute.gpr
+#                ^ source.gpr meta.project.gpr meta.attribute.gpr string.quoted.double.gpr punctuation.definition.string.gpr
+#                 ^^^ source.gpr meta.project.gpr meta.attribute.gpr string.quoted.double.gpr
+#                    ^ source.gpr meta.project.gpr meta.attribute.gpr string.quoted.double.gpr punctuation.definition.string.gpr
+#                     ^^ source.gpr meta.project.gpr meta.attribute.gpr
+#                       ^^^ source.gpr meta.project.gpr meta.attribute.gpr keyword.gpr
+#                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.gpr meta.project.gpr meta.attribute.gpr
+#                                                           ^ source.gpr meta.project.gpr meta.attribute.gpr string.quoted.double.gpr punctuation.definition.string.gpr
+#                                                            ^^^ source.gpr meta.project.gpr meta.attribute.gpr string.quoted.double.gpr
+#                                                               ^ source.gpr meta.project.gpr meta.attribute.gpr string.quoted.double.gpr punctuation.definition.string.gpr
+#                                                                ^ source.gpr meta.project.gpr meta.attribute.gpr
+#                                                                 ^ source.gpr meta.project.gpr meta.attribute.gpr punctuation.gpr
+>   for Target use "arm-eabi";
+#^^^ source.gpr meta.project.gpr
+#   ^^^ source.gpr meta.project.gpr meta.attribute.gpr keyword.gpr
+#      ^ source.gpr meta.project.gpr meta.attribute.gpr
+#       ^^^^^^ source.gpr meta.project.gpr meta.attribute.gpr entity.other.attribute-name.gpr
+#             ^ source.gpr meta.project.gpr meta.attribute.gpr
+#              ^^^ source.gpr meta.project.gpr meta.attribute.gpr keyword.gpr
+#                 ^ source.gpr meta.project.gpr meta.attribute.gpr
+#                  ^ source.gpr meta.project.gpr meta.attribute.gpr string.quoted.double.gpr punctuation.definition.string.gpr
+#                   ^^^^^^^^ source.gpr meta.project.gpr meta.attribute.gpr string.quoted.double.gpr
+#                           ^ source.gpr meta.project.gpr meta.attribute.gpr string.quoted.double.gpr punctuation.definition.string.gpr
+#                            ^ source.gpr meta.project.gpr meta.attribute.gpr punctuation.gpr
+>   for Object_Dir use "obj";
+#^^^ source.gpr meta.project.gpr
+#   ^^^ source.gpr meta.project.gpr meta.attribute.gpr keyword.gpr
+#      ^ source.gpr meta.project.gpr meta.attribute.gpr
+#       ^^^^^^^^^^ source.gpr meta.project.gpr meta.attribute.gpr entity.other.attribute-name.gpr
+#                 ^ source.gpr meta.project.gpr meta.attribute.gpr
+#                  ^^^ source.gpr meta.project.gpr meta.attribute.gpr keyword.gpr
+#                     ^ source.gpr meta.project.gpr meta.attribute.gpr
+#                      ^ source.gpr meta.project.gpr meta.attribute.gpr string.quoted.double.gpr punctuation.definition.string.gpr
+#                       ^^^ source.gpr meta.project.gpr meta.attribute.gpr string.quoted.double.gpr
+#                          ^ source.gpr meta.project.gpr meta.attribute.gpr string.quoted.double.gpr punctuation.definition.string.gpr
+#                           ^ source.gpr meta.project.gpr meta.attribute.gpr punctuation.gpr
+>   for Create_Missing_Dirs use "True";
+#^^^ source.gpr meta.project.gpr
+#   ^^^ source.gpr meta.project.gpr meta.attribute.gpr keyword.gpr
+#      ^ source.gpr meta.project.gpr meta.attribute.gpr
+#       ^^^^^^^^^^^^^^^^^^^ source.gpr meta.project.gpr meta.attribute.gpr entity.other.attribute-name.gpr
+#                          ^ source.gpr meta.project.gpr meta.attribute.gpr
+#                           ^^^ source.gpr meta.project.gpr meta.attribute.gpr keyword.gpr
+#                              ^ source.gpr meta.project.gpr meta.attribute.gpr
+#                               ^ source.gpr meta.project.gpr meta.attribute.gpr string.quoted.double.gpr punctuation.definition.string.gpr
+#                                ^^^^ source.gpr meta.project.gpr meta.attribute.gpr string.quoted.double.gpr
+#                                    ^ source.gpr meta.project.gpr meta.attribute.gpr string.quoted.double.gpr punctuation.definition.string.gpr
+#                                     ^ source.gpr meta.project.gpr meta.attribute.gpr punctuation.gpr
+>
+>   for Source_Dirs use ("src/**");
+#^^^ source.gpr meta.project.gpr
+#   ^^^ source.gpr meta.project.gpr meta.attribute.gpr keyword.gpr
+#      ^ source.gpr meta.project.gpr meta.attribute.gpr
+#       ^^^^^^^^^^^ source.gpr meta.project.gpr meta.attribute.gpr entity.other.attribute-name.gpr
+#                  ^ source.gpr meta.project.gpr meta.attribute.gpr
+#                   ^^^ source.gpr meta.project.gpr meta.attribute.gpr keyword.gpr
+#                      ^^ source.gpr meta.project.gpr meta.attribute.gpr
+#                        ^ source.gpr meta.project.gpr meta.attribute.gpr string.quoted.double.gpr punctuation.definition.string.gpr
+#                         ^^^^^^ source.gpr meta.project.gpr meta.attribute.gpr string.quoted.double.gpr
+#                               ^ source.gpr meta.project.gpr meta.attribute.gpr string.quoted.double.gpr punctuation.definition.string.gpr
+#                                ^ source.gpr meta.project.gpr meta.attribute.gpr
+#                                 ^ source.gpr meta.project.gpr meta.attribute.gpr punctuation.gpr
+>
+>   package Compiler renames STM32F769_Discovery_SFP.Compiler;
+#^^^ source.gpr meta.project.gpr
+#   ^^^^^^^ source.gpr meta.project.gpr meta.package_renaming.gpr keyword.gpr
+#          ^ source.gpr meta.project.gpr meta.package_renaming.gpr
+#           ^^^^^^^^ source.gpr meta.project.gpr meta.package_renaming.gpr entity.name.package.gpr
+#                   ^ source.gpr meta.project.gpr meta.package_renaming.gpr
+#                    ^^^^^^^ source.gpr meta.project.gpr meta.package_renaming.gpr keyword.gpr
+#                           ^ source.gpr meta.project.gpr meta.package_renaming.gpr
+#                            ^^^^^^^^^^^^^^^^^^^^^^^ source.gpr meta.project.gpr meta.package_renaming.gpr entity.name.project.gpr
+#                                                   ^ source.gpr meta.project.gpr meta.package_renaming.gpr punctuation.gpr
+#                                                    ^^^^^^^^ source.gpr meta.project.gpr meta.package_renaming.gpr entity.name.package.gpr
+#                                                            ^ source.gpr meta.project.gpr meta.package_renaming.gpr package.punctuation
+>
+>end HTTP_Cyclone;
+#^^^ source.gpr meta.project.gpr keyword.gpr
+#   ^ source.gpr meta.project.gpr
+#    ^^^^^^^^^^^^ source.gpr meta.project.gpr entity.name.project.gpr
+#                ^ source.gpr meta.project.gpr punctuation.gpr
+>

--- a/integration/vscode/ada/testsuite_grammar/hello/hello.adb
+++ b/integration/vscode/ada/testsuite_grammar/hello/hello.adb
@@ -1,0 +1,7 @@
+-- SYNTAX TEST "source.ada" "simple test"
+-- simple test
+
+procedure Hello is
+begin
+   null;
+end Hello;

--- a/integration/vscode/ada/testsuite_grammar/hello/hello.adb.snap
+++ b/integration/vscode/ada/testsuite_grammar/hello/hello.adb.snap
@@ -1,0 +1,23 @@
+>-- SYNTAX TEST "source.ada" "simple test"
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.ada comment.line.double-dash.ada
+>-- simple test
+#^^^^^^^^^^^^^^ source.ada comment.line.double-dash.ada
+>
+>procedure Hello is
+#^^^^^^^^^ source.ada keyword.ada
+#         ^ source.ada
+#          ^^^^^ source.ada entity.name.function.ada
+#               ^ source.ada
+#                ^^ source.ada keyword.ada
+>begin
+#^^^^^ source.ada keyword.ada
+>   null;
+#^^^ source.ada
+#   ^^^^ source.ada meta.statement.null.ada keyword.ada
+#       ^ source.ada meta.statement.null.ada punctuation.ada
+>end Hello;
+#^^^ source.ada keyword.ada
+#   ^ source.ada
+#    ^^^^^ source.ada entity.name.function.ada
+#         ^ source.ada punctuation.ada
+>

--- a/integration/vscode/ada/testsuite_grammar/hello/hello.adb.snap
+++ b/integration/vscode/ada/testsuite_grammar/hello/hello.adb.snap
@@ -4,20 +4,20 @@
 #^^^^^^^^^^^^^^ source.ada comment.line.double-dash.ada
 >
 >procedure Hello is
-#^^^^^^^^^ source.ada keyword.ada
-#         ^ source.ada
-#          ^^^^^ source.ada entity.name.function.ada
-#               ^ source.ada
-#                ^^ source.ada keyword.ada
+#^^^^^^^^^ source.ada meta.declaration.procedure.body.ada keyword.ada
+#         ^ source.ada meta.declaration.procedure.body.ada
+#          ^^^^^ source.ada meta.declaration.procedure.body.ada entity.name.function.ada
+#               ^ source.ada meta.declaration.procedure.body.ada
+#                ^^ source.ada meta.declaration.procedure.body.ada keyword.ada
 >begin
-#^^^^^ source.ada keyword.ada
+#^^^^^ source.ada meta.declaration.procedure.body.ada keyword.ada
 >   null;
-#^^^ source.ada
-#   ^^^^ source.ada meta.statement.null.ada keyword.ada
-#       ^ source.ada meta.statement.null.ada punctuation.ada
+#^^^ source.ada meta.declaration.procedure.body.ada
+#   ^^^^ source.ada meta.declaration.procedure.body.ada meta.statement.null.ada keyword.ada
+#       ^ source.ada meta.declaration.procedure.body.ada meta.statement.null.ada punctuation.ada
 >end Hello;
-#^^^ source.ada keyword.ada
-#   ^ source.ada
-#    ^^^^^ source.ada entity.name.function.ada
-#         ^ source.ada punctuation.ada
+#^^^ source.ada meta.declaration.procedure.body.ada keyword.ada
+#   ^ source.ada meta.declaration.procedure.body.ada
+#    ^^^^^ source.ada meta.declaration.procedure.body.ada entity.name.function.ada
+#         ^ source.ada meta.declaration.procedure.body.ada punctuation.ada
 >

--- a/integration/vscode/ada/testsuite_grammar/invalid_ada/hello.adb
+++ b/integration/vscode/ada/testsuite_grammar/invalid_ada/hello.adb
@@ -1,0 +1,1 @@
+procedure hello isd laskndnlads

--- a/integration/vscode/ada/testsuite_grammar/invalid_ada/hello.adb.snap
+++ b/integration/vscode/ada/testsuite_grammar/invalid_ada/hello.adb.snap
@@ -1,6 +1,6 @@
 >procedure hello isd laskndnlads
-#^^^^^^^^^ source.ada keyword.ada
-#         ^ source.ada
-#          ^^^^^ source.ada entity.name.function.ada
-#               ^^^^^^^^^^^^^^^^^ source.ada
+#^^^^^^^^^ source.ada meta.declaration.procedure.body.ada keyword.ada
+#         ^ source.ada meta.declaration.procedure.body.ada
+#          ^^^^^ source.ada meta.declaration.procedure.body.ada entity.name.function.ada
+#               ^^^^^^^^^^^^^^^^^ source.ada meta.declaration.procedure.body.ada
 >

--- a/integration/vscode/ada/testsuite_grammar/invalid_ada/hello.adb.snap
+++ b/integration/vscode/ada/testsuite_grammar/invalid_ada/hello.adb.snap
@@ -1,0 +1,6 @@
+>procedure hello isd laskndnlads
+#^^^^^^^^^ source.ada keyword.ada
+#         ^ source.ada
+#          ^^^^^ source.ada entity.name.function.ada
+#               ^^^^^^^^^^^^^^^^^ source.ada
+>

--- a/integration/vscode/ada/tsconfig.json
+++ b/integration/vscode/ada/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"compilerOptions": {
+		"module": "commonjs",
+		"target": "es6",
+		"outDir": "out",
+		"sourceMap": true,
+		"rootDir": "testsuite",
+		"strict": true,
+	},
+	"exclude": ["node_modules", ".vscode-test"]
+}


### PR DESCRIPTION
Add
 *  a VS Code integration test framework based on
https://code.visualstudio.com/api/working-with-extensions/testing-extension
  * a VS Code grammar test framework based on the (very nice)
https://github.com/PanAeon/vscode-tmgrammar-test

Add a Makefile target to drive this. Add a note in the documentation.
Schedule this as part of the travis builder on Linux.

Fixes #386