### PR TITLE
T318-064: Avoid keyword completion after non-whitespace characters

### DIFF
--- a/source/ada/lsp-ada_documents.ads
+++ b/source/ada/lsp-ada_documents.ads
@@ -57,6 +57,12 @@ package LSP.Ada_Documents is
    function Text (Self : Document) return LSP.Types.LSP_String;
    --  Return the text associated with Self
 
+   function Get_Text_At
+     (Self      : Document;
+      Start_Pos : LSP.Messages.Position;
+      End_Pos   : LSP.Messages.Position) return String;
+   --  Return the text in the specified range.
+
    procedure Apply_Changes
      (Self    : aliased in out Document;
       Version : LSP.Messages.Nullable_Number;

--- a/testsuite/ada_lsp/completion.keywords/main.adb
+++ b/testsuite/ada_lsp/completion.keywords/main.adb
@@ -1,0 +1,12 @@
+with Ada.Text_IO;
+
+procedure Main is
+
+   function Add (A, B : Integer) return Integer
+   is
+      (A + B);
+
+begin
+   Add (
+
+end Main;

--- a/testsuite/ada_lsp/completion.keywords/test.json
+++ b/testsuite/ada_lsp/completion.keywords/test.json
@@ -1,0 +1,363 @@
+[
+   {
+      "comment": [
+         "Basic test for keyword completion"
+      ]
+   },
+   {
+      "start": {
+         "cmd": [
+            "${ALS}"
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "processId": 29286,
+               "capabilities": {
+                  "textDocument": {
+                     "completion": {
+                        "completionItem": {
+                           "documentationFormat": [
+                              "plaintext",
+                              "markdown"
+                           ],
+                           "snippetSupport": true
+                        },
+                        "dynamicRegistration": true
+                     },
+                     "definition": {},
+                     "hover": {},
+                     "formatting": {
+                        "dynamicRegistration": true
+                     },
+                     "implementation": {},
+                     "codeLens": {},
+                     "typeDefinition": {},
+                     "selectionRange": {},
+                     "documentHighlight": {},
+                     "documentSymbol": {
+                        "hierarchicalDocumentSymbolSupport": true
+                     },
+                     "synchronization": {},
+                     "references": {},
+                     "rangeFormatting": {},
+                     "onTypeFormatting": {},
+                     "declaration": {},
+                     "foldingRange": {
+                        "lineFoldingOnly": true
+                     },
+                     "colorProvider": {}
+                  },
+                  "workspace": {
+                     "applyEdit": true,
+                     "executeCommand": {},
+                     "didChangeWatchedFiles": {},
+                     "workspaceEdit": {},
+                     "didChangeConfiguration": {}
+                  }
+               },
+               "rootUri": "$URI{.}"
+            },
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize"
+         },
+         "wait": [
+            {
+               "id": 1,
+               "result": {
+                  "capabilities": {
+                     "alsReferenceKinds": [
+                        "reference",
+                        "access",
+                        "write",
+                        "call",
+                        "dispatching call",
+                        "parent",
+                        "child"
+                     ],
+                     "implementationProvider": true,
+                     "foldingRangeProvider": true,
+                     "typeDefinitionProvider": true,
+                     "alsShowDepsProvider": true,
+                     "hoverProvider": true,
+                     "definitionProvider": true,
+                     "renameProvider": {},
+                     "alsCalledByProvider": true,
+                     "referencesProvider": true,
+                     "codeActionProvider": {},
+                     "textDocumentSync": 2,
+                     "documentFormattingProvider": true,
+                     "declarationProvider": true,
+                     "completionProvider": {
+                        "triggerCharacters": [
+                           ".",
+                           "("
+                        ],
+                        "resolveProvider": false
+                     },
+                     "documentSymbolProvider": true,
+                     "executeCommandProvider": {
+                        "commands": [
+                           "als-named-parameters"
+                        ]
+                     }
+                  }
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "initialized"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "settings": {
+                  "ada": {
+                     "scenarioVariables": {},
+                     "enableDiagnostics": false,
+                     "defaultCharset": "ISO-8859-1"
+                  }
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "workspace/didChangeConfiguration"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "text": "with Ada.Text_IO;\n\nprocedure Main is\n\n   function Add (A, B : Integer) return Integer\n   is\n      (A + B);\n\nbegin\n   Add (\n\nend Main;\n",
+                  "version": 0,
+                  "uri": "$URI{main.adb}",
+                  "languageId": "Ada"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "contentChanges": [
+                  {
+                     "text": "r",
+                     "range": {
+                        "start": {
+                           "line": 9,
+                           "character": 8
+                        },
+                        "end": {
+                           "line": 9,
+                           "character": 8
+                        }
+                     }
+                  }
+               ],
+               "textDocument": {
+                  "version": 1,
+                  "uri": "$URI{main.adb}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "position": {
+                  "line": 9,
+                  "character": 9
+               },
+               "textDocument": {
+                  "uri": "$URI{main.adb}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "textDocument/completion"
+         },
+         "wait": [
+            {
+               "id": 3,
+               "result": {
+                  "isIncomplete": false,
+                  "items": []
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "contentChanges": [
+                  {
+                     "text": "r",
+                     "range": {
+                        "start": {
+                           "line": 10,
+                           "character": 0
+                        },
+                        "end": {
+                           "line": 10,
+                           "character": 0
+                        }
+                     }
+                  }
+               ],
+               "textDocument": {
+                  "version": 2,
+                  "uri": "$URI{main.adb}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "position": {
+                  "line": 10,
+                  "character": 1
+               },
+               "textDocument": {
+                  "uri": "$URI{main.adb}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "id": 5,
+            "method": "textDocument/completion"
+         },
+         "wait": [
+            {
+               "id": 5,
+               "result": {
+                  "isIncomplete": false,
+                  "items": [
+                     {
+                        "insertText": "raise",
+                        "kind": 14,
+                        "insertTextFormat": 1,
+                        "additionalTextEdits": [],
+                        "label": "raise"
+                     },
+                     {
+                        "insertText": "range",
+                        "kind": 14,
+                        "insertTextFormat": 1,
+                        "additionalTextEdits": [],
+                        "label": "range"
+                     },
+                     {
+                        "insertText": "record",
+                        "kind": 14,
+                        "insertTextFormat": 1,
+                        "additionalTextEdits": [],
+                        "label": "record"
+                     },
+                     {
+                        "insertText": "rem",
+                        "kind": 14,
+                        "insertTextFormat": 1,
+                        "additionalTextEdits": [],
+                        "label": "rem"
+                     },
+                     {
+                        "insertText": "renames",
+                        "kind": 14,
+                        "insertTextFormat": 1,
+                        "additionalTextEdits": [],
+                        "label": "renames"
+                     },
+                     {
+                        "insertText": "requeue",
+                        "kind": 14,
+                        "insertTextFormat": 1,
+                        "additionalTextEdits": [],
+                        "label": "requeue"
+                     },
+                     {
+                        "insertText": "return",
+                        "kind": 14,
+                        "insertTextFormat": 1,
+                        "additionalTextEdits": [],
+                        "label": "return"
+                     },
+                     {
+                        "insertText": "reverse",
+                        "kind": 14,
+                        "insertTextFormat": 1,
+                        "additionalTextEdits": [],
+                        "label": "reverse"
+                     }
+                  ]
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{main.adb}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didClose"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": 7,
+            "method": "shutdown"
+         },
+         "wait": [
+            {
+               "id": 7,
+               "result": null
+            }
+         ]
+      }
+   },
+   {
+      "stop": {
+         "exit_code": 0
+      }
+   }
+]

--- a/testsuite/ada_lsp/completion.keywords/test.yaml
+++ b/testsuite/ada_lsp/completion.keywords/test.yaml
@@ -1,0 +1,1 @@
+title: 'completion.keywords'


### PR DESCRIPTION
In order to avoid proposing keywords right after a '(' for instance.

Aborts basic test for keyword completion has also been added.