### PR TITLE
Resolve bug in nested declarations

### DIFF
--- a/integration/vscode/ada/syntaxes/ada.tmLanguage.json
+++ b/integration/vscode/ada/syntaxes/ada.tmLanguage.json
@@ -284,7 +284,8 @@
 		"basic_declarative_item": {
 			"patterns": [
 				{ "include": "#basic_declaration" },
-				{ "include": "#aspect_clause" }
+				{ "include": "#aspect_clause" },
+				{ "include": "#use_clause" }
 			]
 		},
 		"basic_declaration": {
@@ -294,7 +295,9 @@
 				{ "include": "#exception_declaration" },
 				{ "include": "#object_declaration" },
 				{ "include": "#subprogram_specification" },
-				{ "include": "#package_declaration" }
+				{ "include": "#package_declaration" },
+				{ "include": "#pragma" },
+				{ "include": "#comment" }
 			]
 		},
 		"block_statement": {
@@ -503,7 +506,8 @@
 		},
 		"component_item": {
 			"patterns": [
-				{ "include": "#component_declaration" }
+				{ "include": "#component_declaration" },
+				{ "include": "#comment" }
 			]
 		},
 		"composite_constraint": {
@@ -752,6 +756,7 @@
 		"expression": {
 			"name": "meta.expression.ada",
 			"patterns": [
+				{ "include": "#comment" },
 				{ "include": "#value" },
 				{ "include": "#operator" }
 			]

--- a/integration/vscode/ada/syntaxes/ada.tmLanguage.json
+++ b/integration/vscode/ada/syntaxes/ada.tmLanguage.json
@@ -847,8 +847,9 @@
 			]
 		},
 		"function_body": {
+			"name": "meta.declaration.function.body.ada",
 			"begin": "(?i)\\b(overriding\\s+)?(function)\\s+((\\w|\\d|\\.|_)+)\\b",
-			"end": "(?i)\\b(?:(end)\\s+(\\3)\\s*)?(;)",
+			"end": "(?i)(?:\\b(end)\\s+(\\3)\\s*)?(;)",
 			"beginCaptures": {
 				"1": { "name": "storage.visibility.ada" },
 				"2": { "name": "keyword.ada" },
@@ -884,6 +885,7 @@
 			]
 		},
 		"function_specification": {
+			"name": "meta.declaration.function.specification.ada",
 			"begin": "(?i)\\b(overriding\\s+)?(function)\\s+((?:\\w|\\d|\\.|_)+)\\b",
 			"end": ";",
 			"beginCaptures": {


### PR DESCRIPTION
Before
![image](https://user-images.githubusercontent.com/34268335/80580195-732fb080-8a0b-11ea-9b3a-80b660cd3577.png)
After
![image](https://user-images.githubusercontent.com/34268335/80580252-8a6e9e00-8a0b-11ea-9ac3-f5642aac5f0f.png)

For @setton if you are interested in adding it in your "nested" test case.
```Ada
procedure Main is
   function D return T
        with X => "Bc";
   
   procedure E is
   begin
      Ada.Text_IO.Put_Line("Hey");
   end E;
begin
 null;
end Main;
```