### PR TITLE
SA14-008: Handle aggregates for completion

### DIFF
--- a/source/ada/lsp-ada_documents.adb
+++ b/source/ada/lsp-ada_documents.adb
@@ -63,11 +63,12 @@ package body LSP.Ada_Documents is
       return LSP.Messages.Als_Visibility;
 
    function Compute_Completion_Item
-     (Context          : LSP.Ada_Contexts.Context;
-      BD               : Libadalang.Analysis.Basic_Decl;
-      DN               : Libadalang.Analysis.Defining_Name;
-      Snippets_Enabled : Boolean;
-      Is_Dot_Call      : Boolean)
+     (Context                  : LSP.Ada_Contexts.Context;
+      BD                       : Libadalang.Analysis.Basic_Decl;
+      DN                       : Libadalang.Analysis.Defining_Name;
+      Snippets_Enabled         : Boolean;
+      Named_Notation_Threshold : Natural;
+      Is_Dot_Call              : Boolean)
       return LSP.Messages.CompletionItem;
    --  Compute a completion item.
    --  Node is the node from which the completion starts (e.g: 'A' in 'A.').
@@ -75,8 +76,24 @@ package body LSP.Ada_Documents is
    --  that should be used to compute the completion item.
    --  When Snippets_Enabled is True, subprogram completion items are computed
    --  as snippets that list all the subprogram's formal parameters.
+   --  Named_Notation_Threshold defines the number of parameters at which point
+   --  named notation is used for subprogram completion snippets.
    --  Is_Dot_Call is used to know if we should omit the first parameter
    --  when computing subprogram snippets.
+
+   procedure Get_Aggregate_Completion
+     (Node                     : Libadalang.Analysis.Aggregate;
+      Context                  : LSP.Ada_Contexts.Context;
+      Named_Notation_Threshold : Natural;
+      Result                   : out LSP.Messages.CompletionList);
+   --  Return the completion list for the given aggregate node.
+   --  The returned completion list may contain several items if the aggregate
+   --  is used to assign a value to a variant record: in that case, a snippet
+   --  per shape (i.e: a shape corresponds to one of the various forms that a
+   --  discriminated variant record can take) will be proposed to the user.
+   --  Named_Notation_Threshold defines the number of parameters/components at
+   --  which point named notation is used for subprogram/aggregate completion
+   --  snippets.
 
    function Compute_Completion_Detail
      (BD : Libadalang.Analysis.Basic_Decl) return LSP.Types.LSP_String;
@@ -1062,11 +1079,12 @@ package body LSP.Ada_Documents is
    -----------------------------
 
    function Compute_Completion_Item
-     (Context          : LSP.Ada_Contexts.Context;
-      BD               : Libadalang.Analysis.Basic_Decl;
-      DN               : Libadalang.Analysis.Defining_Name;
-      Snippets_Enabled : Boolean;
-      Is_Dot_Call      : Boolean)
+     (Context                  : LSP.Ada_Contexts.Context;
+      BD                       : Libadalang.Analysis.Basic_Decl;
+      DN                       : Libadalang.Analysis.Defining_Name;
+      Snippets_Enabled         : Boolean;
+      Named_Notation_Threshold : Natural;
+      Is_Dot_Call              : Boolean)
       return LSP.Messages.CompletionItem
    is
       use LSP.Messages;
@@ -1126,7 +1144,9 @@ package body LSP.Ada_Documents is
          --  Remove the first formal parameter from the list when the dotted
          --  notation is used.
 
-         Idx         : Positive := 1;
+         Idx                : Positive := 1;
+         Nb_Params          : Natural := 0;
+         Use_Named_Notation : Boolean := False;
       begin
 
          --  Create a completion snippet if the subprogram expects some
@@ -1139,22 +1159,53 @@ package body LSP.Ada_Documents is
 
             Insert_Text := Insert_Text & " (";
 
+            --  Compute number of params to know if named notation should be
+            --  used.
+
+            for Param of Params loop
+               Nb_Params := Nb_Params + Param.F_Ids.Children_Count;
+            end loop;
+
+            Use_Named_Notation := Named_Notation_Threshold > 0
+              and then Nb_Params >= Named_Notation_Threshold;
+
             for Param of Params loop
                for Id of Param.F_Ids loop
                   declare
                      Mode : constant String :=
                        Langkit_Support.Text.To_UTF8 (Param.F_Mode.Text);
                   begin
-                     Insert_Text := Insert_Text & To_LSP_String
-                       ("${" & GNATCOLL.Utils.Image (Idx, Min_Width => 1) & ":"
-                        & (if Mode /= "" then
-                               Mode & " "
-                           else
-                             "")
-                        & Langkit_Support.Text.To_UTF8 (Id.Text)
-                        & " : "
-                        & Langkit_Support.Text.To_UTF8 (Param.F_Type_Expr.Text)
-                        & "}, ");
+                     if Use_Named_Notation then
+                        Insert_Text := Insert_Text & To_LSP_String
+                          (Langkit_Support.Text.To_UTF8 (Id.Text)
+                           & " => "
+                           & "${"
+                           & GNATCOLL.Utils.Image (Idx, Min_Width => 1)
+                           & ":"
+                           & (if Mode /= "" then
+                                  Mode & " "
+                             else
+                                "")
+                           &  Langkit_Support.Text.To_UTF8 (Id.Text)
+                           & " : "
+                           & Langkit_Support.Text.To_UTF8
+                             (Param.F_Type_Expr.Text)
+                           & "}, ");
+                     else
+                        Insert_Text := Insert_Text & To_LSP_String
+                          ("${"
+                           & GNATCOLL.Utils.Image (Idx, Min_Width => 1)
+                           & ":"
+                           & (if Mode /= "" then
+                                  Mode & " "
+                             else
+                                "")
+                           & Langkit_Support.Text.To_UTF8 (Id.Text)
+                           & " : "
+                           & Langkit_Support.Text.To_UTF8
+                             (Param.F_Type_Expr.Text)
+                           & "}, ");
+                     end if;
 
                      Idx := Idx + 1;
                   end;
@@ -1180,16 +1231,301 @@ package body LSP.Ada_Documents is
       return Item;
    end Compute_Completion_Item;
 
