### PR TITLE
Improve GPR highlighting support

### DIFF
--- a/integration/vscode/ada/syntaxes/gpr.tmLanguage.json
+++ b/integration/vscode/ada/syntaxes/gpr.tmLanguage.json
@@ -100,12 +100,11 @@
 		},
 		"package": {
 			"name": "meta.package.gpr",
-			"begin": "(?i)\\b(package)\\s+((?:\\w|\\d|_)+)\\s+(is)\\b",
+			"begin": "(?i)\\b(package)\\s+((?:\\w|\\d|_)+)\\b",
 			"end": "(?i)\\b(end)\\s+(\\2)\\s*(;)",
 			"beginCaptures": {
 				"1": { "name": "keyword.gpr" },
-				"2": { "name": "entity.name.package.gpr" },
-				"3": { "name": "keyword.gpr" }
+				"2": { "name": "entity.name.package.gpr" }
 			},
 			"endCaptures": {
 				"1": { "name": "keyword.gpr" },
@@ -113,9 +112,35 @@
 				"3": { "name": "punctuation.gpr" }
 			},
 			"patterns": [
-				{ "include": "#case_construction" },
-				{ "include": "#comment" },
-				{ "include": "#attribute" }
+				{
+					"begin": "(?i)\\bis\\b",
+					"end": "(?i)\\b(?=end)\\b",
+					"beginCaptures": {
+						"0": { "name": "keyword.gpr" }
+					},
+					"patterns": [
+						{ "include": "#case_construction" },
+						{ "include": "#comment" },
+						{ "include": "#attribute" }
+					]
+				},
+				{
+					"begin": "(?i)\\bextends\\b",
+					"end": "(?i)\\b(?=is)\\b",
+					"beginCaptures": {
+						"0": { "name": "keyword.gpr" }
+					},
+					"patterns": [
+						{
+							"match": "\\b((?:\\w|\\d|_)+)(\\.)((?:\\w|\\d|_)+)\\b",
+							"captures": {
+								"1": { "name": "entity.name.project.gpr" },
+								"2": { "name": "punctuation.gpr" },
+								"3": { "name": "entity.name.package.gpr" }
+							}
+						}
+					]
+				}
 			]
 		},
 		"package_renaming": {
@@ -163,8 +188,8 @@
 						"0": { "name": "keyword.gpr" }
 					},
 					"patterns": [
-						{ "include": "#package" },
 						{ "include": "#package_renaming" },
+						{ "include": "#package" },
 						{ "include": "#comment" },
 						{ "include": "#attribute" },
 						{ "include": "#type" },

--- a/integration/vscode/ada/syntaxes/gpr.tmLanguage.json
+++ b/integration/vscode/ada/syntaxes/gpr.tmLanguage.json
@@ -118,6 +118,29 @@
 				{ "include": "#attribute" }
 			]
 		},
+		"package_renaming": {
+			"name": "meta.package_renaming.gpr",
+			"begin": "(?i)\\b(package)\\s+((?:\\w|\\d|_)+)\\s+(renames)\\b",
+			"end": ";",
+			"beginCaptures": {
+				"1": { "name": "keyword.gpr" },
+				"2": { "name": "entity.name.package.gpr" },
+				"3": { "name": "keyword.gpr" }
+			},
+			"endCaptures": {
+				"0": { "name": "package.punctuation" }
+			},
+			"patterns": [
+				{
+					"match": "\\b((?:\\w|\\d|_)+)(\\.)((?:\\w|\\d|_)+)\\b",
+					"captures": {
+						"1": { "name": "entity.name.project.gpr" },
+						"2": { "name": "punctuation.gpr" },
+						"3": { "name": "entity.name.package.gpr" }
+					}
+				}
+			]
+		},
 		"project": {
 			"name": "meta.project.gpr",
 			"begin": "(?i)\\b(?:(abstract|aggregate|library)\\s+)?(project)\\s+((?:\\w|\\d|_)+)\\b",
@@ -141,6 +164,7 @@
 					},
 					"patterns": [
 						{ "include": "#package" },
+						{ "include": "#package_renaming" },
 						{ "include": "#comment" },
 						{ "include": "#attribute" },
 						{ "include": "#type" },

--- a/integration/vscode/ada/syntaxes/gpr.tmLanguage.json
+++ b/integration/vscode/ada/syntaxes/gpr.tmLanguage.json
@@ -214,10 +214,10 @@
 			"match": "(\").*?(\")",
 			"captures": {
 				"1": {
-					"name": "punctuation.definition.string.ada"
+					"name": "punctuation.definition.string.gpr"
 				},
 				"2": {
-					"name": "punctuation.definition.string.ada"
+					"name": "punctuation.definition.string.gpr"
 				}
 			}
 		},

