### PR TITLE
T707-058 Allow the driver to be run from e3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ vscode-test:
 
 check: all
 	set -e; \
-        if [ `python -c "import sys;print 'e3' in sys.modules"` = "True" ]; then\
+        if [ `python -c "import sys;print('e3' in sys.modules)"` = "True" ]; then\
            (cd testsuite ; sh run.sh ) ; \
         else \
            for a in $(TD)/*/*.json; do \

--- a/testsuite/drivers/__init__.py
+++ b/testsuite/drivers/__init__.py
@@ -30,7 +30,7 @@ class ALSTestDriver(TestDriver):
         self.add_fragment(dag, 'prepare')
         self.add_fragment(dag, 'run', after=['prepare'])
 
-    def prepare(self, previous_values):
+    def prepare(self, previous_values, slot):
         """
         Create the working directory to be a copy of the test directory.
         """
@@ -88,6 +88,10 @@ class ALSTestDriver(TestDriver):
             'run_args': kwargs,
             'status': process.status,
             'output': Log(process.out)})
-        self.result.out += process.out
+
+        if self.result.out is None:
+            self.result.out = process.out
+        else:
+            self.result.out += process.out
 
         return process

--- a/testsuite/drivers/basic.py
+++ b/testsuite/drivers/basic.py
@@ -14,7 +14,7 @@ class JsonTestDriver(ALSTestDriver):
           - a number of test drivers, in .json files.
     """
 
-    def run(self, previous_values):
+    def run(self, previous_values, slot):
         # Check whether the test should be skipped
         if self.should_skip():
             return False

--- a/testsuite/drivers/codecs.py
+++ b/testsuite/drivers/codecs.py
@@ -13,7 +13,7 @@ class CodecsTestDriver(ALSTestDriver):
     files.
     """
 
-    def run(self, previous_values):
+    def run(self, previous_values, slot):
         # Check whether the test should be skipped
         if self.should_skip():
             return False

--- a/testsuite/run-tests
+++ b/testsuite/run-tests
@@ -12,11 +12,11 @@ if __name__ == '__main__':
         status = suite.results[k].name
         if status not in ('PASS', 'XFAIL'):
             all_ok = False
-            print "--- {} : {} ---".format(k, status)
+            print("--- {} : {} ---".format(k, status))
             with open(os.path.join(suite.output_dir,
                                    "{}.yaml".format(k)), 'rb') as f:
                 y = f.read()
-                print yaml.safe_load(y).out
+                print(yaml.safe_load(y).out)
 
     if all_ok:
-        print "SUCCESS"
+        print("SUCCESS")


### PR DESCRIPTION
... without gnatpython.
Make the necessary changes to function profiles and names, and
adjustments to use Python 3.

Remove our implementation of get_test_list, which doesn't return
a ParsedTest: instead, use the documented API to select test
drivers.