+   ------------------------------
+   -- Get_Aggregate_Completion --
+   ------------------------------
+
+   procedure Get_Aggregate_Completion
+     (Node                     : Libadalang.Analysis.Aggregate;
+      Context                  : LSP.Ada_Contexts.Context;
+      Named_Notation_Threshold : Natural;
+      Result                   : out LSP.Messages.CompletionList)
+   is
+      pragma Unreferenced (Context);
+
+      use Libadalang.Common;
+      use LSP.Messages;
+      use LSP.Types;
+
+      Aggr_Type          : constant Base_Type_Decl :=
+        Node.P_Expression_Type.P_Canonical_Type;
+      Use_Named_Notation : Boolean := False;
+
+      function Get_Snippet_For_Component
+        (Param              : Base_Formal_Param_Decl;
+         Idx                : Natural;
+         Use_Named_Notation : Boolean) return LSP_String;
+      --  Return a snippet for the given component
+
+      function Get_Snippet_For_Discriminant
+        (Disc               : Discriminant_Values;
+         Idx                : Natural;
+         Use_Named_Notation : Boolean) return LSP_String;
+      --  Return a snippet for the given discriminant
+
+      function Get_Label_For_Shape
+        (Discriminants : Discriminant_Values_Array) return LSP_String;
+      --  Return a suitable label for the given shape (i.e: a shape corresponds
+      --  to one of the various forms that a discriminated variant record can
+      --  take).
+
+      -------------------------------
+      -- Get_Snippet_For_Component --
+      -------------------------------
+
+      function Get_Snippet_For_Component
+        (Param              : Base_Formal_Param_Decl;
+         Idx                : Natural;
+         Use_Named_Notation : Boolean) return LSP_String
+      is
+         Snippet : LSP_String;
+      begin
+         case Param.Kind is
+            when Ada_Component_Decl_Range =>
+
+               for Id of As_Component_Decl (Param).F_Ids loop
+                  if Use_Named_Notation then
+                     Snippet := Snippet & To_LSP_String
+                       (Langkit_Support.Text.To_UTF8 (Id.Text)
+                        & " => ");
+                  end if;
+
+                  Snippet := Snippet & To_LSP_String
+                    ("${"
+                     & GNATCOLL.Utils.Image (Idx, Min_Width => 1)
+                     & ":"
+                     & Langkit_Support.Text.To_UTF8 (Id.Text)
+                     & " : "
+                     & Langkit_Support.Text.To_UTF8
+                       (As_Component_Decl
+                            (Param).F_Component_Def.F_Type_Expr.Text)
+                     & "}, ");
+               end loop;
+
+            when others =>
+               return LSP.Types.Empty_LSP_String;
+         end case;
+
+         return Snippet;
+      end Get_Snippet_For_Component;
+
+      ----------------------------------
+      -- Get_Snippet_For_Discriminant --
+      ----------------------------------
+
+      function Get_Snippet_For_Discriminant
+        (Disc               : Discriminant_Values;
+         Idx                : Natural;
+         Use_Named_Notation : Boolean) return LSP_String
+      is
+         Snippet : LSP_String;
+         Values  : constant Alternatives_List'Class :=
+           Libadalang.Analysis.Values (Disc);
+         Value_Node : Ada_Node;
+      begin
+
+         if Use_Named_Notation then
+            if Values.Children_Count = 1 then
+               Value_Node := Values.Child (Values.First_Child_Index);
+
+               Snippet := To_LSP_String
+                 (Langkit_Support.Text.To_UTF8 (Discriminant (Disc).Text))
+                 & " => ";
+
+               if Value_Node.Kind in Ada_Others_Designator_Range then
+                  Snippet := Snippet & To_LSP_String
+                    ("${"
+                     & GNATCOLL.Utils.Image
+                       (Idx, Min_Width => 1)
+                     & ":"
+                     & Langkit_Support.Text.To_UTF8 (Values.Text)
+                     & "}, ");
+               else
+                  Snippet := Snippet & To_LSP_String
+                    (Langkit_Support.Text.To_UTF8 (Values.Text)
+                     & ", ");
+               end if;
+            else
+               Snippet := To_LSP_String
+                 (Langkit_Support.Text.To_UTF8 (Discriminant (Disc).Text)
+                  & " => "
+                  & "${"
+                  & GNATCOLL.Utils.Image
+                    (Idx, Min_Width => 1)
+                  & ":"
+                  & Langkit_Support.Text.To_UTF8 (Values.Text)
+                  & "}, ");
+            end if;
+         else
+            if Values.Children_Count = 1 then
+               Value_Node := Values.Child (Values.First_Child_Index);
+
+               if Value_Node.Kind in Ada_Others_Designator_Range then
+                  Snippet := Snippet & To_LSP_String
+                    ("${"
+                     & GNATCOLL.Utils.Image
+                       (Idx, Min_Width => 1)
+                     & ":"
+                     & Langkit_Support.Text.To_UTF8 (Values.Text)
+                     & "}, ");
+               else
+                  Snippet := Snippet & To_LSP_String
+                    (Langkit_Support.Text.To_UTF8 (Values.Text)
+                     & ", ");
+               end if;
+            else
+               Snippet := To_LSP_String
+                 ("${"
+                  & GNATCOLL.Utils.Image
+                    (Idx, Min_Width => 1)
+                  & ":"
+                  & Langkit_Support.Text.To_UTF8 (Values.Text)
+                  & "}, ");
+            end if;
+         end if;
+
+         return Snippet;
+      end Get_Snippet_For_Discriminant;
+
+      -------------------------
+      -- Get_Label_For_Shape --
+      -------------------------
+
+      function Get_Label_For_Shape
+        (Discriminants : Discriminant_Values_Array) return LSP_String
+      is
+         Label  : LSP_String;
+         Length : constant Integer := Discriminants'Length;
+      begin
+         if Length = 0 then
+            return To_LSP_String
+              ("Aggregate for "
+               & Langkit_Support.Text.To_UTF8 (Aggr_Type.F_Name.Text));
+         end if;
+
+         Label := To_LSP_String (String'("Aggregate when "));
+
+         for Idx in Discriminants'Range loop
+            declare
+               Disc_Values : constant Discriminant_Values :=
+                 Discriminants (Idx);
+            begin
+               Label := Label & To_LSP_String
+                 (Langkit_Support.Text.To_UTF8
+                    (Discriminant (Disc_Values).Text))
+                 & " => ";
+
+               Label := Label & To_LSP_String
+                 (Langkit_Support.Text.To_UTF8 (Values (Disc_Values).Text));
+
+               if Idx < Discriminants'Length then
+                  Label := Label & ", ";
+               end if;
+            end;
+         end loop;
+
+         return Label;
+      end Get_Label_For_Shape;
+
+   begin
+      if Aggr_Type.Kind in Ada_Type_Decl_Range then
+         declare
+            Shapes        : constant Libadalang.Analysis.Shape_Array :=
+              Aggr_Type.P_Shapes
+                (Include_Discriminants => False,
+                 Origin                => Node);
+            Item          : CompletionItem;
+            Idx           : Positive := 1;
+            Nb_Components : Natural := 0;
+            Insert_Text   : LSP_String;
+         begin
+
+            for Shape of Shapes loop
+               declare
+                  Discriminants : constant Discriminant_Values_Array :=
+                    Discriminants_Values (Shape);
+                  Components    : constant Base_Formal_Param_Decl_Array :=
+                    Libadalang.Analysis.Components (Shape);
+               begin
+                  Item.label := Get_Label_For_Shape (Discriminants);
+                  Item.kind :=
+                    (True, LSP.Messages.Snippet);
+                  Item.detail :=
+                    (True,
+                     Compute_Completion_Detail
+                       (Aggr_Type.As_Basic_Decl));
+                  Item.insertTextFormat :=
+                    Optional_InsertTextFormat'
+                      (Is_Set => True,
+                       Value  => Snippet);
+                  Insert_Text := Empty_LSP_String;
+
+                  --  Compute number of components to know if named notation
+                  --  should be used.
+
+                  for Comp of Components loop
+                     Nb_Components := Nb_Components
+                       + As_Component_Decl (Comp).F_Ids.Children_Count;
+                  end loop;
+
+                  Use_Named_Notation := Named_Notation_Threshold > 0
+                    and then (Discriminants'Length + Nb_Components)
+                        >= Named_Notation_Threshold;
+
+                  --  Compute the snippets for the record discriminants, if any
+                  for Disc of Discriminants loop
+                     Insert_Text := Insert_Text
+                       & Get_Snippet_For_Discriminant
+                       (Disc               => Disc,
+                        Idx                => Idx,
+                        Use_Named_Notation => Use_Named_Notation);
+                     Idx := Idx + 1;
+                  end loop;
+
+                  --  Compute the snippets for the record components
+                  for Comp of Components loop
+                     Insert_Text := Insert_Text
+                       & Get_Snippet_For_Component
+                       (Param              => Comp,
+                        Idx                => Idx,
+                        Use_Named_Notation => Use_Named_Notation);
+
+                     Idx := Idx + 1;
+                  end loop;
+
+                  if Idx > 1 then
+                     --  Remove the "}, " substring that has been
+                     --  appended in the last loop iteration.
+                     Insert_Text := Unbounded_Slice
+                       (Insert_Text,
+                        1,
+                        Length (Insert_Text) - 2);
+
+                     --  Insert '$0' (i.e: the final tab stop) at the
+                     --  end.
+                     Insert_Text := Insert_Text & ")$0";
+                     Item.insertText :=
+                       (Is_Set => True,
+                        Value  => Insert_Text);
+                     Result.items.Append (Item);
+                  end if;
+               end;
+            end loop;
+         end;
+      end if;
+   end Get_Aggregate_Completion;
+
    ------------------------
    -- Get_Completions_At --
    ------------------------
 
    procedure Get_Completions_At
-     (Self             : Document;
-      Context          : LSP.Ada_Contexts.Context;
-      Position         : LSP.Messages.Position;
-      Snippets_Enabled : Boolean;
-      Result           : out LSP.Messages.CompletionList)
+     (Self                     : Document;
+      Context                  : LSP.Ada_Contexts.Context;
+      Position                 : LSP.Messages.Position;
+      Snippets_Enabled         : Boolean;
+      Named_Notation_Threshold : Natural;
+      Result                   : out LSP.Messages.CompletionList)
    is
       use Libadalang.Common;
       use LSP.Messages;
@@ -1241,6 +1577,19 @@ package body LSP.Ada_Documents is
       In_End_Label := not Node.Parent.Is_Null
         and then Node.Parent.Kind in Ada_End_Name_Range;
 
+      --  Check if we are dealing with an aggregate node. If yes, handle it
+      --  separately to propose snipppets to the user, allowing him to fill
+      --  all the needed discriminants/components easily.
+
+      if Node.Kind in Ada_Aggregate_Range then
+         Get_Aggregate_Completion
+           (Node                     => As_Aggregate (Node),
+            Context                  => Context,
+            Named_Notation_Threshold => Named_Notation_Threshold,
+            Result                   => Result);
+         return;
+      end if;
+
       declare
          Raw_Completions : constant Completion_Item_Array :=
            Node.P_Complete;
@@ -1272,12 +1621,14 @@ package body LSP.Ada_Documents is
 
                         Result.items.Append
                           (Compute_Completion_Item
-                             (Context          => Context,
-                              BD               => BD,
-                              DN               => DN,
-                              Snippets_Enabled =>
-                                Snippets_Enabled and not In_End_Label,
-                              Is_Dot_Call      => Is_Dot_Call (CI)));
+                             (Context                  => Context,
+                              BD                       => BD,
+                              DN                       => DN,
+                              Snippets_Enabled         => Snippets_Enabled and
+                                not In_End_Label,
+                              Named_Notation_Threshold =>
+                                Named_Notation_Threshold,
+                              Is_Dot_Call              => Is_Dot_Call (CI)));
                      end if;
                   end;
                end loop;

--- a/source/ada/lsp-ada_documents.ads
+++ b/source/ada/lsp-ada_documents.ads
@@ -95,12 +95,18 @@ package LSP.Ada_Documents is
    --  Get Libadalang Node for given position in the document.
 
    procedure Get_Completions_At
-     (Self             : Document;
-      Context          : LSP.Ada_Contexts.Context;
-      Position         : LSP.Messages.Position;
-      Snippets_Enabled : Boolean;
-      Result           : out LSP.Messages.CompletionList);
+     (Self                     : Document;
+      Context                  : LSP.Ada_Contexts.Context;
+      Position                 : LSP.Messages.Position;
+      Snippets_Enabled         : Boolean;
+      Named_Notation_Threshold : Natural;
+      Result                   : out LSP.Messages.CompletionList);
    --  Populate Result with completions for given position in the document.
+   --  When Snippets_Enabled is True, subprogram completion items are computed
+   --  as snippets that list all the subprogram's formal parameters.
+   --  Named_Notation_Threshold defines the number of parameters / components
+   --  at which point named notation is used for subprogram/aggregate
+   --  completion snippets.
 
    procedure Get_Folding_Blocks
      (Self       : Document;

--- a/source/ada/lsp-ada_handlers.adb
+++ b/source/ada/lsp-ada_handlers.adb
@@ -544,10 +544,10 @@ package body LSP.Ada_Handlers is
                LSP.Messages.Full));
       Response.result.capabilities.completionProvider :=
         (True,
-         (resolveProvider   => (True, False),
-          triggerCharacters => (True, Empty_Vector & (+".")),
+         (resolveProvider     => (True, False),
+          triggerCharacters   => (True, Empty_Vector & (+".") & (+"(")),
           allCommitCharacters => (Is_Set => False),
-          workDoneProgress  => (Is_Set => False)));
+          workDoneProgress    => (Is_Set => False)));
       Response.result.capabilities.hoverProvider :=
         (Is_Set => True,
          Value  => (workDoneProgress => (Is_Set => False)));
@@ -2402,6 +2402,7 @@ package body LSP.Ada_Handlers is
       enableDiagnostics      : constant String := "enableDiagnostics";
       enableIndexing         : constant String := "enableIndexing";
       renameInComments       : constant String := "renameInComments";
+      namedNotationThreshold : constant String := "namedNotationThreshold";
 
       Ada       : constant LSP.Types.LSP_Any := Value.settings.Get ("ada");
       File      : LSP.Types.LSP_String;
@@ -2447,6 +2448,14 @@ package body LSP.Ada_Handlers is
          if Ada.Has_Field (renameInComments) then
             Self.Refactoring.Renaming.In_Comments :=
               Ada.Get (renameInComments);
+         end if;
+
+         --  Retrieve the number of parameters / components at which point
+         --  named notation is used for subprogram/aggregate completion
+         --  snippets.
+
+         if Ada.Has_Field (namedNotationThreshold) then
+            Self.Named_Notation_Threshold := Ada.Get (namedNotationThreshold);
          end if;
       end if;
 
@@ -2815,10 +2824,11 @@ package body LSP.Ada_Handlers is
         (Is_Error => False);
    begin
       Document.Get_Completions_At
-        (Context          => Context.all,
-         Position         => Value.position,
-         Snippets_Enabled => Self.Completion_Snippets_Enabled,
-         Result           => Response.result);
+        (Context                  => Context.all,
+         Position                 => Value.position,
+         Snippets_Enabled         => Self.Completion_Snippets_Enabled,
+         Named_Notation_Threshold => Self.Named_Notation_Threshold,
+         Result                   => Response.result);
 
       return Response;
    end On_Completion_Request;

--- a/source/ada/lsp-ada_handlers.ads
+++ b/source/ada/lsp-ada_handlers.ads
@@ -156,6 +156,10 @@ private
       Completion_Snippets_Enabled : Boolean := False;
       --  True if the client supports completion snippets
 
+      Named_Notation_Threshold : Natural := 3;
+      --  Defines the number of parameters/components at which point named
+      --  notation is used for subprogram/aggregate completion snippets.
+
       ----------------------
       -- Project handling --
       ----------------------

--- a/testsuite/ada_lsp/C825-005.xrefs.extending/test.json
+++ b/testsuite/ada_lsp/C825-005.xrefs.extending/test.json
@@ -41,7 +41,8 @@
                      "textDocumentSync": 2,
                      "completionProvider": {
                         "triggerCharacters": [
-                           "."
+                            ".",
+                            "("
                         ],
                         "resolveProvider": false
                      },

--- a/testsuite/ada_lsp/D301-004.xrefs.generics/test.json
+++ b/testsuite/ada_lsp/D301-004.xrefs.generics/test.json
@@ -41,7 +41,8 @@
                      "textDocumentSync": 2,
                      "completionProvider": {
                         "triggerCharacters": [
-                           "."
+                            ".",
+                            "("
                         ],
                         "resolveProvider": false
                      },

--- a/testsuite/ada_lsp/D803-003.xrefs.generics_go_to_body/test.json
+++ b/testsuite/ada_lsp/D803-003.xrefs.generics_go_to_body/test.json
@@ -41,7 +41,8 @@
                      "textDocumentSync": 2,
                      "completionProvider": {
                         "triggerCharacters": [
-                           "."
+                            ".",
+                            "("
                         ],
                         "resolveProvider": false
                      },

--- a/testsuite/ada_lsp/F131-024.xrefs.separate_body/test.json
+++ b/testsuite/ada_lsp/F131-024.xrefs.separate_body/test.json
@@ -47,7 +47,8 @@
                      "textDocumentSync": 2,
                      "completionProvider": {
                         "triggerCharacters": [
-                           "."
+                            ".",
+                            "("
                         ],
                         "resolveProvider": false
                      },

--- a/testsuite/ada_lsp/F222-029.xrefs.prefixed_notation/test.json
+++ b/testsuite/ada_lsp/F222-029.xrefs.prefixed_notation/test.json
@@ -41,7 +41,8 @@
                      "textDocumentSync": 2,
                      "completionProvider": {
                         "triggerCharacters": [
-                           "."
+                            ".",
+                            "("
                         ],
                         "resolveProvider": false
                      },

--- a/testsuite/ada_lsp/G323-009.tooltips.function_prototype/test.json
+++ b/testsuite/ada_lsp/G323-009.tooltips.function_prototype/test.json
@@ -47,7 +47,8 @@
                      "textDocumentSync": 2,
                      "completionProvider": {
                         "triggerCharacters": [
-                           "."
+                            ".",
+                            "("
                         ],
                         "resolveProvider": false
                      },

--- a/testsuite/ada_lsp/JB24-033.xrefs.no_refs_for_non_loaded_projects/test.json
+++ b/testsuite/ada_lsp/JB24-033.xrefs.no_refs_for_non_loaded_projects/test.json
@@ -41,7 +41,8 @@
                      "textDocumentSync": 2,
                      "completionProvider": {
                         "triggerCharacters": [
-                           "."
+                            ".",
+                            "("
                         ],
                         "resolveProvider": false
                      },

--- a/testsuite/ada_lsp/O208-003.xrefs.aggregate_library_projects/test.json
+++ b/testsuite/ada_lsp/O208-003.xrefs.aggregate_library_projects/test.json
@@ -41,7 +41,8 @@
                      "textDocumentSync": 2,
                      "completionProvider": {
                         "triggerCharacters": [
-                           "."
+                            ".",
+                            "("
                         ],
                         "resolveProvider": false
                      },

--- a/testsuite/ada_lsp/P107-003.refactoring.underscores/test.json
+++ b/testsuite/ada_lsp/P107-003.refactoring.underscores/test.json
@@ -41,7 +41,8 @@
                      "textDocumentSync": 2,
                      "completionProvider": {
                         "triggerCharacters": [
-                           "."
+                            ".",
+                            "("
                         ],
                         "resolveProvider": false
                      },

