### PR TITLE
SB14-037: Add new reference kind "access"

### DIFF
--- a/doc/reference_kinds.md
+++ b/doc/reference_kinds.md
@@ -13,10 +13,11 @@ extra field to the `Location` type:
 
 ```typescript
 
-export type AlsReferenceKind = 'write' | 'call' | 'dispatching call' | 'parent' | 'child';
+export type AlsReferenceKind = 'write' | 'access' | 'call' | 'dispatching call' | 'parent' | 'child';
 
 export namespace AlsReferenceKind {
    export const Write            : AlsReferenceKind = 'write';
+   export const Access           : AlsReferenceKind = 'access';
    export const Static_Call      : AlsReferenceKind = 'call';
    export const Dispatching_Call : AlsReferenceKind = 'dispatching call';
    export const Parent           : AlsReferenceKind = 'parent';

--- a/source/protocol/generated/lsp-message_io.adb
+++ b/source/protocol/generated/lsp-message_io.adb
@@ -238,6 +238,8 @@ package body LSP.Message_IO is
    begin
       if Text = "reference" then
          V := Simple;
+      elsif Text = "access" then
+         V := Access_Ref;
       elsif Text = "write" then
          V := Write;
       elsif Text = "call" then
@@ -271,6 +273,8 @@ package body LSP.Message_IO is
          case Value is
             when Simple =>
                return "reference";
+            when Access_Ref =>
+               return "access";
             when Write =>
                return "write";
             when Static_Call =>

--- a/source/protocol/lsp-messages.ads
+++ b/source/protocol/lsp-messages.ads
@@ -351,10 +351,11 @@ package LSP.Messages is
 
    --  reference_kinds ALS extension:
    --
-   --  export type AlsReferenceKind = 'w' | 'c' | 'd' | 'p' | 'h';
+   --  export type AlsReferenceKind = 'w' | 'a' | 'c' | 'd' | 'p' | 'h';
    --
    --  export namespace AlsReferenceKind {
    --     export const Write            : AlsReferenceKind = 'write';
+   --     export const Access           : AlsReferenceKind = 'access';
    --     export const Static_Call      : AlsReferenceKind = 'call';
    --     export const Dispatching_Call : AlsReferenceKind = 'dispatching call';
    --     export const Parent           : AlsReferenceKind = 'parent';
@@ -362,7 +363,7 @@ package LSP.Messages is
    --  }
 
    type AlsReferenceKind is
-     (Simple, Write, Static_Call, Dispatching_Call, Parent, Child);
+     (Simple, Access_Ref, Write, Static_Call, Dispatching_Call, Parent, Child);
 
    procedure Read_AlsReferenceKind
      (S : access Ada.Streams.Root_Stream_Type'Class;

--- a/testsuite/ada_lsp/F131-024.xrefs.separate_body/test.json
+++ b/testsuite/ada_lsp/F131-024.xrefs.separate_body/test.json
@@ -35,6 +35,7 @@
                      "typeDefinitionProvider": true,
                      "alsReferenceKinds": [
                         "reference",
+                         "access",
                         "write",
                         "call",
                         "dispatching call", "parent", "child"

--- a/testsuite/ada_lsp/G323-009.tooltips.function_prototype/test.json
+++ b/testsuite/ada_lsp/G323-009.tooltips.function_prototype/test.json
@@ -35,6 +35,7 @@
                      "typeDefinitionProvider": true,
                      "alsReferenceKinds": [
                         "reference",
+                         "access",
                         "write",
                         "call",
                         "dispatching call", "parent", "child"

--- a/testsuite/ada_lsp/S820-016.called_by.entry/test.json
+++ b/testsuite/ada_lsp/S820-016.called_by.entry/test.json
@@ -34,6 +34,7 @@
                      "typeDefinitionProvider": true,
                      "alsReferenceKinds": [
                         "reference",
+                         "access",
                         "write",
                         "call",
                         "dispatching call", "parent", "child"

--- a/testsuite/ada_lsp/SA11-040.definition.fallback/test.json
+++ b/testsuite/ada_lsp/SA11-040.definition.fallback/test.json
@@ -34,6 +34,7 @@
                      "typeDefinitionProvider": true,
                      "alsReferenceKinds": [
                         "reference",
+                         "access",
                         "write",
                         "call",
                         "dispatching call", "parent", "child"

--- a/testsuite/ada_lsp/SA22-029.rename_in_comments/test.json
+++ b/testsuite/ada_lsp/SA22-029.rename_in_comments/test.json
@@ -34,6 +34,7 @@
                      "typeDefinitionProvider": true,
                      "alsReferenceKinds": [
                         "reference",
+                         "access",
                         "write",
                         "call",
                         "dispatching call", "parent", "child"

--- a/testsuite/ada_lsp/SA22-032.folding/test.json
+++ b/testsuite/ada_lsp/SA22-032.folding/test.json
@@ -64,6 +64,7 @@
                      "alsCalledByProvider": true,
                      "alsReferenceKinds": [
                         "reference",
+                         "access",
                         "write",
                         "call",
                         "dispatching call",

--- a/testsuite/ada_lsp/SA24-055.called_by_on_abstract/test.json
+++ b/testsuite/ada_lsp/SA24-055.called_by_on_abstract/test.json
@@ -34,6 +34,7 @@
                      "typeDefinitionProvider": true,
                      "alsReferenceKinds": [
                         "reference",
+                         "access",
                         "write",
                         "call",
                         "dispatching call", "parent", "child"

--- a/testsuite/ada_lsp/SB14-037.references.access_kind/default.gpr
+++ b/testsuite/ada_lsp/SB14-037.references.access_kind/default.gpr
@@ -1,0 +1,2 @@
+project Default is
+end Default;

--- a/testsuite/ada_lsp/SB14-037.references.access_kind/main.adb
+++ b/testsuite/ada_lsp/SB14-037.references.access_kind/main.adb
@@ -1,0 +1,13 @@
+with Ada.Text_IO;
+
+procedure Main is
+   A : Integer;
+   procedure Foo (V : access Integer) is
+   begin
+      V.all := 3;
+   end Foo;
+begin
+   A := 1;
+   Foo (A'Unrestricted_Access);
+   Ada.Text_IO.Put_Line (A'Image);
+end Main;

--- a/testsuite/ada_lsp/SB14-037.references.access_kind/test.json
+++ b/testsuite/ada_lsp/SB14-037.references.access_kind/test.json
@@ -1,8 +1,8 @@
 [
    {
       "comment": [
-          "This test checks that textDocument/definition responses filter out",
-          "end labels"
+          "This test checks that the access references kind are properly",
+          "flagged"
       ]
    },
    {
@@ -54,7 +54,7 @@
                      "typeDefinitionProvider": true,
                      "alsReferenceKinds": [
                         "reference",
-                         "access",
+                        "access",
                         "write",
                         "call",
                         "dispatching call", "parent", "child"
@@ -68,8 +68,8 @@
                      "textDocumentSync": 2,
                      "completionProvider": {
                         "triggerCharacters": [
-                            ".",
-                            "("
+                           ".",
+                           "("
                         ],
                         "resolveProvider": false
                      },
@@ -114,99 +114,125 @@
          "request": {
             "params": {
                "textDocument": {
-                  "text": "package Parent.Child is\n\n   type Child_Type is new Parent_Type with null record;\n\nend Parent.Child;\n",
-                  "version": 0,
-                  "uri": "$URI{parent-child.ads}",
+                  "text": "with Ada.Text_IO;\n\nprocedure Main is\n   A : Integer;\n   procedure Foo (V : access Integer) is\n   begin\n      V.all := 3;\n   end Foo;\nbegin\n   A := 1;\n   Foo (A'Unrestricted_Access);\n   Ada.Text_IO.Put_Line (A'Image);\nend Main;\n", 
+                  "version": 0, 
+                  "uri": "$URI{main.adb}", 
                   "languageId": "Ada"
                }
-            },
-            "jsonrpc": "2.0",
+            }, 
+            "jsonrpc": "2.0", 
             "method": "textDocument/didOpen"
          },
          "wait": []
       }
    },
-   {
+      {
       "send": {
          "request": {
             "params": {
                "position": {
-                  "line": 4,
-                  "character": 14
-               },
+                  "line": 3, 
+                  "character": 3
+               }, 
                "textDocument": {
-                  "uri": "$URI{parent-child.ads}"
-               },
+                  "uri": "$URI{main.adb}"
+               }, 
                "context": {
                   "includeDeclaration": true
                }
-            },
-            "jsonrpc": "2.0",
-            "id": 2,
+            }, 
+            "jsonrpc": "2.0", 
+            "id": 2, 
             "method": "textDocument/references"
-         },
+         }, 
          "wait": [
             {
-               "id": 2,
+               "id": 2, 
                "result": [
                   {
                      "range": {
                         "start": {
-                           "line": 0,
-                           "character": 12
-                        },
+                           "line": 3, 
+                           "character": 3
+                        }, 
                         "end": {
-                           "line": 0,
-                           "character": 17
+                           "line": 3, 
+                           "character": 4
                         }
-                     },
+                     }, 
+                     "alsKind": [
+                        "reference"
+                     ], 
                      "uri": "$URI{main.adb}"
-                  },
+                  }, 
                   {
                      "range": {
                         "start": {
-                           "line": 0,
-                           "character": 30
-                        },
+                           "line": 9, 
+                           "character": 3
+                        }, 
                         "end": {
-                           "line": 0,
-                           "character": 35
+                           "line": 9, 
+                           "character": 4
                         }
-                     },
+                     }, 
+                     "alsKind": [
+                        "write"
+                     ], 
                      "uri": "$URI{main.adb}"
-                  },
+                  }, 
                   {
                      "range": {
                         "start": {
-                           "line": 0,
+                           "line": 10, 
                            "character": 8
-                        },
+                        }, 
                         "end": {
-                           "line": 0,
-                           "character": 20
+                           "line": 10, 
+                           "character": 9
                         }
-                     },
-                     "uri": "$URI{parent-child.ads}"
+                     }, 
+                     "alsKind": [
+                        "access", 
+                        "write"
+                     ], 
+                     "uri": "$URI{main.adb}"
+                  }, 
+                  {
+                     "range": {
+                        "start": {
+                           "line": 11, 
+                           "character": 25
+                        }, 
+                        "end": {
+                           "line": 11, 
+                           "character": 26
+                        }
+                     }, 
+                     "alsKind": [
+                        "reference"
+                     ], 
+                     "uri": "$URI{main.adb}"
                   }
                ]
             }
          ]
       }
-   },
+   }, 
    {
       "send": {
          "request": {
             "params": {
                "textDocument": {
-                  "uri": "$URI{parent-child.ads}"
+                  "uri": "$URI{main.adb}"
                }
-            },
-            "jsonrpc": "2.0",
+            }, 
+            "jsonrpc": "2.0", 
             "method": "textDocument/didClose"
-         },
+         }, 
          "wait": []
       }
-   },
+   }, 
    {
       "send": {
          "request": {
@@ -228,3 +254,4 @@
       }
    }
 ]
+

--- a/testsuite/ada_lsp/SB14-037.references.access_kind/test.yaml
+++ b/testsuite/ada_lsp/SB14-037.references.access_kind/test.yaml
@@ -1,0 +1,1 @@
+title: 'SB14-037.references.access_kind'

--- a/testsuite/ada_lsp/SB21-042.tooltips.aspects/test.json
+++ b/testsuite/ada_lsp/SB21-042.tooltips.aspects/test.json
@@ -34,6 +34,7 @@
                      "typeDefinitionProvider": true,
                      "alsReferenceKinds": [
                         "reference",
+                         "access",
                         "write",
                         "call",
                         "dispatching call", "parent", "child"

--- a/testsuite/ada_lsp/SC16-095.fallback_when_no_body/test.json
+++ b/testsuite/ada_lsp/SC16-095.fallback_when_no_body/test.json
@@ -52,6 +52,7 @@
                      "typeDefinitionProvider": true,
                       "alsReferenceKinds": [
                         "reference",
+                         "access",
                         "write",
                         "call",
                         "dispatching call", "parent", "child"

--- a/testsuite/ada_lsp/T123-048.incremental_editing/test.json
+++ b/testsuite/ada_lsp/T123-048.incremental_editing/test.json
@@ -267,10 +267,11 @@
                      "typeDefinitionProvider": true,
                      "alsReferenceKinds": [
                         "reference",
-                        "write",
-                        "call",
-                        "dispatching call",
-                        "parent",
+                        "access", 
+                        "write", 
+                        "call", 
+                        "dispatching call", 
+                        "parent", 
                         "child"
                      ],
                      "hoverProvider": true,

--- a/testsuite/ada_lsp/aggregate.is_called_by/test.json
+++ b/testsuite/ada_lsp/aggregate.is_called_by/test.json
@@ -34,6 +34,7 @@
                      "typeDefinitionProvider": true,
                      "alsReferenceKinds": [
                         "reference",
+                         "access",
                         "write",
                         "call",
                         "dispatching call", "parent", "child"

--- a/testsuite/ada_lsp/aggregate.references_after_update/test.json
+++ b/testsuite/ada_lsp/aggregate.references_after_update/test.json
@@ -52,6 +52,7 @@
                      "typeDefinitionProvider": true,
                      "alsReferenceKinds": [
                         "reference",
+                         "access",
                         "write",
                         "call",
                         "dispatching call", "parent", "child"

--- a/testsuite/ada_lsp/aggregate.simple/test.json
+++ b/testsuite/ada_lsp/aggregate.simple/test.json
@@ -34,6 +34,7 @@
                      "typeDefinitionProvider": true,
                      "alsReferenceKinds": [
                         "reference",
+                         "access",
                         "write",
                         "call",
                         "dispatching call", "parent", "child"

--- a/testsuite/ada_lsp/called_by_dispatching/test.json
+++ b/testsuite/ada_lsp/called_by_dispatching/test.json
@@ -35,6 +35,7 @@
                      "typeDefinitionProvider": true,
                       "alsReferenceKinds": [
                         "reference",
+                         "access",
                         "write",
                         "call",
                         "dispatching call", "parent", "child"

--- a/testsuite/ada_lsp/completion.aggregates.derived_types/test.json
+++ b/testsuite/ada_lsp/completion.aggregates.derived_types/test.json
@@ -100,6 +100,7 @@
                           "alsCalledByProvider": true,
                           "alsReferenceKinds": [
                               "reference",
+                              "access",
                               "write",
                               "call",
                               "dispatching call",

--- a/testsuite/ada_lsp/completion.aggregates.simple/test.json
+++ b/testsuite/ada_lsp/completion.aggregates.simple/test.json
@@ -100,6 +100,7 @@
                           "alsCalledByProvider": true,
                           "alsReferenceKinds": [
                               "reference",
+                              "access",
                               "write",
                               "call",
                               "dispatching call",

--- a/testsuite/ada_lsp/completion.complex_renames/test.json
+++ b/testsuite/ada_lsp/completion.complex_renames/test.json
@@ -99,6 +99,7 @@
                          "alsCalledByProvider": true,
                          "alsReferenceKinds": [
                              "reference",
+                         "access",
                              "write",
                              "call",
                              "dispatching call",

--- a/testsuite/ada_lsp/completion.end_labels/test.json
+++ b/testsuite/ada_lsp/completion.end_labels/test.json
@@ -100,6 +100,7 @@
                          "alsCalledByProvider": true,
                          "alsReferenceKinds": [
                              "reference",
+                         "access",
                              "write",
                              "call",
                              "dispatching call",

--- a/testsuite/ada_lsp/completion.subp_parameters/test.json
+++ b/testsuite/ada_lsp/completion.subp_parameters/test.json
@@ -100,6 +100,7 @@
                           "alsCalledByProvider": true,
                           "alsReferenceKinds": [
                               "reference",
+                         "access",
                               "write",
                               "call",
                               "dispatching call",

--- a/testsuite/ada_lsp/completion.subp_params_dotted_names/test.json
+++ b/testsuite/ada_lsp/completion.subp_params_dotted_names/test.json
@@ -100,6 +100,7 @@
                           "alsCalledByProvider": true,
                           "alsReferenceKinds": [
                               "reference",
+                         "access",
                               "write",
                               "call",
                               "dispatching call",

--- a/testsuite/ada_lsp/declaration.overridings/test.json
+++ b/testsuite/ada_lsp/declaration.overridings/test.json
@@ -54,6 +54,7 @@
                      "typeDefinitionProvider": true,
                      "alsReferenceKinds": [
                         "reference",
+                         "access",
                         "write",
                         "call",
                         "dispatching call",

--- a/testsuite/ada_lsp/definition_and_overridings/test.json
+++ b/testsuite/ada_lsp/definition_and_overridings/test.json
@@ -53,6 +53,7 @@
                      "typeDefinitionProvider": true,
                      "alsReferenceKinds": [
                         "reference",
+                         "access",
                         "write",
                         "call",
                         "dispatching call", "parent", "child"

--- a/testsuite/ada_lsp/definition_parents/test.json
+++ b/testsuite/ada_lsp/definition_parents/test.json
@@ -52,6 +52,7 @@
                      "typeDefinitionProvider": true,
                      "alsReferenceKinds": [
                         "reference",
+                         "access",
                         "write",
                         "call",
                         "dispatching call",

--- a/testsuite/ada_lsp/editor.incremental/test.json
+++ b/testsuite/ada_lsp/editor.incremental/test.json
@@ -267,6 +267,7 @@
                      "typeDefinitionProvider": true,
                      "alsReferenceKinds": [
                         "reference",
+                         "access",
                         "write",
                         "call",
                         "dispatching call",

--- a/testsuite/ada_lsp/implementation.aggregates/test.json
+++ b/testsuite/ada_lsp/implementation.aggregates/test.json
@@ -52,6 +52,7 @@
                      "typeDefinitionProvider": true,
                       "alsReferenceKinds": [
                         "reference",
+                         "access",
                         "write",
                         "call",
                         "dispatching call",

--- a/testsuite/ada_lsp/implementation.overridings/test.json
+++ b/testsuite/ada_lsp/implementation.overridings/test.json
@@ -52,6 +52,7 @@
                      "typeDefinitionProvider": true,
                       "alsReferenceKinds": [
                         "reference",
+                         "access",
                         "write",
                         "call",
                         "dispatching call",

--- a/testsuite/ada_lsp/implementation/test.json
+++ b/testsuite/ada_lsp/implementation/test.json
@@ -52,6 +52,7 @@
                      "typeDefinitionProvider": true,
                      "alsReferenceKinds": [
                         "reference",
+                         "access",
                         "write",
                         "call",
                         "dispatching call",

--- a/testsuite/ada_lsp/indexing_progress/test.json
+++ b/testsuite/ada_lsp/indexing_progress/test.json
@@ -34,6 +34,7 @@
                      "typeDefinitionProvider": true,
                      "alsReferenceKinds": [
                        "reference",
+                         "access",
                         "write",
                         "call",
                         "dispatching call", "parent", "child"

--- a/testsuite/ada_lsp/named_params.dot_calls/test.json
+++ b/testsuite/ada_lsp/named_params.dot_calls/test.json
@@ -96,6 +96,7 @@
                           "alsCalledByProvider": true,
                           "alsReferenceKinds": [
                               "reference",
+                         "access",
                               "write",
                               "call",
                               "dispatching call",

--- a/testsuite/ada_lsp/references.child/test.json
+++ b/testsuite/ada_lsp/references.child/test.json
@@ -54,6 +54,7 @@
                      "typeDefinitionProvider": true,
                      "alsReferenceKinds": [
                         "reference",
+                         "access",
                         "write",
                         "call",
                         "dispatching call",

--- a/testsuite/ada_lsp/rename.primitive_parameters/test.json
+++ b/testsuite/ada_lsp/rename.primitive_parameters/test.json
@@ -56,6 +56,7 @@
                      "typeDefinitionProvider": true,
                      "alsReferenceKinds": [
                         "reference",
+                         "access",
                         "write",
                         "call",
                         "dispatching call",

--- a/testsuite/ada_lsp/rename.tagged_type_primitives/test.json
+++ b/testsuite/ada_lsp/rename.tagged_type_primitives/test.json
@@ -55,6 +55,7 @@
                      "typeDefinitionProvider": true,
                      "alsReferenceKinds": [
                         "reference",
+                         "access",
                         "write",
                         "call",
                         "dispatching call",

--- a/testsuite/ada_lsp/type_definition.aggregate/test.json
+++ b/testsuite/ada_lsp/type_definition.aggregate/test.json
@@ -52,6 +52,7 @@
                      "typeDefinitionProvider": true,
                      "alsReferenceKinds": [
                         "reference",
+                         "access",
                         "write",
                         "call",
                         "dispatching call",


### PR DESCRIPTION
Add a reference kind for the following write references:
Foo'Access
Foo'Unrestricted_Access
It allows to filter them from more common write reference like
"assignment" ("Foo :=").
Note: They will still be flagged as write references