### PR TITLE
T702-027: Avoid recursion on documentSymbol request for expressions

### DIFF
--- a/source/ada/lsp-ada_documents.adb
+++ b/source/ada/lsp-ada_documents.adb
@@ -937,7 +937,9 @@ package body LSP.Ada_Documents is
          Next             : LSP.Messages.DocumentSymbol_Trees.Cursor := Cursor;
          New_Nested_Level : Integer := Nested_Level;
       begin
-         if Node = No_Ada_Node then
+         if Node = No_Ada_Node
+           or else Node.Kind in Libadalang.Common.Ada_Expr
+         then
             return;
          end if;
 


### PR DESCRIPTION
Since we only want to display declarations in the Outline and expression
nodes can't contain declarations.