--- a/testsuite/ada_lsp/P429-023.refactoring.rename_clauses/test.json
+++ b/testsuite/ada_lsp/P429-023.refactoring.rename_clauses/test.json
@@ -41,7 +41,8 @@
                      "textDocumentSync": 2,
                      "completionProvider": {
                         "triggerCharacters": [
-                           "."
+                            ".",
+                            "("
                         ],
                         "resolveProvider": false
                      },

--- a/testsuite/ada_lsp/QB01-002.xrefs.non_ascii_documentation/test.json
+++ b/testsuite/ada_lsp/QB01-002.xrefs.non_ascii_documentation/test.json
@@ -41,7 +41,8 @@
                      "textDocumentSync": 2,
                      "completionProvider": {
                         "triggerCharacters": [
-                           "."
+                            ".",
+                            "("
                         ],
                         "resolveProvider": false
                      },

--- a/testsuite/ada_lsp/S820-016.called_by.entry/test.json
+++ b/testsuite/ada_lsp/S820-016.called_by.entry/test.json
@@ -46,7 +46,8 @@
                      "textDocumentSync": 2,
                      "completionProvider": {
                         "triggerCharacters": [
-                           "."
+                            ".",
+                            "("
                         ],
                         "resolveProvider": false
                      },

--- a/testsuite/ada_lsp/SA11-040.definition.fallback/test.json
+++ b/testsuite/ada_lsp/SA11-040.definition.fallback/test.json
@@ -46,7 +46,8 @@
                      "textDocumentSync": 2,
                      "completionProvider": {
                         "triggerCharacters": [
-                           "."
+                            ".",
+                            "("
                         ],
                         "resolveProvider": false
                      },

--- a/testsuite/ada_lsp/SA22-029.rename_in_comments/test.json
+++ b/testsuite/ada_lsp/SA22-029.rename_in_comments/test.json
@@ -46,7 +46,8 @@
                      "textDocumentSync": 2,
                      "completionProvider": {
                         "triggerCharacters": [
-                           "."
+                            ".",
+                            "("
                         ],
                         "resolveProvider": false
                      },

--- a/testsuite/ada_lsp/SA22-032.folding/test.json
+++ b/testsuite/ada_lsp/SA22-032.folding/test.json
@@ -40,7 +40,8 @@
                      "completionProvider": {
                         "resolveProvider": false,
                         "triggerCharacters": [
-                           "."
+                            ".",
+                            "("
                         ]
                      },
                      "hoverProvider": true,

--- a/testsuite/ada_lsp/SA24-055.called_by_on_abstract/test.json
+++ b/testsuite/ada_lsp/SA24-055.called_by_on_abstract/test.json
@@ -46,7 +46,8 @@
                      "textDocumentSync": 2,
                      "completionProvider": {
                         "triggerCharacters": [
-                           "."
+                            ".",
+                            "("
                         ],
                         "resolveProvider": false
                      },

--- a/testsuite/ada_lsp/SB21-042.tooltips.aspects/test.json
+++ b/testsuite/ada_lsp/SB21-042.tooltips.aspects/test.json
@@ -46,7 +46,8 @@
                      "textDocumentSync": 2,
                      "completionProvider": {
                         "triggerCharacters": [
-                           "."
+                            ".",
+                            "("
                         ],
                         "resolveProvider": false
                      },

--- a/testsuite/ada_lsp/SC16-095.fallback_when_no_body/test.json
+++ b/testsuite/ada_lsp/SC16-095.fallback_when_no_body/test.json
@@ -65,7 +65,8 @@
                      "textDocumentSync": 2,
                      "completionProvider": {
                         "triggerCharacters": [
-                           "."
+                            ".",
+                            "("
                         ],
                         "resolveProvider": false
                      },

--- a/testsuite/ada_lsp/T123-048.incremental_editing/test.json
+++ b/testsuite/ada_lsp/T123-048.incremental_editing/test.json
@@ -3,380 +3,381 @@
       "comment": [
          "test incremental text synchronization with a file starting with an LF"
       ]
-   }, 
+   },
    {
       "start": {
          "cmd": [
             "${ALS}"
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "workspaceFolders": [
                   {
-                     "uri": "$URI{.}", 
+                     "uri": "$URI{.}",
                      "name": "T123-048.incremental_editing"
                   }
-               ], 
-               "trace": "off", 
-               "rootUri": "$URI{.}", 
+               ],
+               "trace": "off",
+               "rootUri": "$URI{.}",
                "capabilities": {
                   "textDocument": {
                      "completion": {
                         "completionItem": {
                            "documentationFormat": [
-                              "markdown", 
+                              "markdown",
                               "plaintext"
-                           ], 
-                           "commitCharactersSupport": true, 
-                           "preselectSupport": true, 
-                           "deprecatedSupport": true, 
+                           ],
+                           "commitCharactersSupport": true,
+                           "preselectSupport": true,
+                           "deprecatedSupport": true,
                            "snippetSupport": true
-                        }, 
+                        },
                         "completionItemKind": {
                            "valueSet": [
-                              1, 
-                              2, 
-                              3, 
-                              4, 
-                              5, 
-                              6, 
-                              7, 
-                              8, 
-                              9, 
-                              10, 
-                              11, 
-                              12, 
-                              13, 
-                              14, 
-                              15, 
-                              16, 
-                              17, 
-                              18, 
-                              19, 
-                              20, 
-                              21, 
-                              22, 
-                              23, 
-                              24, 
+                              1,
+                              2,
+                              3,
+                              4,
+                              5,
+                              6,
+                              7,
+                              8,
+                              9,
+                              10,
+                              11,
+                              12,
+                              13,
+                              14,
+                              15,
+                              16,
+                              17,
+                              18,
+                              19,
+                              20,
+                              21,
+                              22,
+                              23,
+                              24,
                               25
                            ]
-                        }, 
-                        "contextSupport": true, 
+                        },
+                        "contextSupport": true,
                         "dynamicRegistration": true
-                     }, 
+                     },
                      "definition": {
-                        "linkSupport": true, 
+                        "linkSupport": true,
                         "dynamicRegistration": true
-                     }, 
+                     },
                      "signatureHelp": {
                         "signatureInformation": {
                            "documentationFormat": [
-                              "markdown", 
+                              "markdown",
                               "plaintext"
-                           ], 
+                           ],
                            "parameterInformation": {
                               "labelOffsetSupport": true
                            }
-                        }, 
+                        },
                         "dynamicRegistration": true
-                     }, 
+                     },
                      "hover": {
                         "contentFormat": [
-                           "markdown", 
+                           "markdown",
                            "plaintext"
-                        ], 
+                        ],
                         "dynamicRegistration": true
-                     }, 
+                     },
                      "declaration": {
-                        "linkSupport": true, 
+                        "linkSupport": true,
                         "dynamicRegistration": true
-                     }, 
+                     },
                      "implementation": {
-                        "linkSupport": true, 
+                        "linkSupport": true,
                         "dynamicRegistration": true
-                     }, 
+                     },
                      "formatting": {
                         "dynamicRegistration": true
-                     }, 
+                     },
                      "typeDefinition": {
-                        "linkSupport": true, 
+                        "linkSupport": true,
                         "dynamicRegistration": true
-                     }, 
+                     },
                      "codeAction": {
                         "codeActionLiteralSupport": {
                            "codeActionKind": {
                               "valueSet": [
-                                 "", 
-                                 "quickfix", 
-                                 "refactor", 
-                                 "refactor.extract", 
-                                 "refactor.inline", 
-                                 "refactor.rewrite", 
-                                 "source", 
+                                 "",
+                                 "quickfix",
+                                 "refactor",
+                                 "refactor.extract",
+                                 "refactor.inline",
+                                 "refactor.rewrite",
+                                 "source",
                                  "source.organizeImports"
                               ]
                            }
-                        }, 
+                        },
                         "dynamicRegistration": true
-                     }, 
+                     },
                      "documentHighlight": {
                         "dynamicRegistration": true
-                     }, 
+                     },
                      "documentSymbol": {
                         "symbolKind": {
                            "valueSet": [
-                              1, 
-                              2, 
-                              3, 
-                              4, 
-                              5, 
-                              6, 
-                              7, 
-                              8, 
-                              9, 
-                              10, 
-                              11, 
-                              12, 
-                              13, 
-                              14, 
-                              15, 
-                              16, 
-                              17, 
-                              18, 
-                              19, 
-                              20, 
-                              21, 
-                              22, 
-                              23, 
-                              24, 
-                              25, 
+                              1,
+                              2,
+                              3,
+                              4,
+                              5,
+                              6,
+                              7,
+                              8,
+                              9,
+                              10,
+                              11,
+                              12,
+                              13,
+                              14,
+                              15,
+                              16,
+                              17,
+                              18,
+                              19,
+                              20,
+                              21,
+                              22,
+                              23,
+                              24,
+                              25,
                               26
                            ]
-                        }, 
-                        "hierarchicalDocumentSymbolSupport": true, 
+                        },
+                        "hierarchicalDocumentSymbolSupport": true,
                         "dynamicRegistration": true
-                     }, 
+                     },
                      "rename": {
-                        "prepareSupport": true, 
+                        "prepareSupport": true,
                         "dynamicRegistration": true
-                     }, 
+                     },
                      "synchronization": {
-                        "didSave": true, 
-                        "willSave": true, 
-                        "willSaveWaitUntil": true, 
+                        "didSave": true,
+                        "willSave": true,
+                        "willSaveWaitUntil": true,
                         "dynamicRegistration": true
-                     }, 
+                     },
                      "references": {
                         "dynamicRegistration": true
-                     }, 
+                     },
                      "rangeFormatting": {
                         "dynamicRegistration": true
-                     }, 
+                     },
                      "onTypeFormatting": {
                         "dynamicRegistration": true
-                     }, 
+                     },
                      "codeLens": {
                         "dynamicRegistration": true
-                     }, 
+                     },
                      "publishDiagnostics": {
                         "relatedInformation": true
-                     }, 
+                     },
                      "documentLink": {
                         "dynamicRegistration": true
-                     }, 
+                     },
                      "foldingRange": {
-                        "lineFoldingOnly": true, 
-                        "rangeLimit": 5000, 
+                        "lineFoldingOnly": true,
+                        "rangeLimit": 5000,
                         "dynamicRegistration": true
-                     }, 
+                     },
                      "colorProvider": {
                         "dynamicRegistration": true
                      }
-                  }, 
+                  },
                   "workspace": {
-                     "workspaceFolders": true, 
+                     "workspaceFolders": true,
                      "executeCommand": {
                         "dynamicRegistration": true
-                     }, 
+                     },
                      "didChangeWatchedFiles": {
                         "dynamicRegistration": true
-                     }, 
+                     },
                      "didChangeConfiguration": {
                         "dynamicRegistration": true
-                     }, 
-                     "applyEdit": true, 
-                     "configuration": true, 
+                     },
+                     "applyEdit": true,
+                     "configuration": true,
                      "symbol": {
                         "symbolKind": {
                            "valueSet": [
-                              1, 
-                              2, 
-                              3, 
-                              4, 
-                              5, 
-                              6, 
-                              7, 
-                              8, 
-                              9, 
-                              10, 
-                              11, 
-                              12, 
-                              13, 
-                              14, 
-                              15, 
-                              16, 
-                              17, 
-                              18, 
-                              19, 
-                              20, 
-                              21, 
-                              22, 
-                              23, 
-                              24, 
-                              25, 
+                              1,
+                              2,
+                              3,
+                              4,
+                              5,
+                              6,
+                              7,
+                              8,
+                              9,
+                              10,
+                              11,
+                              12,
+                              13,
+                              14,
+                              15,
+                              16,
+                              17,
+                              18,
+                              19,
+                              20,
+                              21,
+                              22,
+                              23,
+                              24,
+                              25,
                               26
                            ]
-                        }, 
+                        },
                         "dynamicRegistration": true
-                     }, 
+                     },
                      "workspaceEdit": {
-                        "failureHandling": "textOnlyTransactional", 
+                        "failureHandling": "textOnlyTransactional",
                         "resourceOperations": [
-                           "create", 
-                           "rename", 
+                           "create",
+                           "rename",
                            "delete"
-                        ], 
+                        ],
                         "documentChanges": true
                      }
                   }
                }
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 0, 
+            },
+            "jsonrpc": "2.0",
+            "id": 0,
             "method": "initialize"