--- a/integration/vscode/ada/syntaxes/gpr.tmLanguage.json
+++ b/integration/vscode/ada/syntaxes/gpr.tmLanguage.json
@@ -2,6 +2,7 @@
 	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
 	"name": "gpr",
 	"patterns": [
+		{ "include": "#with_clause" },
 		{ "include": "#project" },
 		{ "include": "#comment" }
 	],
@@ -192,6 +193,25 @@
 			"patterns": [
 				{ "include": "#assignment" },
 				{ "include": "#type_annotation" }
+			]
+		},
+		"with_clause": {
+			"name": "meta.clause.with.gpr",
+			"begin": "(?i)\\b(?:(limited)\\s+)?(with)\\b",
+			"end": ";",
+			"beginCaptures": {
+				"1": { "name": "keyword.gpr" },
+				"2": { "name": "keyword.gpr" }
+			},
+			"endCaptures": {
+				"0": { "name": "punctuation.gpr" }
+			},
+			"patterns": [
+				{ "include": "#string" },
+				{
+					"match": ",",
+					"name": "punctuation.gpr"
+				}
 			]
 		}
 	 },

--- a/integration/vscode/ada/syntaxes/gpr.tmLanguage.json
+++ b/integration/vscode/ada/syntaxes/gpr.tmLanguage.json
@@ -120,24 +120,44 @@
 		},
 		"project": {
 			"name": "meta.project.gpr",
-			"begin": "(?i)\\b(?:(abstract|aggregate|library)\\s+)?(project)\\s+((?:\\w|\\d|_)+)\\s+(is)\\b",
+			"begin": "(?i)\\b(?:(abstract|aggregate|library)\\s+)?(project)\\s+((?:\\w|\\d|_)+)\\b",
 			"end": "(?i)\\b(end)\\s+(\\3)\\s*(;)",
 			"beginCaptures": {
 				"1": { "name": "keyword.gpr" },
 				"2": { "name": "keyword.gpr" },
-				"3": { "name": "entity.name.project.gpr" },
-				"4": { "name": "keyword.gpr" }
+				"3": { "name": "entity.name.project.gpr" }
 			},
 			"endCaptures": {
 				"1": { "name": "keyword.gpr" },
+				"2": { "name": "entity.name.project.gpr" },
 				"3": { "name": "punctuation.gpr" }
 			},
 			"patterns": [
-				{ "include": "#package" },
-				{ "include": "#comment" },
-				{ "include": "#attribute" },
-				{ "include": "#type" },
-				{ "include": "#typed_variable" }
+				{
+					"begin": "(?i)\\bis\\b",
+					"end": "(?i)\\b(?=end)\\b",
+					"beginCaptures": {
+						"0": { "name": "keyword.gpr" }
+					},
+					"patterns": [
+						{ "include": "#package" },
+						{ "include": "#comment" },
+						{ "include": "#attribute" },
+						{ "include": "#type" },
+						{ "include": "#typed_variable" }
+					]
+				},
+				{
+					"begin": "(?i)\\b(extends)(?:\\s+(all))?\\b",
+					"beginCaptures": {
+						"1": { "name": "keyword.gpr" },
+						"2": { "name": "keyword.gpr" }
+					},
+					"end": "(?i)\\b(?=is)\\b",
+					"patterns": [
+						{ "include": "#string" }
+					]
+				}
 			]
 		},
 		"string": {


### PR DESCRIPTION
For my own use I also needed to improve the highlighting support of `.gpr` files.

I added:
- Support for with clause.
- Support for extends keyword in both projects and package.
- Support for package extension.

I also attach an example that should be correctly highlighted for your tests.
```Ada
with "Ada_Drivers_Library/boards/stm32f769_discovery/stm32f769_discovery_sfp.gpr";

project HTTP_Cyclone extends "Ada_Drivers_Library/examples/shared/common/common.gpr" is


   for Runtime ("Ada") use STM32F769_Discovery_sfp'Runtime("Ada");
   for Target use "arm-eabi";
   for Object_Dir use "obj";
   for Create_Missing_Dirs use "True";

   for Source_Dirs use ("src/**");

   package Compiler renames STM32F769_Discovery_SFP.Compiler;

end HTTP_Cyclone;
```
![image](https://user-images.githubusercontent.com/34268335/80304714-2011ef80-87b8-11ea-9bd3-68567a5f7120.png)

Also, last commit changes `"punctuation.definition.string.ada"` for `"punctuation.definition.string.gpr"`. Tell me if it's correct because I'm not sure.