### PR TITLE
T423-090: Display project name for aggregate project tooltips

### DIFF
--- a/source/ada/lsp-ada_handlers.adb
+++ b/source/ada/lsp-ada_handlers.adb
@@ -1630,7 +1630,9 @@ package body LSP.Ada_Handlers is
             value     => Decl_Text,
             language  => +"ada"));
 
-      --  Append the declaration's location
+      --  Append the declaration's location.
+      --  In addition, append the project's name if we are dealing with an
+      --  aggregate project.
 
       Decl_Unit_File := GNATCOLL.VFS.Create (+Decl.Unit.Get_Filename);
 
@@ -1642,6 +1644,10 @@ package body LSP.Ada_Handlers is
          & GNATCOLL.Utils.Image
            (Integer (Decl.Sloc_Range.Start_Column), Min_Width => 1)
          & ")");
+
+      if Self.Project_Tree.Root_Project.Is_Aggregate_Project then
+         Location_Text := Location_Text & " in project " & C.Id;
+      end if;
 
       Response.result.contents.Vector.Append
         (LSP.Messages.MarkedString'

--- a/testsuite/ada_lsp/implementation.aggregates/test.json
+++ b/testsuite/ada_lsp/implementation.aggregates/test.json
@@ -235,7 +235,7 @@
                         "value": "function Common_Fun return Integer",
                         "language": "ada"
                      },
-                     "at common_pack.ads (4:4)"
+                     "at common_pack.ads (4:4) in project p"
                   ]
                }
             }
@@ -267,7 +267,7 @@
                         "value": "function Common_Fun return Integer",
                         "language": "ada"
                      },
-                     "at common_pack.ads (4:4)"
+                     "at common_pack.ads (4:4) in project p"
                   ]
                }
             }


### PR DESCRIPTION
Since displaying the base name of the entity's declaration file might
not be sufficient in case of aggregate projects.