-         }, 
+         },
          "wait": [
             {
-               "id": 0, 
+               "id": 0,
                "result": {
                   "capabilities": {
-                     "typeDefinitionProvider": true, 
+                     "typeDefinitionProvider": true,
                      "alsReferenceKinds": [
-                        "reference", 
-                        "write", 
-                        "call", 
-                        "dispatching call", 
-                        "parent", 
+                        "reference",
+                        "write",
+                        "call",
+                        "dispatching call",
+                        "parent",
                         "child"
-                     ], 
-                     "hoverProvider": true, 
-                     "definitionProvider": true, 
-                     "renameProvider": {}, 
-                     "alsCalledByProvider": true, 
-                     "referencesProvider": true, 
-                     "textDocumentSync": 2, 
-                     "declarationProvider": true, 
+                     ],
+                     "hoverProvider": true,
+                     "definitionProvider": true,
+                     "renameProvider": {},
+                     "alsCalledByProvider": true,
+                     "referencesProvider": true,
+                     "textDocumentSync": 2,
+                     "declarationProvider": true,
                      "completionProvider": {
                         "triggerCharacters": [
-                           "."
-                        ], 
+                            ".",
+                            "("
+                        ],
                         "resolveProvider": false
-                     }, 
+                     },
                      "documentSymbolProvider": true
                   }
                }
             }
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
-            "params": {}, 
-            "jsonrpc": "2.0", 
+            "params": {},
+            "jsonrpc": "2.0",
             "method": "initialized"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "settings": {
                   "ada": {
-                     "renameInComments": false, 
+                     "renameInComments": false,
                      "trace": {
                         "server": "off"
-                     }, 
-                     "projectFile": "", 
-                     "enableDiagnostics": true, 
-                     "scenarioVariables": {}, 
+                     },
+                     "projectFile": "",
+                     "enableDiagnostics": true,
+                     "scenarioVariables": {},
                      "defaultCharset": "iso-8859-1"
                   }
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "workspace/didChangeConfiguration"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {"comment": "--------------------------- open a file -------------------------"},
    {
       "send": {
          "request": {
             "params": {
                "textDocument": {
-                  "text": "\nprocedure Main is\n   procedure C_Function\n   with Convention => C,\n        Import     => True,\n        Link_Name  => \"c_function\";\n\nbegin\n   C_Function;\nend Main;\n", 
-                  "version": 1, 
-                  "uri": "$URI{main.adb}", 
+                  "text": "\nprocedure Main is\n   procedure C_Function\n   with Convention => C,\n        Import     => True,\n        Link_Name  => \"c_function\";\n\nbegin\n   C_Function;\nend Main;\n",
+                  "version": 1,
+                  "uri": "$URI{main.adb}",
                   "languageId": "ada"
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "textDocument/didOpen"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {"comment": "--------------------------- query a tooltip to verify -------------------------"},
    {
       "send": {
          "request": {
             "params": {
                "position": {
-                  "line": 2, 
+                  "line": 2,
                   "character": 17
-               }, 
+               },
                "textDocument": {
                   "uri": "$URI{main.adb}"
                }
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 2, 
+            },
+            "jsonrpc": "2.0",
+            "id": 2,
             "method": "textDocument/hover"
-         }, 
+         },
          "wait": [
             {
-               "id": 2, 
+               "id": 2,
                "result": {
                   "contents": [
                      {
-                        "value": "procedure C_Function\nwith\n  Convention => C,\n  Import     => True,\n  Link_Name  => \"c_function\"", 
+                        "value": "procedure C_Function\nwith\n  Convention => C,\n  Import     => True,\n  Link_Name  => \"c_function\"",
                         "language": "ada"
-                     }, 
+                     },
                      "at main.adb (3:4)"
                   ]
                }
             }
          ]
       }
-   }, 
+   },
    {"comment": "--------------------------- insert a space in the middle of a function name -------------------------"},
    {
       "send": {
@@ -384,80 +385,80 @@
             "params": {
                "contentChanges": [
                   {
-                     "text": " ", 
+                     "text": " ",
                      "range": {
                         "start": {
-                           "line": 2, 
+                           "line": 2,
                            "character": 15
-                        }, 
+                        },
                         "end": {
-                           "line": 2, 
+                           "line": 2,
                            "character": 15
                         }
-                     }, 
+                     },
                      "rangeLength": 0
                   }
-               ], 
+               ],
                "textDocument": {
-                  "version": 2, 
+                  "version": 2,
                   "uri": "$URI{main.adb}"
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "textDocument/didChange"
-         }, 
+         },
          "wait": [
             {
                "params": {
-                  "uri": "$URI{main.adb}", 
+                  "uri": "$URI{main.adb}",
                   "diagnostics": [
                      {
                         "range": {
                            "start": {
-                              "line": 2, 
+                              "line": 2,
                               "character": 16
-                           }, 
+                           },
                            "end": {
-                              "line": 2, 
+                              "line": 2,
                               "character": 24
                            }
-                        }, 
+                        },
                         "message": "Missing ';'"
                      }
                   ]
-               }, 
+               },
                "method": "textDocument/publishDiagnostics"
             }
          ]
       }
-   }, 
+   },
    {"comment": "--------------------------- hover should be empty -------------------------"},
    {
       "send": {
          "request": {
             "params": {
                "position": {
-                  "line": 2, 
+                  "line": 2,
                   "character": 21
-               }, 
+               },
                "textDocument": {
                   "uri": "$URI{main.adb}"
                }
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 6, 
+            },
+            "jsonrpc": "2.0",
+            "id": 6,
             "method": "textDocument/hover"
-         }, 
+         },
          "wait": [
             {
-               "id": 6, 
+               "id": 6,
                "result": {
                   "contents": []
                }
             }
          ]
       }
-   }, 
+   },
    {"comment": "--------------------------- undo the change -------------------------"},
    {
       "send": {
@@ -465,98 +466,98 @@
             "params": {
                "contentChanges": [
                   {
-                     "text": "", 
+                     "text": "",
                      "range": {
                         "start": {
-                           "line": 2, 
+                           "line": 2,
                            "character": 15
-                        }, 
+                        },
                         "end": {
-                           "line": 2, 
+                           "line": 2,
                            "character": 16
                         }
-                     }, 
+                     },
                      "rangeLength": 1
                   }
-               ], 
+               ],
                "textDocument": {
-                  "version": 3, 
+                  "version": 3,
                   "uri": "$URI{main.adb}"
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "textDocument/didChange"
-         }, 
+         },
          "wait": [
             {
                "params": {
-                  "uri": "$URI{main.adb}", 
+                  "uri": "$URI{main.adb}",
                   "diagnostics": []
-               }, 
+               },
                "method": "textDocument/publishDiagnostics"
             }
          ]
       }
-   }, 
+   },
    {"comment": "--------------------------- verify that the hover is good again -------------------------"},
    {
       "send": {
          "request": {
             "params": {
                "position": {
-                  "line": 2, 
+                  "line": 2,
                   "character": 18
-               }, 
+               },
                "textDocument": {
                   "uri": "$URI{main.adb}"
                }
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 8, 
+            },
+            "jsonrpc": "2.0",
+            "id": 8,
             "method": "textDocument/hover"
-         }, 
+         },
          "wait": [
             {
-               "id": 8, 
+               "id": 8,
                "result": {
                   "contents": [
                      {
-                        "value": "procedure C_Function\nwith\n  Convention => C,\n  Import     => True,\n  Link_Name  => \"c_function\"", 
+                        "value": "procedure C_Function\nwith\n  Convention => C,\n  Import     => True,\n  Link_Name  => \"c_function\"",
                         "language": "ada"
-                     }, 
+                     },
                      "at main.adb (3:4)"
                   ]
                }
             }
          ]
       }
-   },  
+   },
    {
       "send": {
          "request": {
-            "params": null, 
-            "jsonrpc": "2.0", 
-            "id": 10, 
+            "params": null,
+            "jsonrpc": "2.0",
+            "id": 10,
             "method": "shutdown"
-         }, 
+         },
          "wait": [
             {
-               "id": 10, 
+               "id": 10,
                "result": null
             }
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
-            "params": null, 
-            "jsonrpc": "2.0", 
+            "params": null,
+            "jsonrpc": "2.0",
             "method": "exit"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "stop": {
          "exit_code": 0

--- a/testsuite/ada_lsp/aggregate.is_called_by/test.json
+++ b/testsuite/ada_lsp/aggregate.is_called_by/test.json
@@ -46,7 +46,8 @@
                      "textDocumentSync": 2,
                      "completionProvider": {
                         "triggerCharacters": [
-                           "."
+                            ".",
+                            "("
                         ],
                         "resolveProvider": false
                      },
@@ -89,15 +90,15 @@
          "request": {
             "params": {
                "textDocument": {
-                  "text": "package body Common_Pack is\n\n   ---------\n   -- Foo --\n   ---------\n\n   procedure Foo is\n   begin\n      Bar;\n   end Foo;\n\n   ---------\n   -- Bar --\n   ---------\n\n   procedure Bar is\n   begin\n      null;\n   end Bar;\n\nend Common_Pack;\n", 
-                  "version": 0, 
-                  "uri": "$URI{common/common_pack.adb}", 
+                  "text": "package body Common_Pack is\n\n   ---------\n   -- Foo --\n   ---------\n\n   procedure Foo is\n   begin\n      Bar;\n   end Foo;\n\n   ---------\n   -- Bar --\n   ---------\n\n   procedure Bar is\n   begin\n      null;\n   end Bar;\n\nend Common_Pack;\n",
+                  "version": 0,
+                  "uri": "$URI{common/common_pack.adb}",
                   "languageId": "Ada"
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "textDocument/didOpen"
-         }, 
+         },
          "wait": []
       }
    },
@@ -106,153 +107,153 @@
          "request": {
             "params": {
                "position": {
-                  "line": 8, 
+                  "line": 8,
                   "character": 6
-               }, 
+               },
                "textDocument": {
                   "uri": "$URI{common/common_pack.adb}"
                }
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 3, 
+            },
+            "jsonrpc": "2.0",
+            "id": 3,
             "method": "textDocument/alsCalledBy"
-         }, 
+         },
          "wait": [
             {
-               "id": 3, 
+               "id": 3,
                "result": [
                   {
                      "refs": [
                         {
                            "range": {
                               "start": {
-                                 "line": 8, 
+                                 "line": 8,
                                  "character": 6
-                              }, 
+                              },
                               "end": {
-                                 "line": 8, 
+                                 "line": 8,
                                  "character": 9
                               }
-                           }, 
+                           },
                            "alsKind": [
                               "call"
-                           ], 
+                           ],
                            "uri": "$URI{common/common_pack.adb}"
                         }
-                     ], 
+                     ],
                      "location": {
                         "range": {
                            "start": {
-                              "line": 1, 
+                              "line": 1,
                               "character": 13
-                           }, 
+                           },
                            "end": {
-                              "line": 1, 
+                              "line": 1,
                               "character": 16
                            }
-                        }, 
+                        },
                         "uri": "$URI{common/common_pack.ads}"
-                     }, 
+                     },
                      "name": "Foo"
                   }
                ]
             }
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "position": {
-                  "line": 1, 
+                  "line": 1,
                   "character": 13
-               }, 
+               },
                "textDocument": {
                   "uri": "$URI{common/common_pack.ads}"
                }
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 4, 
+            },
+            "jsonrpc": "2.0",
+            "id": 4,
             "method": "textDocument/alsCalledBy"
-         }, 
+         },
          "wait": [
             {
-               "id": 4, 
+               "id": 4,
                "result": [
                   {
                      "refs": [
                         {
                            "range": {
                               "start": {
-                                 "line": 3, 
+                                 "line": 3,
                                  "character": 3
-                              }, 
+                              },
                               "end": {
-                                 "line": 3, 
+                                 "line": 3,
                                  "character": 6
                               }
-                           }, 
+                           },
                            "alsKind": [
                               "call"
-                           ], 
+                           ],
                            "uri": "$URI{p/main.adb}"
                         }
-                     ], 
+                     ],
                      "location": {
                         "range": {
                            "start": {
-                              "line": 1, 
+                              "line": 1,
                               "character": 10
-                           }, 
+                           },
                            "end": {
-                              "line": 1, 
+                              "line": 1,
                               "character": 14
                            }
-                        }, 
+                        },
                         "uri": "$URI{p/main.adb}"
-                     }, 
+                     },
                      "name": "Main"
-                  }, 
+                  },
                   {
                      "refs": [
                         {
                            "range": {
                               "start": {
-                                 "line": 3, 
+                                 "line": 3,
                                  "character": 3
-                              }, 
+                              },
                               "end": {
-                                 "line": 3, 
+                                 "line": 3,
                                  "character": 6
                               }
-                           }, 
+                           },
                            "alsKind": [
                               "call"
-                           ], 
+                           ],
                            "uri": "$URI{q/main.adb}"
                         }
-                     ], 
+                     ],
                      "location": {
                         "range": {
                            "start": {
-                              "line": 1, 
+                              "line": 1,
                               "character": 10
-                           }, 
+                           },
                            "end": {
-                              "line": 1, 
+                              "line": 1,
                               "character": 14
                            }
-                        }, 
+                        },
                         "uri": "$URI{q/main.adb}"
-                     }, 
+                     },
                      "name": "Main"
                   }
                ]
             }
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
@@ -260,28 +261,28 @@
                "textDocument": {
                   "uri": "$URI{common/common_pack.adb}"
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "textDocument/didClose"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
-            "jsonrpc": "2.0", 
-            "id": 5, 
+            "jsonrpc": "2.0",
+            "id": 5,
             "method": "shutdown"
-         }, 
+         },
          "wait": [
             {
-               "id": 5, 
+               "id": 5,
                "result": null
             }
          ]
       }
-   }, 
+   },
    {
       "stop": {
          "exit_code": 0

--- a/testsuite/ada_lsp/aggregate.references_after_update/test.json
+++ b/testsuite/ada_lsp/aggregate.references_after_update/test.json
@@ -65,7 +65,8 @@
                      "textDocumentSync": 2,
                      "completionProvider": {
                         "triggerCharacters": [
-                           "."
+                            ".",
+                            "("
                         ],
                         "resolveProvider": false
                      },

--- a/testsuite/ada_lsp/aggregate.simple/test.json
+++ b/testsuite/ada_lsp/aggregate.simple/test.json
@@ -46,7 +46,8 @@
                      "textDocumentSync": 2,
                      "completionProvider": {
                         "triggerCharacters": [
-                           "."
+                            ".",
+                            "("
                         ],
                         "resolveProvider": false
                      },

--- a/testsuite/ada_lsp/called_by.null_subp/called_by.null_subp.json
+++ b/testsuite/ada_lsp/called_by.null_subp/called_by.null_subp.json
@@ -3,154 +3,155 @@
       "comment": [
          "test automatically generated"
       ]
-   }, 
+   },
    {
       "start": {
          "cmd": [
             "${ALS}"
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
-               "processId": 91710, 
-               "rootPath": ".", 
+               "processId": 91710,
+               "rootPath": ".",
                "capabilities": {
                   "workspace": {
                      "applyEdit": false
                   }
-               }, 
+               },
                "rootUri": "$URI{.}"
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 1, 
+            },
+            "jsonrpc": "2.0",
+            "id": 1,
             "method": "initialize"
-         }, 
+         },
          "wait": [
             {
-               "id": 1, 
+               "id": 1,
                "result": {
                   "capabilities": {
-                     "typeDefinitionProvider": true, 
-                     "hoverProvider": true, 
-                     "definitionProvider": true, 
-                     "renameProvider": {}, 
-                     "alsCalledByProvider": true, 
-                     "referencesProvider": true, 
-                     "textDocumentSync": 2, 
+                     "typeDefinitionProvider": true,
+                     "hoverProvider": true,
+                     "definitionProvider": true,
+                     "renameProvider": {},
+                     "alsCalledByProvider": true,
+                     "referencesProvider": true,
+                     "textDocumentSync": 2,
                      "completionProvider": {
                         "triggerCharacters": [
-                           "."
-                        ], 
+                            ".",
+                            "("
+                        ],
                         "resolveProvider": false
-                     }, 
+                     },
                      "documentSymbolProvider": true
                   }
                }
             }]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
-            "jsonrpc": "2.0", 
+            "jsonrpc": "2.0",
             "method": "initialized"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "settings": {
                   "ada": {
-                     "projectFile": "p.gpr", 
-                     "scenarioVariables": {}, 
-                     "enableDiagnostics": false, 
+                     "projectFile": "p.gpr",
+                     "scenarioVariables": {},
+                     "enableDiagnostics": false,
                      "defaultCharset": "UTF-8"
                   }
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "workspace/didChangeConfiguration"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "textDocument": {
-                  "text": "package Pack is\n   procedure Foo is null;\nend Pack;\n", 
-                  "version": 0, 
-                  "uri": "$URI{pack.ads}", 
+                  "text": "package Pack is\n   procedure Foo is null;\nend Pack;\n",
+                  "version": 0,
+                  "uri": "$URI{pack.ads}",
                   "languageId": "Ada"
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "textDocument/didOpen"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "position": {
-                  "line": 1, 
+                  "line": 1,
                   "character": 13
-               }, 
+               },
                "textDocument": {
                   "uri": "$URI{pack.ads}"
                }
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 2, 
+            },
+            "jsonrpc": "2.0",
+            "id": 2,
             "method": "textDocument/alsCalledBy"
-         }, 
+         },
          "wait": [ {
-               "id": 2, 
+               "id": 2,
                "result": [
                   {
                      "refs": [
                         {
                            "range": {
                               "start": {
-                                 "line": 3, 
+                                 "line": 3,
                                  "character": 8
-                              }, 
+                              },
                               "end": {
-                                 "line": 3, 
+                                 "line": 3,
                                  "character": 11
                               }
-                           }, 
+                           },
                            "uri": "$URI{main.adb}"
                         }
-                     ], 
+                     ],
                      "location": {
                         "range": {
                            "start": {
-                              "line": 1, 
+                              "line": 1,
                               "character": 10
-                           }, 
+                           },
                            "end": {
-                              "line": 1, 
+                              "line": 1,
                               "character": 14
                            }
-                        }, 
+                        },
                         "uri": "$URI{main.adb}"
-                     }, 
+                     },
                      "name": "Main"
                   }
                ]
             }]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
@@ -158,28 +159,28 @@
                "textDocument": {
                   "uri": "$URI{pack.ads}"
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "textDocument/didClose"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
-            "jsonrpc": "2.0", 
-            "id": 3, 
+            "jsonrpc": "2.0",
+            "id": 3,
             "method": "shutdown"
-         }, 
-         "wait": [           
+         },
+         "wait": [
             {
-               "id": 3, 
+               "id": 3,
                "result": null
             }
          ]
       }
-   }, 
+   },
    {
       "stop": {
          "exit_code": 0

--- a/testsuite/ada_lsp/called_by/called_by.json
+++ b/testsuite/ada_lsp/called_by/called_by.json
@@ -3,121 +3,122 @@
       "comment": [
          "test automatically generated"
       ]
-   }, 
+   },
    {
       "start": {
          "cmd": [
             "${ALS}"
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
-               "processId": 13950, 
+               "processId": 13950,
                "capabilities": {
                   "workspace": {
                      "applyEdit": false
                   }
-               }, 
+               },
                "rootUri": "$URI{.}"
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 1, 
+            },
+            "jsonrpc": "2.0",
+            "id": 1,
             "method": "initialize"
-         }, 
+         },
          "wait": [{
-               "id": 1, 
+               "id": 1,
                "result": {
                   "capabilities": {
-                     "hoverProvider": true, 
-                     "documentSymbolProvider": true, 
-                     "referencesProvider": true, 
-                     "textDocumentSync": 2, 
+                     "hoverProvider": true,
+                     "documentSymbolProvider": true,
+                     "referencesProvider": true,
+                     "textDocumentSync": 2,
                      "completionProvider": {
                         "triggerCharacters": [
-                           "."
-                        ], 
+                            ".",
+                            "("
+                        ],
                         "resolveProvider": false
-                     }, 
+                     },
                      "definitionProvider": true,
                      "alsCalledByProvider": true
                   }
                }
             }]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
-            "jsonrpc": "2.0", 
+            "jsonrpc": "2.0",
             "method": "initialized"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "settings": {
                   "ada": {
-                     "projectFile": "p.gpr", 
-                     "scenarioVariables": {}, 
+                     "projectFile": "p.gpr",
+                     "scenarioVariables": {},
                      "defaultCharset": "ISO-8859-1"
                   }
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "workspace/didChangeConfiguration"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "textDocument": {
-                  "text": "with P; use P;\nprocedure Main is\n   function Exprfinmain return Boolean is (Foo = 43);\nbegin\n   if Foo > 10 then\n      raise Constraint_Error;\n   end if;\n\n   declare\n      package Bla is\n         X : Integer := Foo;\n      end Bla;\n\n      package body Bla is\n         Y : Integer := Foo + 2;\n      begin\n         X := Foo + 3;\n      end Bla;\n   begin\n      null;\n   end;\nend Main;\n", 
-                  "version": 0, 
-                  "uri": "$URI{main.adb}", 
+                  "text": "with P; use P;\nprocedure Main is\n   function Exprfinmain return Boolean is (Foo = 43);\nbegin\n   if Foo > 10 then\n      raise Constraint_Error;\n   end if;\n\n   declare\n      package Bla is\n         X : Integer := Foo;\n      end Bla;\n\n      package body Bla is\n         Y : Integer := Foo + 2;\n      begin\n         X := Foo + 3;\n      end Bla;\n   begin\n      null;\n   end;\nend Main;\n",
+                  "version": 0,
+                  "uri": "$URI{main.adb}",
                   "languageId": "Ada"
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "textDocument/didOpen"
-         }, 
+         },
          "wait": [
             {
                "params": {
-                  "uri": "$URI{main.adb}", 
+                  "uri": "$URI{main.adb}",
                   "diagnostics": []
-               }, 
+               },
                "method": "textDocument/publishDiagnostics"
             }]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "position": {
-                  "line": 2, 
+                  "line": 2,
                   "character": 45
-               }, 
+               },
                "textDocument": {
                   "uri": "$URI{main.adb}"
-               }, 
+               },
                "context": {
                   "includeDeclaration": true
                }
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 2, 
+            },
+            "jsonrpc": "2.0",
+            "id": 2,
             "method": "textDocument/alsCalledBy"
-         }, 
+         },
 
          "wait": [{"jsonrpc":"2.0","id":2,
                    "result":[
@@ -148,7 +149,7 @@
                            "name":"T",
                            "refs":[{"uri":"$URI{p.adb}","range":{"start":{"line":10,"character":11},"end":{"line":10,"character":14}}}]}]}]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
@@ -156,22 +157,22 @@
                "textDocument": {
                   "uri": "$URI{main.adb}"
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "textDocument/didClose"
-         }, 
+         },
          "wait": [
             {
-            "jsonrpc": "2.0", 
+            "jsonrpc": "2.0",
                "params": {
-                  "uri": "$URI{main.adb}", 
+                  "uri": "$URI{main.adb}",
                   "diagnostics": []
-               }, 
+               },
                "method": "textDocument/publishDiagnostics"
             }
          ]
       }
-   }, 
+   },
    {
       "stop": {
          "exit_code": 0

--- a/testsuite/ada_lsp/called_by_dispatching/test.json
+++ b/testsuite/ada_lsp/called_by_dispatching/test.json
@@ -47,7 +47,8 @@
                      "textDocumentSync": 2,
                      "completionProvider": {
                         "triggerCharacters": [
-                           "."
+                            ".",
+                            "("
                         ],
                         "resolveProvider": false
                      },

--- a/testsuite/ada_lsp/called_by_not_open/called_by_not_open.json
+++ b/testsuite/ada_lsp/called_by_not_open/called_by_not_open.json
@@ -3,97 +3,98 @@
       "comment": [
          "test automatically generated"
       ]
-   }, 
+   },
    {
       "start": {
          "cmd": [
             "${ALS}"
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
-               "processId": 13950, 
+               "processId": 13950,
                "capabilities": {
                   "workspace": {
                      "applyEdit": false
                   }
-               }, 
+               },
                "rootUri": "$URI{.}"
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 1, 
+            },
+            "jsonrpc": "2.0",
+            "id": 1,
             "method": "initialize"
-         }, 
+         },
          "wait": [{
-               "id": 1, 
+               "id": 1,
                "result": {
                   "capabilities": {
-                     "hoverProvider": true, 
-                     "documentSymbolProvider": true, 
-                     "referencesProvider": true, 
-                     "textDocumentSync": 2, 
+                     "hoverProvider": true,
+                     "documentSymbolProvider": true,
+                     "referencesProvider": true,
+                     "textDocumentSync": 2,
                      "completionProvider": {
                         "triggerCharacters": [
-                           "."
-                        ], 
+                            ".",
+                            "("
+                        ],
                         "resolveProvider": false
-                     }, 
+                     },
                      "definitionProvider": true,
                      "alsCalledByProvider": true
                   }
                }
             }]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
-            "jsonrpc": "2.0", 
+            "jsonrpc": "2.0",
             "method": "initialized"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "settings": {
                   "ada": {
-                     "projectFile": "p.gpr", 
-                     "scenarioVariables": {}, 
+                     "projectFile": "p.gpr",
+                     "scenarioVariables": {},
                      "defaultCharset": "ISO-8859-1"
                   }
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "workspace/didChangeConfiguration"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "position": {
-                  "line": 2, 
+                  "line": 2,
                   "character": 45
-               }, 
+               },
                "textDocument": {
                   "uri": "$URI{main.adb}"
-               }, 
+               },
                "context": {
                   "includeDeclaration": true
                }
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 2, 
+            },
+            "jsonrpc": "2.0",
+            "id": 2,
             "method": "textDocument/alsCalledBy"
-         }, 
+         },
 
          "wait": [{"jsonrpc":"2.0","id":2,
                    "result":[

--- a/testsuite/ada_lsp/callgraph.named_blocks/test.json
+++ b/testsuite/ada_lsp/callgraph.named_blocks/test.json
@@ -41,7 +41,8 @@
                      "textDocumentSync": 2,
                      "completionProvider": {
                         "triggerCharacters": [
-                           "."
+                            ".",
+                            "("
                         ],
                         "resolveProvider": false
                      },

--- a/testsuite/ada_lsp/completion.aggregates.derived_types/default.gpr
+++ b/testsuite/ada_lsp/completion.aggregates.derived_types/default.gpr
@@ -1,0 +1,10 @@
+project Default is
+
+   package Compiler is
+      for Switches ("Ada") use ("-g", "-O2");
+   end Compiler;
+
+   for Main use ("main.adb") & project'Main;
+
+end Default;
+

--- a/testsuite/ada_lsp/completion.aggregates.derived_types/main.adb
+++ b/testsuite/ada_lsp/completion.aggregates.derived_types/main.adb
@@ -1,0 +1,21 @@
+procedure Main is
+
+   type Base_Rec (Disc : Integer) is tagged record
+      case Disc is
+         when 1 =>
+            A : Integer;
+         when 2 =>
+            Z : Integer;
+         when others =>
+            B : Integer;
+      end case;
+   end record;
+
+   type Derived_Rec is new Base_Rec with record
+      D : Integer;
+   end record;
+
+   Obj : Derived_Rec :=
+begin
+   null;
+end Main;

--- a/testsuite/ada_lsp/completion.aggregates.derived_types/test.json
+++ b/testsuite/ada_lsp/completion.aggregates.derived_types/test.json
@@ -1,0 +1,286 @@
+[
+   {
+      "comment": [
+          "This test checks that aggregate completion works fine with derived ",
+          "types"
+      ]
+   },
+   {
+      "start": {
+         "cmd": [
+            "${ALS}"
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "processId": 30170,
+               "capabilities": {
+                  "textDocument": {
+                     "completion": {
+                        "completionItem": {
+                           "documentationFormat": [
+                              "plaintext",
+                              "markdown"
+                           ],
+                           "snippetSupport": true
+                        },
+                        "dynamicRegistration": true
+                     },
+                     "definition": {},
+                     "hover": {},
+                     "formatting": {
+                        "dynamicRegistration": true
+                     },
+                     "implementation": {},
+                     "codeLens": {},
+                     "typeDefinition": {},
+                     "selectionRange": {},
+                     "documentHighlight": {},
+                     "documentSymbol": {
+                        "hierarchicalDocumentSymbolSupport": true
+                     },
+                     "synchronization": {},
+                     "references": {},
+                     "rangeFormatting": {},
+                     "onTypeFormatting": {},
+                     "declaration": {},
+                     "foldingRange": {
+                        "lineFoldingOnly": true
+                     },
+                     "colorProvider": {}
+                  },
+                  "workspace": {
+                     "applyEdit": true,
+                     "executeCommand": {},
+                     "didChangeWatchedFiles": {},
+                     "workspaceEdit": {},
+                     "didChangeConfiguration": {}
+                  }
+               },
+               "rootUri": "$URI{.}"
+            },
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize"
+         },
+          "wait": [
+              {
+                  "jsonrpc": "2.0",
+                  "id": 1,
+                  "result": {
+                      "capabilities": {
+                          "textDocumentSync": 2,
+                          "completionProvider": {
+                              "triggerCharacters": [
+                                  ".",
+                                  "("
+                              ],
+                              "resolveProvider": false
+                          },
+                          "hoverProvider": true,
+                          "declarationProvider": true,
+                          "definitionProvider": true,
+                          "typeDefinitionProvider": true,
+                          "implementationProvider": true,
+                          "referencesProvider": true,
+                          "documentSymbolProvider": true,
+                          "codeActionProvider": {
+                          },
+                          "renameProvider": {
+                          },
+                          "foldingRangeProvider": true,
+                          "executeCommandProvider": {
+                              "commands": [
+                                  "als-named-parameters"
+                              ]
+                          },
+                          "alsCalledByProvider": true,
+                          "alsReferenceKinds": [
+                              "reference",
+                              "write",
+                              "call",
+                              "dispatching call",
+                              "parent",
+                              "child"
+                          ]
+                      }
+                  }
+              }
+          ]
+
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "initialized"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "settings": {
+                  "ada": {
+                     "scenarioVariables": {},
+                     "enableDiagnostics": false,
+                     "defaultCharset": "ISO-8859-1"
+                  }
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "workspace/didChangeConfiguration"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "text": "procedure Main is\n\n   type Base_Rec (Disc : Integer) is tagged record\n      case Disc is\n         when 1 =>\n            A : Integer;\n         when 2 =>\n            Z : Integer;\n         when others =>\n            B : Integer;\n      end case;\n   end record;\n\n   type Derived_Rec is new Base_Rec with record\n      D : Integer;\n   end record;\n\n   Obj : Derived_Rec :=\nbegin\n   null;\nend Main;\n",
+                  "version": 0,
+                  "uri": "$URI{main.adb}",
+                  "languageId": "Ada"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "contentChanges": [
+                  {
+                     "text": "procedure Main is\n\n   type Base_Rec (Disc : Integer) is tagged record\n      case Disc is\n         when 1 =>\n            A : Integer;\n         when 2 =>\n            Z : Integer;\n         when others =>\n            B : Integer;\n      end case;\n   end record;\n\n   type Derived_Rec is new Base_Rec with record\n      D : Integer;\n   end record;\n\n   Obj : Derived_Rec := \nbegin\n   null;\nend Main;\n"
+                  }
+               ],
+               "textDocument": {
+                  "version": 1,
+                  "uri": "$URI{main.adb}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "contentChanges": [
+                  {
+                     "text": "procedure Main is\n\n   type Base_Rec (Disc : Integer) is tagged record\n      case Disc is\n         when 1 =>\n            A : Integer;\n         when 2 =>\n            Z : Integer;\n         when others =>\n            B : Integer;\n      end case;\n   end record;\n\n   type Derived_Rec is new Base_Rec with record\n      D : Integer;\n   end record;\n\n   Obj : Derived_Rec := (\nbegin\n   null;\nend Main;\n"
+                  }
+               ],
+               "textDocument": {
+                  "version": 2,
+                  "uri": "$URI{main.adb}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "position": {
+                  "line": 17,
+                  "character": 25
+               },
+               "textDocument": {
+                  "uri": "$URI{main.adb}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "id": 5,
+            "method": "textDocument/completion"
+         },
+         "wait": [
+            {
+               "id": 5,
+               "result": {
+                  "isIncomplete": false,
+                  "items": [
+                     {
+                        "insertText": "Disc => 1, A => ${2:A : Integer}, D => ${3:D : Integer})$0",
+                        "kind": 15,
+                        "detail": "type Derived_Rec is new Base_Rec with record\n   D : Integer;\nend record;",
+                        "label": "Aggregate when Disc => 1",
+                        "additionalTextEdits": [],
+                        "insertTextFormat": 2
+                     },
+                     {
+                        "insertText": "Disc => 2, Z => ${5:Z : Integer}, D => ${6:D : Integer})$0",
+                        "kind": 15,
+                        "detail": "type Derived_Rec is new Base_Rec with record\n   D : Integer;\nend record;",
+                        "label": "Aggregate when Disc => 2",
+                        "additionalTextEdits": [],
+                        "insertTextFormat": 2
+                     },
+                     {
+                        "insertText": "Disc => ${7:others}, B => ${8:B : Integer}, D => ${9:D : Integer})$0",
+                        "kind": 15,
+                        "detail": "type Derived_Rec is new Base_Rec with record\n   D : Integer;\nend record;",
+                        "label": "Aggregate when Disc => others",
+                        "additionalTextEdits": [],
+                        "insertTextFormat": 2
+                     }
+                  ]
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{main.adb}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didClose"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": 9,
+            "method": "shutdown"
+         },
+         "wait": [
+            {
+               "id": 9,
+               "result": null
+            }
+         ]
+      }
+   },
+   {
+      "stop": {
+         "exit_code": 0
+      }
+   }
+]

--- a/testsuite/ada_lsp/completion.aggregates.derived_types/test.yaml
+++ b/testsuite/ada_lsp/completion.aggregates.derived_types/test.yaml
@@ -1,0 +1,1 @@
+title: 'completion.aggregates.derived_types'

--- a/testsuite/ada_lsp/completion.aggregates.simple/default.gpr
+++ b/testsuite/ada_lsp/completion.aggregates.simple/default.gpr
@@ -1,0 +1,10 @@
+project Default is
+
+   package Compiler is
+      for Switches ("Ada") use ("-g", "-O2");
+   end Compiler;
+
+   for Main use ("main.adb") & project'Main;
+
+end Default;
+

--- a/testsuite/ada_lsp/completion.aggregates.simple/main.adb
+++ b/testsuite/ada_lsp/completion.aggregates.simple/main.adb
@@ -1,0 +1,11 @@
+procedure Main is
+   type Aggr_Type_1 is record
+      A : Integer;
+      B : Integer;
+      C : Integer;
+   end record;
+
+   Obj : Aggr_Type_1;
+begin
+   Obj :=
+end Main;

--- a/testsuite/ada_lsp/completion.aggregates.simple/test.json
+++ b/testsuite/ada_lsp/completion.aggregates.simple/test.json
@@ -1,0 +1,249 @@
+[
+   {
+      "comment": [
+          "This test checks that aggregate completion works fine for simple ",
+          "records"
+      ]
+   },
+   {
+      "start": {
+         "cmd": [
+            "${ALS}"
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "processId": 31570,
+               "capabilities": {
+                  "textDocument": {
+                     "completion": {
+                        "completionItem": {
+                           "documentationFormat": [
+                              "plaintext",
+                              "markdown"
+                           ],
+                           "snippetSupport": true
+                        },
+                        "dynamicRegistration": true
+                     },
+                     "definition": {},
+                     "hover": {},
+                     "formatting": {
+                        "dynamicRegistration": true
+                     },
+                     "implementation": {},
+                     "codeLens": {},
+                     "typeDefinition": {},
+                     "selectionRange": {},
+                     "documentHighlight": {},
+                     "documentSymbol": {
+                        "hierarchicalDocumentSymbolSupport": true
+                     },
+                     "synchronization": {},
+                     "references": {},
+                     "rangeFormatting": {},
+                     "onTypeFormatting": {},
+                     "declaration": {},
+                     "foldingRange": {
+                        "lineFoldingOnly": true
+                     },
+                     "colorProvider": {}
+                  },
+                  "workspace": {
+                     "applyEdit": true,
+                     "executeCommand": {},
+                     "didChangeWatchedFiles": {},
+                     "workspaceEdit": {},
+                     "didChangeConfiguration": {}
+                  }
+               },
+               "rootUri": "$URI{.}"
+            },
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize"
+         },
+          "wait": [
+              {
+                  "jsonrpc": "2.0",
+                  "id": 1,
+                  "result": {
+                      "capabilities": {
+                          "textDocumentSync": 2,
+                          "completionProvider": {
+                              "triggerCharacters": [
+                                  ".",
+                                  "("
+                              ],
+                              "resolveProvider": false
+                          },
+                          "hoverProvider": true,
+                          "declarationProvider": true,
+                          "definitionProvider": true,
+                          "typeDefinitionProvider": true,
+                          "implementationProvider": true,
+                          "referencesProvider": true,
+                          "documentSymbolProvider": true,
+                          "codeActionProvider": {
+                          },
+                          "renameProvider": {
+                          },
+                          "foldingRangeProvider": true,
+                          "executeCommandProvider": {
+                              "commands": [
+                                  "als-named-parameters"
+                              ]
+                          },
+                          "alsCalledByProvider": true,
+                          "alsReferenceKinds": [
+                              "reference",
+                              "write",
+                              "call",
+                              "dispatching call",
+                              "parent",
+                              "child"
+                          ]
+                      }
+                  }
+              }
+          ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "initialized"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "settings": {
+                  "ada": {
+                     "scenarioVariables": {},
+                     "enableDiagnostics": false,
+                     "defaultCharset": "ISO-8859-1"
+                  }
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "workspace/didChangeConfiguration"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "text": "procedure Main is\n   type Aggr_Type_1 is record\n      A : Integer;\n      B : Integer;\n      C : Integer;\n   end record;\n\n   Obj : Aggr_Type_1;\nbegin\n   Obj :=\nend Main;\n",
+                  "version": 0,
+                  "uri": "$URI{main.adb}",
+                  "languageId": "Ada"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "contentChanges": [
+                  {
+                     "text": "procedure Main is\n   type Aggr_Type_1 is record\n      A : Integer;\n      B : Integer;\n      C : Integer;\n   end record;\n\n   Obj : Aggr_Type_1;\nbegin\n   Obj :=(\nend Main;\n"
+                  }
+               ],
+               "textDocument": {
+                  "version": 1,
+                  "uri": "$URI{main.adb}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "position": {
+                  "line": 9,
+                  "character": 10
+               },
+               "textDocument": {
+                  "uri": "$URI{main.adb}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "textDocument/completion"
+         },
+         "wait": [
+            {
+               "id": 3,
+               "result": {
+                  "isIncomplete": false,
+                  "items": [
+                     {
+                        "insertText": "A => ${1:A : Integer}, B => ${2:B : Integer}, C => ${3:C : Integer})$0",
+                        "kind": 15,
+                        "detail": "type Aggr_Type_1 is record\n   A : Integer;\n   B : Integer;\n   C : Integer;\nend record;",
+                        "label": "Aggregate for Aggr_Type_1",
+                        "additionalTextEdits": [],
+                        "insertTextFormat": 2
+                     }
+                  ]
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{main.adb}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didClose"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": 6,
+            "method": "shutdown"
+         },
+         "wait": [
+            {
+               "id": 6,
+               "result": null
+            }
+         ]
+      }
+   },
+   {
+      "stop": {
+         "exit_code": 0
+      }
+   }
+]

--- a/testsuite/ada_lsp/completion.aggregates.simple/test.yaml
+++ b/testsuite/ada_lsp/completion.aggregates.simple/test.yaml
@@ -1,0 +1,1 @@
+title: 'completion.aggregates.simple'

--- a/testsuite/ada_lsp/completion.complex_renames/test.json
+++ b/testsuite/ada_lsp/completion.complex_renames/test.json
@@ -75,7 +75,8 @@
                          "completionProvider": {
                              "resolveProvider": false,
                              "triggerCharacters": [
-                                 "."
+                                 ".",
+                                 "("
                              ]
                          },
                          "hoverProvider": true,

--- a/testsuite/ada_lsp/completion.end_labels/test.json
+++ b/testsuite/ada_lsp/completion.end_labels/test.json
@@ -75,7 +75,8 @@
                          "textDocumentSync": 2,
                          "completionProvider": {
                              "triggerCharacters": [
-                                 "."
+                                 ".",
+                                 "("
                              ],
                              "resolveProvider": false
                          },

--- a/testsuite/ada_lsp/completion.subp_parameters/test.json
+++ b/testsuite/ada_lsp/completion.subp_parameters/test.json
@@ -76,7 +76,8 @@
                           "completionProvider": {
                               "resolveProvider": false,
                               "triggerCharacters": [
-                                  "."
+                                  ".",
+                                  "("
                               ]
                           },
                           "hoverProvider": true,

--- a/testsuite/ada_lsp/completion.subp_params_dotted_names/test.json
+++ b/testsuite/ada_lsp/completion.subp_params_dotted_names/test.json
@@ -76,7 +76,8 @@
                           "completionProvider": {
                               "resolveProvider": false,
                               "triggerCharacters": [
-                                  "."
+                                  ".",
+                                  "("
                               ]
                           },
                           "hoverProvider": true,

--- a/testsuite/ada_lsp/declaration.overridings/test.json
+++ b/testsuite/ada_lsp/declaration.overridings/test.json
@@ -69,7 +69,8 @@
                      "declarationProvider": true,
                      "completionProvider": {
                         "triggerCharacters": [
-                           "."
+                            ".",
+                            "("
                         ],
                         "resolveProvider": false
                      },

--- a/testsuite/ada_lsp/definition_and_overridings/test.json
+++ b/testsuite/ada_lsp/definition_and_overridings/test.json
@@ -65,7 +65,8 @@
                      "textDocumentSync": 2,
                      "completionProvider": {
                         "triggerCharacters": [
-                           "."
+                            ".",
+                            "("
                         ],
                         "resolveProvider": false
                      },

--- a/testsuite/ada_lsp/definition_parents/test.json
+++ b/testsuite/ada_lsp/definition_parents/test.json
@@ -67,7 +67,8 @@
                      "textDocumentSync": 2,
                      "completionProvider": {
                         "triggerCharacters": [
-                           "."
+                            ".",
+                            "("
                         ],
                         "resolveProvider": false
                      },

--- a/testsuite/ada_lsp/editor.incremental/test.json
+++ b/testsuite/ada_lsp/editor.incremental/test.json
@@ -282,7 +282,8 @@
                      "declarationProvider": true,
                      "completionProvider": {
                         "triggerCharacters": [
-                           "."
+                            ".",
+                            "("
                         ],
                         "resolveProvider": false
                      },

--- a/testsuite/ada_lsp/find_all_refs_child_package/test.json
+++ b/testsuite/ada_lsp/find_all_refs_child_package/test.json
@@ -67,7 +67,8 @@
                      "textDocumentSync": 2,
                      "completionProvider": {
                         "triggerCharacters": [
-                           "."
+                            ".",
+                            "("
                         ],
                         "resolveProvider": false
                      },

--- a/testsuite/ada_lsp/find_all_refs_subp/find_all_refs_subp.json
+++ b/testsuite/ada_lsp/find_all_refs_subp/find_all_refs_subp.json
@@ -92,7 +92,8 @@
                      "textDocumentSync": 2,
                      "completionProvider": {
                         "triggerCharacters": [
-                           "."
+                            ".",
+                            "("
                         ],
                         "resolveProvider": false
                      },

--- a/testsuite/ada_lsp/implementation.aggregates/test.json
+++ b/testsuite/ada_lsp/implementation.aggregates/test.json
@@ -68,7 +68,8 @@
                      "textDocumentSync": 2,
                      "completionProvider": {
                         "triggerCharacters": [
-                           "."
+                            ".",
+                            "("
                         ],
                         "resolveProvider": false
                      },

--- a/testsuite/ada_lsp/implementation.overridings/test.json
+++ b/testsuite/ada_lsp/implementation.overridings/test.json
@@ -68,7 +68,8 @@
                      "textDocumentSync": 2,
                      "completionProvider": {
                         "triggerCharacters": [
-                           "."
+                            ".",
+                            "("
                         ],
                         "resolveProvider": false
                      },

--- a/testsuite/ada_lsp/implementation/test.json
+++ b/testsuite/ada_lsp/implementation/test.json
@@ -68,7 +68,8 @@
                      "textDocumentSync": 2,
                      "completionProvider": {
                         "triggerCharacters": [
-                           "."
+                            ".",
+                            "("
                         ],
                         "resolveProvider": false
                      },

--- a/testsuite/ada_lsp/incorrect_fallback/incorrect_fallback.json
+++ b/testsuite/ada_lsp/incorrect_fallback/incorrect_fallback.json
@@ -3,180 +3,181 @@
       "comment": [
          "test automatically generated"
       ]
-   }, 
+   },
    {
       "start": {
          "cmd": [
             "${ALS}"
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
-               "trace": "off", 
-               "processId": 8226, 
-               "rootPath": null, 
+               "trace": "off",
+               "processId": 8226,
+               "rootPath": null,
                "capabilities": {
                   "textDocument": {
                      "completion": {
                         "completionItem": {
-                           "commitCharactersSupport": true, 
+                           "commitCharactersSupport": true,
                            "snippetSupport": true
-                        }, 
+                        },
                         "dynamicRegistration": true
-                     }, 
+                     },
                      "definition": {
                         "dynamicRegistration": true
-                     }, 
+                     },
                      "signatureHelp": {
                         "dynamicRegistration": true
-                     }, 
+                     },
                      "hover": {
                         "dynamicRegistration": true
-                     }, 
+                     },
                      "formatting": {
                         "dynamicRegistration": true
-                     }, 
+                     },
                      "codeAction": {
                         "dynamicRegistration": true
-                     }, 
+                     },
                      "documentHighlight": {
                         "dynamicRegistration": true
-                     }, 
+                     },
                      "documentSymbol": {
                         "dynamicRegistration": true
-                     }, 
+                     },
                      "rename": {
                         "dynamicRegistration": true
-                     }, 
+                     },
                      "synchronization": {
-                        "didSave": true, 
-                        "willSave": true, 
-                        "willSaveWaitUntil": true, 
+                        "didSave": true,
+                        "willSave": true,
+                        "willSaveWaitUntil": true,
                         "dynamicRegistration": true
-                     }, 
+                     },
                      "references": {
                         "dynamicRegistration": true
-                     }, 
+                     },
                      "rangeFormatting": {
                         "dynamicRegistration": true
-                     }, 
+                     },
                      "onTypeFormatting": {
                         "dynamicRegistration": true
-                     }, 
+                     },
                      "codeLens": {
                         "dynamicRegistration": true
-                     }, 
+                     },
                      "documentLink": {
                         "dynamicRegistration": true
                      }
-                  }, 
+                  },
                   "workspace": {
                      "executeCommand": {
                         "dynamicRegistration": true
-                     }, 
-                     "applyEdit": true, 
+                     },
+                     "applyEdit": true,
                      "symbol": {
                         "dynamicRegistration": true
-                     }, 
+                     },
                      "didChangeWatchedFiles": {
                         "dynamicRegistration": true
-                     }, 
+                     },
                      "didChangeConfiguration": {
                         "dynamicRegistration": true
                      }
                   }
-               }, 
+               },
                "rootUri": null
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 0, 
+            },
+            "jsonrpc": "2.0",
+            "id": 0,
             "method": "initialize"
-         }, 
+         },
          "wait": [
             {
                "id": 0,
                "result": {
                   "capabilities": {
-                     "hoverProvider": true, 
-                     "documentSymbolProvider": true, 
-                     "referencesProvider": true, 
-                     "textDocumentSync": 2, 
+                     "hoverProvider": true,
+                     "documentSymbolProvider": true,
+                     "referencesProvider": true,
+                     "textDocumentSync": 2,
                      "completionProvider": {
                         "triggerCharacters": [
-                           "."
-                        ], 
+                            ".",
+                            "("
+                        ],
                         "resolveProvider": false
-                     }, 
+                     },
                      "definitionProvider": true
                   }
                }
             }
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
-            "params": {}, 
-            "jsonrpc": "2.0", 
+            "params": {},
+            "jsonrpc": "2.0",
             "method": "initialized"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "settings": {
                   "ada": {
-                     "projectFile": "", 
-                     "scenarioVariables": {}, 
+                     "projectFile": "",
+                     "scenarioVariables": {},
                      "trace": {
                         "server": "off"
                      }
                   }
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "workspace/didChangeConfiguration"
-         }, 
+         },
          "wait": [ ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "textDocument": {
-                  "text": "procedure Test is\n   function Foo return Float is (12.0);\n   function Foo return Integer is (12);\n\n   procedure Bar (A : Float; B : Integer) is null;\nbegin\n   -- This should resolve to the wrong Foo, using the imprecise fallback\n   Bar (Foo, );\nend Test;\n", 
-                  "version": 1, 
-                  "uri": "$URI{test.adb}", 
+                  "text": "procedure Test is\n   function Foo return Float is (12.0);\n   function Foo return Integer is (12);\n\n   procedure Bar (A : Float; B : Integer) is null;\nbegin\n   -- This should resolve to the wrong Foo, using the imprecise fallback\n   Bar (Foo, );\nend Test;\n",
+                  "version": 1,
+                  "uri": "$URI{test.adb}",
                   "languageId": "ada"
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "textDocument/didOpen"
-         }, 
+         },
          "wait": [
             {
                "params": {
-                  "uri": "$URI{test.adb}", 
+                  "uri": "$URI{test.adb}",
                   "diagnostics": [
                      {
                         "range": {
                            "start": {
-                              "line": 7, 
+                              "line": 7,
                               "character": 13
-                           }, 
+                           },
                            "end": {
-                              "line": 7, 
+                              "line": 7,
                               "character": 14
                            }
-                        }, 
+                        },
                         "message": "Expected '<>', got ')'"
                      },
                      {
@@ -193,76 +194,76 @@
                         "message": "Missing ';'"
                      }
                   ]
-               }, 
+               },
                "method": "textDocument/publishDiagnostics"
             }
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "position": {
-                  "line": 7, 
+                  "line": 7,
                   "character": 8
-               }, 
+               },
                "textDocument": {
                   "uri": "$URI{test.adb}"
                }
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 1, 
+            },
+            "jsonrpc": "2.0",
+            "id": 1,
             "method": "textDocument/definition"
-         }, 
+         },
          "wait": [
             {
-               "id": 1, 
+               "id": 1,
                "result": [
                   {
                      "range": {
                         "start": {
-                           "line": 2, 
+                           "line": 2,
                            "character": 12
-                        }, 
+                        },
                         "end": {
-                           "line": 2, 
+                           "line": 2,
                            "character": 15
                         }
-                     }, 
+                     },
                      "uri": "$URI{test.adb}"
                   }
                ]
             }
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
-            "params": null, 
-            "jsonrpc": "2.0", 
-            "id": 2, 
+            "params": null,
+            "jsonrpc": "2.0",
+            "id": 2,
             "method": "shutdown"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
-            "params": null, 
-            "jsonrpc": "2.0", 
+            "params": null,
+            "jsonrpc": "2.0",
             "method": "exit"
-         }, 
+         },
          "wait": [
             {
-               "id": 2, 
+               "id": 2,
                "result": null
             }
          ]
       }
-   }, 
+   },
    {
       "stop": {
          "exit_code": 0

--- a/testsuite/ada_lsp/indexing_progress/test.json
+++ b/testsuite/ada_lsp/indexing_progress/test.json
@@ -46,7 +46,8 @@
                      "textDocumentSync": 2,
                      "completionProvider": {
                         "triggerCharacters": [
-                           "."
+                            ".",
+                            "("
                         ],
                         "resolveProvider": false
                      },

--- a/testsuite/ada_lsp/invalidation.file_contents/test.json
+++ b/testsuite/ada_lsp/invalidation.file_contents/test.json
@@ -3,124 +3,125 @@
       "comment": [
          "test navigation accross invalidation of file contents"
       ]
-   }, 
+   },
    {
       "start": {
          "cmd": [
             "${ALS}"
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
-               "processId": 12026, 
+               "processId": 12026,
                "capabilities": {
                   "workspace": {
                      "applyEdit": false
                   }
-               }, 
+               },
                "rootUri": "$URI{.}"
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 1, 
+            },
+            "jsonrpc": "2.0",
+            "id": 1,
             "method": "initialize"
-         }, 
+         },
          "wait": [
             {
-               "id": 1, 
+               "id": 1,
                "result": {
                   "capabilities": {
-                     "typeDefinitionProvider": true, 
-                     "hoverProvider": true, 
-                     "definitionProvider": true, 
-                     "renameProvider": {}, 
-                     "alsCalledByProvider": true, 
-                     "referencesProvider": true, 
+                     "typeDefinitionProvider": true,
+                     "hoverProvider": true,
+                     "definitionProvider": true,
+                     "renameProvider": {},
+                     "alsCalledByProvider": true,
+                     "referencesProvider": true,
                      "textDocumentSync": 2,
                      "completionProvider": {
                         "triggerCharacters": [
-                           "."
-                        ], 
+                            ".",
+                            "("
+                        ],
                         "resolveProvider": false
-                     }, 
+                     },
                      "documentSymbolProvider": true
                   }
                }
             }
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
-            "jsonrpc": "2.0", 
+            "jsonrpc": "2.0",
             "method": "initialized"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "settings": {
                   "ada": {
-                     "projectFile": "p.gpr", 
-                     "scenarioVariables": {}, 
-                     "enableDiagnostics": false, 
+                     "projectFile": "p.gpr",
+                     "scenarioVariables": {},
+                     "enableDiagnostics": false,
                      "defaultCharset": "UTF-8"
                   }
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "workspace/didChangeConfiguration"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "textDocument": {
-                  "text": "--  with P; use P;\n--  with Q; use Q;\nprocedure Main is\nbegin\n   Foo;\nend Main;\n", 
-                  "version": 0, 
-                  "uri": "$URI{main.adb}", 
+                  "text": "--  with P; use P;\n--  with Q; use Q;\nprocedure Main is\nbegin\n   Foo;\nend Main;\n",
+                  "version": 0,
+                  "uri": "$URI{main.adb}",
                   "languageId": "Ada"
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "textDocument/didOpen"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "position": {
-                  "line": 4, 
+                  "line": 4,
                   "character": 5
-               }, 
+               },
                "textDocument": {
                   "uri": "$URI{main.adb}"
                }
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 2, 
+            },
+            "jsonrpc": "2.0",
+            "id": 2,
             "method": "textDocument/definition"
-         }, 
+         },
          "wait": [
             {
-               "id": 2, 
+               "id": 2,
                "result": []
             }
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
@@ -129,73 +130,73 @@
                   {
                      "text": "with P; use P;\n--  with Q; use Q;\nprocedure Main is\nbegin\n   Foo;\nend Main;\n"
                   }
-               ], 
+               ],
                "textDocument": {
-                  "version": 1, 
+                  "version": 1,
                   "uri": "$URI{main.adb}"
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "textDocument/didChange"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "position": {
-                  "line": 4, 
+                  "line": 4,
                   "character": 4
-               }, 
+               },
                "textDocument": {
                   "uri": "$URI{main.adb}"
                }
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 3, 
+            },
+            "jsonrpc": "2.0",
+            "id": 3,
             "method": "textDocument/definition"
-         }, 
+         },
          "wait": [
             {
-               "id": 3, 
+               "id": 3,
                "result": [
                   {
                      "range": {
                         "start": {
-                           "line": 1, 
+                           "line": 1,
                            "character": 13
-                        }, 
+                        },
                         "end": {
-                           "line": 1, 
+                           "line": 1,
                            "character": 16
                         }
-                     }, 
+                     },
                      "uri": "$URI{p.ads}"
                   }
                ]
             }
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "textDocument": {
-                  "text": "package P is\n   procedure Foo is null;\nend P;\n", 
-                  "version": 0, 
-                  "uri": "$URI{p.ads}", 
+                  "text": "package P is\n   procedure Foo is null;\nend P;\n",
+                  "version": 0,
+                  "uri": "$URI{p.ads}",
                   "languageId": "Ada"
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "textDocument/didOpen"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
@@ -204,42 +205,42 @@
                   {
                      "text": ""
                   }
-               ], 
+               ],
                "textDocument": {
-                  "version": 1, 
+                  "version": 1,
                   "uri": "$URI{p.ads}"
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "textDocument/didChange"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "position": {
-                  "line": 4, 
+                  "line": 4,
                   "character": 4
-               }, 
+               },
                "textDocument": {
                   "uri": "$URI{main.adb}"
                }
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 4, 
+            },
+            "jsonrpc": "2.0",
+            "id": 4,
             "method": "textDocument/definition"
-         }, 
+         },
          "wait": [
             {
-               "id": 4, 
+               "id": 4,
                "result": []
             }
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
@@ -248,56 +249,56 @@
                   {
                      "text": "package P is\n   procedure Foo is null;\nend P;\n"
                   }
-               ], 
+               ],
                "textDocument": {
-                  "version": 2, 
+                  "version": 2,
                   "uri": "$URI{p.ads}"
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "textDocument/didChange"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "position": {
-                  "line": 4, 
+                  "line": 4,
                   "character": 5
-               }, 
+               },
                "textDocument": {
                   "uri": "$URI{main.adb}"
                }
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 5, 
+            },
+            "jsonrpc": "2.0",
+            "id": 5,
             "method": "textDocument/definition"
-         }, 
+         },
          "wait": [
             {
-               "id": 5, 
+               "id": 5,
                "result": [
                   {
                      "range": {
                         "start": {
-                           "line": 1, 
+                           "line": 1,
                            "character": 13
-                        }, 
+                        },
                         "end": {
-                           "line": 1, 
+                           "line": 1,
                            "character": 16
                         }
-                     }, 
+                     },
                      "uri": "$URI{p.ads}"
                   }
                ]
             }
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
@@ -306,18 +307,18 @@
                   {
                      "text": "with P; use P;\n with Q; use Q;\nprocedure Main is\nbegin\n   Foo;\nend Main;\n"
                   }
-               ], 
+               ],
                "textDocument": {
-                  "version": 2, 
+                  "version": 2,
                   "uri": "$URI{main.adb}"
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "textDocument/didChange"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
@@ -326,73 +327,73 @@
                   {
                      "text": "-- with P; use P;\n with Q; use Q;\nprocedure Main is\nbegin\n   Foo;\nend Main;\n"
                   }
-               ], 
+               ],
                "textDocument": {
-                  "version": 3, 
+                  "version": 3,
                   "uri": "$URI{main.adb}"
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "textDocument/didChange"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "position": {
-                  "line": 4, 
+                  "line": 4,
                   "character": 4
-               }, 
+               },
                "textDocument": {
                   "uri": "$URI{main.adb}"
                }
-            }, 
-            "jsonrpc": "2.0", 
-            "id": 6, 
+            },
+            "jsonrpc": "2.0",
+            "id": 6,
             "method": "textDocument/definition"
-         }, 
+         },
          "wait": [
             {
-               "id": 6, 
+               "id": 6,
                "result": [
                   {
                      "range": {
                         "start": {
-                           "line": 1, 
+                           "line": 1,
                            "character": 13
-                        }, 
+                        },
                         "end": {
-                           "line": 1, 
+                           "line": 1,
                            "character": 16
                         }
-                     }, 
+                     },
                      "uri": "$URI{q.ads}"
                   }
                ]
             }
          ]
       }
-   }, 
+   },
    {
       "send": {
          "request": {
             "params": {
                "textDocument": {
-                  "text": "package Q is\n   procedure Foo is null;\nend Q;\n", 
-                  "version": 0, 
-                  "uri": "$URI{q.ads}", 
+                  "text": "package Q is\n   procedure Foo is null;\nend Q;\n",
+                  "version": 0,
+                  "uri": "$URI{q.ads}",
                   "languageId": "Ada"
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "textDocument/didOpen"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
@@ -400,13 +401,13 @@
                "textDocument": {
                   "uri": "$URI{main.adb}"
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "textDocument/didClose"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
@@ -414,13 +415,13 @@
                "textDocument": {
                   "uri": "$URI{p.ads}"
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "textDocument/didClose"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
@@ -428,28 +429,28 @@
                "textDocument": {
                   "uri": "$URI{q.ads}"
                }
-            }, 
-            "jsonrpc": "2.0", 
+            },
+            "jsonrpc": "2.0",
             "method": "textDocument/didClose"
-         }, 
+         },
          "wait": []
       }
-   }, 
+   },
    {
       "send": {
          "request": {
-            "jsonrpc": "2.0", 
-            "id": 7, 
+            "jsonrpc": "2.0",
+            "id": 7,
             "method": "shutdown"
-         }, 
+         },
          "wait": [
             {
-               "id": 7, 
+               "id": 7,
                "result": null
             }
          ]
       }
-   }, 
+   },
    {
       "stop": {
          "exit_code": 0

--- a/testsuite/ada_lsp/named_params.dot_calls/test.json
+++ b/testsuite/ada_lsp/named_params.dot_calls/test.json
@@ -72,7 +72,8 @@
                           "completionProvider": {
                               "resolveProvider": false,
                               "triggerCharacters": [
-                                  "."
+                                  ".",
+                                  "("
                               ]
                           },
                           "hoverProvider": true,

--- a/testsuite/ada_lsp/references.child/test.json
+++ b/testsuite/ada_lsp/references.child/test.json
@@ -69,7 +69,8 @@
                      "declarationProvider": true,
                      "completionProvider": {
                         "triggerCharacters": [
-                           "."
+                            ".",
+                            "("
                         ],
                         "resolveProvider": false
                      },

--- a/testsuite/ada_lsp/rename.not_up_to_date/test.json
+++ b/testsuite/ada_lsp/rename.not_up_to_date/test.json
@@ -41,7 +41,8 @@
                      "textDocumentSync": 2,
                      "completionProvider": {
                         "triggerCharacters": [
-                           "."
+                            ".",
+                            "("
                         ],
                         "resolveProvider": false
                      },

--- a/testsuite/ada_lsp/rename.primitive_parameters/test.json
+++ b/testsuite/ada_lsp/rename.primitive_parameters/test.json
@@ -71,7 +71,8 @@
                      "textDocumentSync": 2,
                      "completionProvider": {
                         "triggerCharacters": [
-                           "."
+                           ".",
+			   "("
                         ],
                         "resolveProvider": false
                      },

--- a/testsuite/ada_lsp/rename.tagged_type_primitives/test.json
+++ b/testsuite/ada_lsp/rename.tagged_type_primitives/test.json
@@ -70,7 +70,8 @@
                      "textDocumentSync": 2,
                      "completionProvider": {
                         "triggerCharacters": [
-                           "."
+                            ".",
+                            "("
                         ],
                         "resolveProvider": false
                      },

--- a/testsuite/ada_lsp/type_definition.aggregate/test.json
+++ b/testsuite/ada_lsp/type_definition.aggregate/test.json
@@ -67,7 +67,8 @@
                      "textDocumentSync": 2,
                      "completionProvider": {
                         "triggerCharacters": [
-                           "."
+                            ".",
+                            "("
                         ],
                         "resolveProvider": false
                      },


### PR DESCRIPTION
Completion snippets that list all the possible shapes (discriminants,
components...) of an aggregate are now proposed when opening a parenthesis
to initialize/assign records.

A new flag has also been added in order to control the number of parameters
at which point named notation should be used in the proposed snippets.

Tests have been adapted since "(" now can trigger completion and thus is
listed in the LSP triggerCharacters config field.