### PR TITLE
Rework highlighting

### DIFF
--- a/integration/vscode/ada/advanced/ada.tmLanguage.json
+++ b/integration/vscode/ada/advanced/ada.tmLanguage.json
@@ -267,13 +267,41 @@
 					"name": "punctuation.ada",
 					"match": ","
 				},
+				{
+					"match": "(?i)\\b(null)\\s+(record)\\b",
+					"captures": {
+						"1": { "name": "storage.modifier.ada" },
+						"2": { "name": "storage.modifier.ada" }
+					}
+				},
+				{
+					"begin": "(?i)\\brecord\\b",
+					"end": "(?i)\\b(end)\\s+(record)\\b",
+					"beginCaptures": {
+						"0": { "name": "storage.modifier.ada" }
+					},
+					"endCaptures": {
+						"1": { "name": "keyword.ada" },
+						"2": { "name": "storage.modifier.ada" }
+					},
+					"patterns": [
+						{ "include": "#component_item" }
+					]
+				},
+				{
+					"match": "(?i)\\bprivate\\b",
+					"captures": {
+						"0": { "name": "storage.visibility.ada" }
+					}
+				},
 				{ "include": "#aspect_definition" },
-				{ "include": "#aspect_mark" }
+				{ "include": "#aspect_mark" },
+				{ "include": "#comment" }
 			]
 		},
 		"assignment_statement": {
 			"name": "meta.statement.assignment.ada",
-			"begin": "\\b(.+)\\s*(:=)",
+			"begin": "\\b((?:\\w|\\d|\\.|_|\\(|\\)|\"|'|\\s)+)\\s*(:=)",
 			"end": ";",
 			"beginCaptures": {
 				"1": {
@@ -281,6 +309,16 @@
 						{
 							"match": "((?:\\w|\\d|\\.|_)+)",
 							"name": "variable.name.ada"
+						},
+						{
+							"begin": "\\(",
+							"end": "\\)",
+							"captures": {
+								"0": { "name": "punctuation.ada" }
+							},
+							"patterns": [
+								{ "include": "#expression" }
+							]
 						}
 					]
 				},
@@ -290,7 +328,8 @@
 				"0": { "name": "punctuation.ada" }
 			},
 			"patterns": [
-				{ "include": "#expression" }
+				{ "include": "#expression" },
+				{ "include": "#comment" }
 			]
 		},
 		"attribute": {
@@ -328,6 +367,7 @@
 				{ "include": "#subtype_declaration" },
 				{ "include": "#exception_declaration" },
 				{ "include": "#object_declaration" },
+				{ "include": "#single_protected_declaration" },
 				{ "include": "#single_task_declaration" },
 				{ "include": "#subprogram_specification" },
 				{ "include": "#package_declaration" },
@@ -486,20 +526,7 @@
 						{ "include": "#expression" }
 					]
 				},
-				{
-					"begin": "(?i)\\brange\\b",
-					"end": "(?=;)",
-					"beginCaptures": {
-						"0": { "name": "storage.modifier.ada" }
-					},
-					"patterns": [
-						{
-							"name": "keyword.ada",
-							"match": "\\.\\."
-						},
-						{ "include": "#expression" }
-					]
-				}
+				{ "include": "#range_constraint" }
 			]
 		},
 		"component_declaration": {
@@ -651,34 +678,18 @@
 			"name": "meta.declaration.type.definition.derived.ada",
 			"patterns": [
 				{
-					"match": "(?i)\\b(new)\\s+((?:\\w|\\d|\\.|_)+)\\b",
-					"captures": {
-						"1": { "name": "storage.modifier.ada" },
-						"2": { "patterns": [ { "include": "#subtype_mark" } ] }
-					}
-				},
-				{
-					"begin": "(?i)\\b(with)\\s+(record)\\b",
-					"end": "(?i)\\b(end)\\s+(record)\\b",
+					"begin": "(?i)\\bnew\\b",
 					"beginCaptures": {
-						"1": { "name": "storage.modifier.ada" },
-						"2": { "name": "storage.modifier.ada" }
+						"0": { "name": "storage.modifier.ada" }
 					},
-					"endCaptures": {
-						"1": { "name": "keyword.ada" },
-						"2": { "name": "storage.modifier.ada" }
-					},
+					"end": "(?i)(?=(\\bwith\\b|;))",
 					"patterns": [
-						{ "include": "#component_item" }
+						{
+							"name": "storage.modifier.ada",
+							"match": "(?i)\\band\\b"
+						},
+						{ "include": "#subtype_mark" }
 					]
-				},
-				{
-					"match": "(?i)\\b(with)\\s+(null)\\s+(record)\\b",
-					"captures": {
-						"1": { "name": "storage.modifier.ada" },
-						"2": { "name": "storage.modifier.ada" },
-						"3": { "name": "storage.modifier.ada" }
-					}
 				},
 				{
 					"name": "storage.modifier.ada",
@@ -687,13 +698,6 @@
 				{
 					"name": "storage.visibility.ada",
 					"match": "(?i)\\bprivate\\b"
-				},
-				{
-					"match": "(?i)\\b(with)\\s+(private)\\b",
-					"captures": {
-						"1": { "name": "storage.modifier.ada" },
-						"2": { "name": "storage.visibility.ada" }
-					}
 				},
 				{ "include": "#subtype_mark" }
 			]
@@ -872,7 +876,10 @@
 						{ "include": "#expression" }
 					]
 				},
-				{ "include": "#label" }
+				{
+					"match": "(?:\\w|\\d|_)+",
+					"name": "entity.name.label.ada"
+				}
 			]
 		},
 		"exponent_part": {
@@ -887,8 +894,12 @@
 			"name": "meta.expression.ada",
 			"patterns": [
 				{
-					"match": "(?i)\\b(null)\\b",
+					"match": "(?i)\\bnull\\b",
 					"name": "constant.language.ada"
+				},
+				{
+					"match": "=>(\\+)?",
+					"name": "keyword.other.ada"
 				},
 				{
 					"begin": "\\(",
@@ -900,59 +911,26 @@
 						{ "include": "#expression" }
 					]
 				},
-				{ "include": "#comment" },
+				{
+					"match": ",",
+					"name": "punctuation.ada"
+				},
+				{
+					"match": "\\.\\.",
+					"name": "keyword.ada"
+				},
 				{ "include": "#value" },
+				{ "include": "#attribute" },
+				{ "include": "#comment" },
 				{ "include": "#operator" },
 				{
-					"match": "(?i)\\b(and(?:\\s+then)?|or(?:\\s+else)?|xor)\\b",
+					"match": "(?i)\\b(and|or|xor)\\b",
+					"name": "keyword.ada"
+				},
+				{
+					"match": "(?i)\\b(if|then|else|elsif|in|for|(?<!\\.)all|some|\\.\\.|delta|with)\\b",
 					"name": "keyword.ada"
 				}
-			]
-		},
-		"fixed_point_definition": {
-			"name": "meta.declaration.type.definition.fixed-point.ada",
-			"begin": "(?i)\\bdelta\\b",
-			"end": "(?i)(?=(with|;))",
-			"beginCaptures": {
-				"0": { "name": "storage.modifier.ada" }
-			},
-			"patterns": [
-				{
-					"name": "storage.modifier.ada",
-					"match": "(?i)\\b(digits|range)\\b"
-				},
-				{
-					"name": "keyword.ada",
-					"match": "\\.\\."
-				},
-				{
-					"name": "keyword.modifier.unknown.ada",
-					"match": "<>"
-				},
-				{ "include": "#expression" }
-			]
-		},
-		"floating_point_definition": {
-			"name": "meta.declaration.type.definition.floating-point.ada",
-			"begin": "(?i)\\bdigits\\b",
-			"end": "(?i)(?=(with|;))",
-			"beginCaptures": {
-				"0": { "name": "storage.modifier.ada" }
-			},
-			"patterns": [
-				{
-					"name": "storage.modifier.ada",
-					"match": "(?i)\\brange\\b"
-				},
-				{
-					"name": "keyword.ada",
-					"match": "\\.\\."
-				},
-				{
-					"name": "keyword.modifier.unknown.ada",
-					"match": "<>"
-				},
-				{ "include": "#expression" }
 			]
 		},
 		"for_loop_statement": {
@@ -965,7 +943,7 @@
 			"endCaptures": {
 				"1": { "name": "keyword.control.ada" },
 				"2": { "name": "keyword.control.ada" },
-				"3": { "patterns": [ { "include": "#label" } ] },
+				"3": { "name": "entity.name.label.ada" },
 				"4": { "name": "punctuation.ada" }
 			},
 			"patterns": [
@@ -1008,12 +986,17 @@
 		},
 		"function_body": {
 			"name": "meta.declaration.function.body.ada",
-			"begin": "(?i)\\b(overriding\\s+)?(function)\\s+((\\w|\\d|\\.|_)+)\\b",
-			"end": "(?i)(?:\\b(end)\\s+(\\3)\\s*)?(;)",
+			"begin": "(?i)\\b(overriding\\s+)?(function)\\s+(?:((?:\\w|\\d|\\.|_)+\\b)|(\".+\"))",
+			"end": "(?i)(?:\\b(end)\\s+(\\3|\\4)\\s*)?(;)",
 			"beginCaptures": {
 				"1": { "name": "storage.visibility.ada" },
 				"2": { "name": "keyword.ada" },
-				"3": { "name": "entity.name.function.ada" }
+				"3": { "name": "entity.name.function.ada" },
+				"4": {
+					"patterns": [
+						{ "include": "#string_literal" }
+					]
+				}
 			},
 			"endCaptures": {
 				"1": { "name": "keyword.ada" },
@@ -1065,49 +1048,16 @@
 								"0": { "name": "storage.modifier.ada" }
 							}
 						},
-						{ "include": "#declarative_item" }
+						{ "include": "#declarative_item" },
+						{ "include": "#subprogram_renaming_declaration" },
+						{ "include": "#expression" }
 					]
 				}
 			]
 		},
 		"function_specification": {
-			"name": "meta.declaration.function.specification.ada",
-			"begin": "(?i)\\b(overriding\\s+)?(function)\\s+(?:((?:\\w|\\d|\\.|_)+\\b)|(\".+\"))",
-			"end": ";",
-			"beginCaptures": {
-				"1": { "name": "storage.visibility.ada" },
-				"2": { "name": "keyword.ada" },
-				"3": { "name": "entity.name.function.ada" },
-				"4": {
-					"patterns": [
-						{ "include": "#string_literal" }
-					]
-				}
-			},
-			"endCaptures": {
-				"0": { "name": "punctuation.ada" }
-			},
 			"patterns": [
-				{
-					"begin": "(?i)\\bis\\b",
-					"beginCaptures": {
-						"0": { "name": "keyword.ada" }
-					},
-					"end": "(?=;)",
-					"patterns": [
-						{
-							"name": "meta.declaration.function.abstract.ada",
-							"match": "(?i)\\babstract\\b",
-							"captures": {
-								"0": { "name": "storage.modifier.ada" }
-							}
-						}
-					]
-				},
-				{ "include": "#aspect_specification" },
-				{ "include": "#result_profile" },
-				{ "include": "#subprogram_renaming_declaration" },
-				{ "include": "#parameter_profile" }
+				{ "include": "#function_body" }
 			]
 		},
 		"goto_statement": {
@@ -1203,7 +1153,7 @@
 			"patterns": [
 				{
 					"begin": "(?i)\\belsif\\b",
-					"end": "(?i)(?:(?<!\\sand)\\s*(?=then))",
+					"end": "(?i)(?:(?<!\\sand)\\s+(?=then))",
 					"beginCaptures": {
 						"0": { "name": "keyword.control.ada" }
 					},
@@ -1270,7 +1220,7 @@
 			"patterns": [
 				{
 					"name": "keyword.ada",
-					"match": "(?i)\\b(abort|abs|accept|all|and|at|begin|body|declare|delay|end|entry|exception|function|generic|in|is|mod|new|not|null|of|or|others|out|overriding|package|pragma|procedure|range|record|rem|renames|requeue|reverse|select|separate|some|subtype|then|type|use|when|with|xor)\\b"
+					"match": "(?i)\\b(abort|abs|accept|all|and|at|begin|body|declare|delay|end|entry|exception|function|generic|in|is|mod|new|not|null|of|or|others|out|package|pragma|procedure|range|record|rem|renames|requeue|reverse|select|separate|some|subtype|then|type|use|when|with|xor)\\b"
 				},
 				{
 					"name": "keyword.control.ada",
@@ -1282,7 +1232,7 @@
 				},
 				{
 					"name": "storage.visibility.ada",
-					"match": "(?i)\\b(private)\\b"
+					"match": "(?i)\\b(private|overriding)\\b"
 				},
 				{
 					"name": "keyword.modifier.unknown.ada",
@@ -1323,7 +1273,7 @@
 		},
 		"label": {
 			"name": "meta.label.ada",
-			"match": "(<<)?((?:\\w|\\d|_)+)(:|>>)",
+			"match": "(<<)?((?:\\w|\\d|_)+)\\s*(:[^=]|>>)",
 			"captures": {
 				"1": { "name": "punctuation.label.ada" },
 				"2": { "name": "entity.name.label.ada" },
@@ -1373,7 +1323,7 @@
 		},
 		"object_declaration": {
 			"name": "meta.declaration.object.ada",
-			"begin": "(?i)\\b((?:\\w|\\d|_)+(?:\\s*,\\s*(?:\\w|\\d|_)+)?)\\s*(:)",
+			"begin": "(?i)\\b((?:\\w|\\d|_)+(?:\\s*,\\s*(?:\\w|\\d|_)+)*)\\s*(:)",
 			"end": "(;)",
 			"beginCaptures": {
 				"1": {
@@ -1410,6 +1360,7 @@
 							"name": "storage.visibility.ada",
 							"match": "(?i)\\baliased\\b"
 						},
+						{ "include": "#aspect_specification" },
 						{ "include": "#subtype_mark" }
 					]
 				},
@@ -1417,12 +1368,16 @@
 					"begin": "(?<=:=)",
 					"end": "(?=;)",
 					"patterns": [
+						{ "include": "#aspect_specification" },
 						{ "include": "#expression" }
 					]
 				},
 				{
 					"begin": "(?<=renames)",
-					"end": "(?=;)"
+					"end": "(?=;)",
+					"patterns": [
+						{ "include": "#aspect_specification" }
+					]
 				}
 			]
 		},
@@ -1451,11 +1406,21 @@
 			},
 			"patterns": [
 				{
-					"begin": "(?i)\\bis\\b",
+					"begin": "(?i)\\bbegin\\b",
 					"beginCaptures": {
 						"0": { "name": "keyword.ada" }
 					},
 					"end": "(?i)\\b(?=end)\\b",
+					"patterns": [
+						{ "include": "#handled_sequence_of_statements" }
+					]
+				},
+				{
+					"begin": "(?i)\\bis\\b",
+					"beginCaptures": {
+						"0": { "name": "keyword.ada" }
+					},
+					"end": "(?i)(?=(\\bbegin\\b|\\bend\\b))",
 					"patterns": [
 						{ 
 							"match": "(?i)\\bprivate\\b",
@@ -1464,7 +1429,8 @@
 						{ "include": "#declarative_item" },
 						{ "include": "#comment" }
 					]
-				}
+				},
+				{ "include": "#aspect_specification" }
 			]
 		},
 		"package_declaration": {
@@ -1497,12 +1463,6 @@
 					},
 					"end": "(?=(end|;))",
 					"patterns": [
-						{ 
-							"match": "(?i)\\bprivate\\b",
-							"name": "keyword.ada"
-						},
-						{ "include": "#basic_declarative_item" },
-						{ "include": "#comment" },
 						{
 							"name": "meta.declaration.package.generic.ada",
 							"begin": "(?i)\\bnew\\b",
@@ -1514,9 +1474,16 @@
 								{ "include": "#package_mark" },
 								{ "include": "#actual_parameter_part" }
 							]
-						}
+						},
+						{ 
+							"match": "(?i)\\bprivate\\b",
+							"name": "keyword.ada"
+						},
+						{ "include": "#basic_declarative_item" },
+						{ "include": "#comment" }
 					]
-				}
+				},
+				{ "include": "#aspect_specification" }
 			]
 		},
 		"parameter_association": {
@@ -1556,10 +1523,6 @@
 					},
 					"patterns": [
 						{
-							"name": "storage.visibility.ada",
-							"match": "(?i)\\b(access|aliased|not\\s+null)"
-						},
-						{
 							"name": "keyword.ada",
 							"match": "(?i)\\b(in|out)\\b"
 						},
@@ -1583,7 +1546,8 @@
 				{
 					"name": "variable.parameter.ada",
 					"match": "\\b(?:\\w|\\d|\\.|_)+\\b"
-				}
+				},
+				{ "include": "#comment" }
 			]
 		},
 		"pragma": {
@@ -1657,7 +1621,8 @@
 				},
 				{ "include": "#subprogram_renaming_declaration" },
 				{ "include": "#aspect_specification" },
-				{ "include": "#parameter_profile" }
+				{ "include": "#parameter_profile" },
+				{ "include": "#comment" }
 			]
 		},
 		"procedure_call_statement": {
@@ -1671,33 +1636,14 @@
 				"0": { "name": "punctuation.ada" }
 			},
 			"patterns": [
-				{ "include": "#actual_parameter_part" }
+				{ "include": "#attribute" },
+				{ "include": "#actual_parameter_part" },
+				{ "include": "#comment" }
 			]
 		},
 		"procedure_specification": {
-			"name": "meta.declaration.procedure.specification.ada",
-			"begin": "(?i)\\b(overriding\\s+)?(procedure)\\s+((?:\\w|\\d|\\.|_)+)\\b",
-			"end": ";",
-			"beginCaptures": {
-				"1": { "name": "storage.visibility.ada" },
-				"2": { "name": "keyword.ada" },
-				"3": { "name": "entity.name.function.ada" }
-			},
-			"endCaptures": {
-				"0": { "name": "punctuation.ada" }
-			},
 			"patterns": [
-				{
-					"name": "meta.declaration.procedure.modified.ada",
-					"match": "(?i)\\b(is)\\s+(null|abstract)\\b",
-					"captures": {
-						"1": { "name": "keyword.ada" },
-						"2": { "name": "storage.modifier.ada" }
-					}
-				},
-				{ "include": "#subprogram_renaming_declaration" },
-				{ "include": "#aspect_specification" },
-				{ "include": "#parameter_profile" }
+				{ "include": "#procedure_body" }
 			]
 		},
 		"protected_body": {
@@ -1725,6 +1671,15 @@
 						{ "include": "#protected_operation_item" }
 					]
 				}
+			]
+		},
+		"protected_element_declaration": {
+			"patterns": [
+				{ "include": "#subprogram_specification" },
+				{ "include": "#aspect_clause" },
+				{ "include": "#entry_declaration" },
+				{ "include": "#component_declaration" },
+				{ "include": "#pragma" }
 			]
 		},
 		"protected_operation_item": {
@@ -1808,6 +1763,24 @@
 				}
 			]
 		},
+		"range_constraint": {
+			"begin": "(?i)\\brange\\b",
+			"end": "(?=(\\bwith\\b|;))",
+			"beginCaptures": {
+				"0": { "name": "storage.modifier.ada" }
+			},
+			"patterns": [
+				{
+					"name": "keyword.ada",
+					"match": "\\.\\."
+				},
+				{
+					"name": "keyword.modifier.unknown.ada",
+					"match": "<>"
+				},
+				{ "include": "#expression" }
+			]
+		},
 		"relational_operator": {
 			"name": "keyword.operator.relational.ada",
 			"match": "(=|/=|<|<=|>|>=)"
@@ -1829,9 +1802,9 @@
 			]
 		},
 		"real_type_definition": {
+			"name": "meta.declaration.type.definition.real-type.ada",
 			"patterns": [
-				{ "include": "#floating_point_definition" },
-				{ "include": "#fixed_point_definition" }
+				{ "include": "#scalar_constraint" }
 			]
 		},
 		"record_type_definition": {
@@ -1871,6 +1844,7 @@
 			]
 		},
 		"regular_type_declaration": {
+			"name": "meta.declaration.type.definition.regular.ada",
 			"begin": "(?i)\\b(type)\\b",
 			"end": ";",
 			"beginCaptures": {
@@ -1882,11 +1856,12 @@
 			"patterns": [
 				{
 					"begin": "(?i)\\bis\\b",
-					"end": "(?i)(?=(with(?!\\s+(private|(null\\s+)?record))|;))",
+					"end": "(?i)(?=(with(?!\\s+(private))|;))",
 					"beginCaptures": {
 						"0": { "name": "keyword.ada" }
 					},
 					"patterns": [
+						
 						{ "include": "#type_definition" }
 					]
 				},
@@ -1898,7 +1873,6 @@
 						{ "include": "#subtype_mark" }
 					]
 				},
-				
 				{ "include": "#aspect_specification" }
 			]
 		},
@@ -1978,13 +1952,16 @@
 			"name": "meta.declaration.constraint.scalar.ada",
 			"patterns": [
 				{
-					"name": "storage.modifier.ada",
-					"match": "(?i)\\b(digits|range|delta)\\b"
+					"begin": "(?i)\\b(digits|delta)\\b",
+					"end": "(?i)(?=\\brange\\b|\\bdigits\\b|\\bwith\\b|;)",
+					"beginCaptures": {
+						"1": { "name": "storage.modifier.ada" }
+					},
+					"patterns": [
+						{ "include": "#expression" }
+					]
 				},
-				{
-					"name": "keyword.ada",
-					"match": "\\.\\."
-				},
+				{ "include": "#range_constraint" },
 				{ "include": "#expression" }
 			]
 		},
@@ -2039,21 +2016,8 @@
 			]
 		},
 		"signed_integer_type_definition": {
-			"begin": "(?i)\\b(range)\\b",
-			"end": "(?i)(?=(with|;))",
-			"beginCaptures": {
-				"1": { "name": "storage.modifier.ada" }
-			},
 			"patterns": [
-				{
-					"name": "keyword.ada",
-					"match": "\\.\\."
-				},
-				{
-					"name": "keyword.modifier.unknown.ada",
-					"match": "<>"
-				},
-				{ "include": "#expression" }
+				{ "include": "#range_constraint" }
 			]
 		},
 		"simple_loop_statement": {
@@ -2071,6 +2035,53 @@
 			},
 			"patterns": [
 				{ "include": "#statement" }
+			]
+		},
+		"single_protected_declaration": {
+			"name": "meta.declaration.protected.ada",
+			"begin": "(?i)\\b(protected)\\s+((?:\\w|\\d|_)+)\\b",
+			"end": "(?i)(?:\\b(end)\\s*(\\s\\2)?\\s*)?(;)",
+			"beginCaptures": {
+				"1": { "name": "keyword.ada" },
+				"2": { "name": "entity.name.protected.ada" }
+			},
+			"endCaptures": {
+				"1": { "name": "keyword.ada" },
+				"2": { "name": "entity.name.protected.ada" },
+				"3": { "name": "punctuation.ada" }
+			},
+			"patterns": [
+				{
+					"begin": "(?i)\\bis\\b",
+					"end": "(?i)(?=(\\bend\\b|;))",
+					"beginCaptures": {
+						"0": {"name": "keyword.ada"}
+					},
+					"patterns": [
+						{
+							"begin": "(?i)\\bnew\\b",
+							"end": "(?i)\\bwith\\b",
+							"captures": {
+								"0": { "name": "keyword.ada" }
+							},
+							"patterns": [
+								{
+									"match": "(?i)\\band\\b",
+									"name": "keyword.ada"
+								},
+								{ "include": "#subtype_mark" },
+								{ "include": "#comment" }
+							]
+						},
+						{
+							"match": "(?i)\\bprivate\\b",
+							"name": "keyword.ada"
+						},
+						{ "include": "#protected_element_declaration" },
+						{ "include": "#comment" }
+					]
+				},
+				{ "include": "#comment" }
 			]
 		},
 		"single_task_declaration": {
@@ -2233,25 +2244,55 @@
 		},
 		"subtype_indication": {
 			"name": "meta.declaration.indication.subtype.ada",
-			"match": "(?i)\\b((?:\\w|\\d|_)+)(\\s+[^\\s\\((with)][^;]+)?\\b",
-			"captures": {
-				"1": { "patterns": [ { "include": "#subtype_mark" } ] },
-				"2": { "patterns": [ { "include": "#scalar_constraint" } ] }
-			}
+			"patterns": [
+				{ "include": "#scalar_constraint" },
+				{ "include": "#subtype_mark" }
+			]
 		},
 		"subtype_mark": {
-			"name": "entity.name.type.ada",
-			"match": "\\b(?:\\w|\\d|\\.|_)+\\b",
-			"captures": {
-				"0": {
+			"patterns": [
+				{
+					"name": "storage.visibility.ada",
+					"match": "(?i)\\b(access|aliased|not\\s+null|constant)\\b"
+				},
+				{ "include": "#attribute" },
+				{ "include": "#actual_parameter_part" },
+				{
+					"begin": "(?i)\\b(procedure|function)\\b",
+					"beginCaptures": {
+						"0": { "name": "keyword.ada" }
+					},
+					"end": "(?=(;|\\)))",
 					"patterns": [
+						{ "include": "#parameter_profile" },
 						{
-							"name": "punctuation.ada",
-							"match": "[_.]"
+							"begin": "(?i)\\breturn\\b",
+							"end": "(?=(;|\\)))",
+							"beginCaptures": {
+								"0": { "name": "keyword.ada" }
+							},
+							"patterns": [
+								{ "include": "#subtype_mark" }
+							]
 						}
 					]
-				}
-			}
+				},
+				{
+					"name": "entity.name.type.ada",
+					"match": "\\b(?:\\w|\\d|\\.|_)+\\b",
+					"captures": {
+						"0": {
+							"patterns": [
+								{
+									"name": "punctuation.ada",
+									"match": "[_.]"
+								}
+							]
+						}
+					}
+				},
+				{ "include": "#comment" }
+			]
 		},
 		"task_body": {
 			"name": "meta.declaration.task.body.ada",

--- a/integration/vscode/ada/testsuite_grammar/nesting/main.adb.snap.advanced
+++ b/integration/vscode/ada/testsuite_grammar/nesting/main.adb.snap.advanced
@@ -19,54 +19,64 @@
 #             ^^ source.ada meta.declaration.procedure.body.ada meta.declaration.package.specification.ada keyword.ada
 >      procedure C is begin null; end C;
 #^^^^^^ source.ada meta.declaration.procedure.body.ada meta.declaration.package.specification.ada
-#      ^^^^^^^^^ source.ada meta.declaration.procedure.body.ada meta.declaration.package.specification.ada meta.declaration.procedure.specification.ada keyword.ada
-#               ^ source.ada meta.declaration.procedure.body.ada meta.declaration.package.specification.ada meta.declaration.procedure.specification.ada
-#                ^ source.ada meta.declaration.procedure.body.ada meta.declaration.package.specification.ada meta.declaration.procedure.specification.ada entity.name.function.ada
-#                 ^^^^^^^^^^^^^^ source.ada meta.declaration.procedure.body.ada meta.declaration.package.specification.ada meta.declaration.procedure.specification.ada
-#                               ^ source.ada meta.declaration.procedure.body.ada meta.declaration.package.specification.ada meta.declaration.procedure.specification.ada punctuation.ada
-#                                ^ source.ada meta.declaration.procedure.body.ada meta.declaration.package.specification.ada
-#                                 ^^^^^ source.ada meta.declaration.procedure.body.ada meta.declaration.package.specification.ada
-#                                      ^ source.ada meta.declaration.procedure.body.ada meta.declaration.package.specification.ada punctuation.ada
+#      ^^^^^^^^^ source.ada meta.declaration.procedure.body.ada meta.declaration.package.specification.ada meta.declaration.procedure.body.ada keyword.ada
+#               ^ source.ada meta.declaration.procedure.body.ada meta.declaration.package.specification.ada meta.declaration.procedure.body.ada
+#                ^ source.ada meta.declaration.procedure.body.ada meta.declaration.package.specification.ada meta.declaration.procedure.body.ada entity.name.function.ada
+#                 ^ source.ada meta.declaration.procedure.body.ada meta.declaration.package.specification.ada meta.declaration.procedure.body.ada
+#                  ^^ source.ada meta.declaration.procedure.body.ada meta.declaration.package.specification.ada meta.declaration.procedure.body.ada keyword.ada
+#                    ^ source.ada meta.declaration.procedure.body.ada meta.declaration.package.specification.ada meta.declaration.procedure.body.ada
+#                     ^^^^^ source.ada meta.declaration.procedure.body.ada meta.declaration.package.specification.ada meta.declaration.procedure.body.ada keyword.ada
+#                          ^ source.ada meta.declaration.procedure.body.ada meta.declaration.package.specification.ada meta.declaration.procedure.body.ada
+#                           ^^^^ source.ada meta.declaration.procedure.body.ada meta.declaration.package.specification.ada meta.declaration.procedure.body.ada meta.statement.null.ada keyword.ada
+#                               ^ source.ada meta.declaration.procedure.body.ada meta.declaration.package.specification.ada meta.declaration.procedure.body.ada meta.statement.null.ada punctuation.ada
+#                                ^ source.ada meta.declaration.procedure.body.ada meta.declaration.package.specification.ada meta.declaration.procedure.body.ada
+#                                 ^^^ source.ada meta.declaration.procedure.body.ada meta.declaration.package.specification.ada meta.declaration.procedure.body.ada keyword.ada
+#                                    ^ source.ada meta.declaration.procedure.body.ada meta.declaration.package.specification.ada meta.declaration.procedure.body.ada
+#                                     ^ source.ada meta.declaration.procedure.body.ada meta.declaration.package.specification.ada meta.declaration.procedure.body.ada entity.name.function.ada
+#                                      ^ source.ada meta.declaration.procedure.body.ada meta.declaration.package.specification.ada meta.declaration.procedure.body.ada punctuation.ada
 >   end B;
-#^^^ source.ada meta.declaration.procedure.body.ada
-#   ^^^ source.ada meta.declaration.procedure.body.ada keyword.ada
-#      ^^ source.ada meta.declaration.procedure.body.ada
-#        ^ source.ada meta.declaration.procedure.body.ada punctuation.ada
+#^^^ source.ada meta.declaration.procedure.body.ada meta.declaration.package.specification.ada
+#   ^^^ source.ada meta.declaration.procedure.body.ada meta.declaration.package.specification.ada keyword.ada
+#      ^ source.ada meta.declaration.procedure.body.ada meta.declaration.package.specification.ada
+#       ^ source.ada meta.declaration.procedure.body.ada meta.declaration.package.specification.ada entity.name.package.ada
+#        ^ source.ada meta.declaration.procedure.body.ada meta.declaration.package.specification.ada punctuation.ada
 >
 >   package body B is
-#^^^ source.ada
-#   ^^^^^^^ source.ada meta.declaration.package.body.ada keyword.ada
-#          ^ source.ada meta.declaration.package.body.ada
-#           ^^^^ source.ada meta.declaration.package.body.ada keyword.ada
-#               ^ source.ada meta.declaration.package.body.ada
-#                ^ source.ada meta.declaration.package.body.ada entity.name.package.ada
-#                 ^ source.ada meta.declaration.package.body.ada
-#                  ^^ source.ada meta.declaration.package.body.ada keyword.ada
+#^^^ source.ada meta.declaration.procedure.body.ada
+#   ^^^^^^^ source.ada meta.declaration.procedure.body.ada meta.declaration.package.body.ada keyword.ada
+#          ^ source.ada meta.declaration.procedure.body.ada meta.declaration.package.body.ada
+#           ^^^^ source.ada meta.declaration.procedure.body.ada meta.declaration.package.body.ada keyword.ada
+#               ^ source.ada meta.declaration.procedure.body.ada meta.declaration.package.body.ada
+#                ^ source.ada meta.declaration.procedure.body.ada meta.declaration.package.body.ada entity.name.package.ada
+#                 ^ source.ada meta.declaration.procedure.body.ada meta.declaration.package.body.ada
+#                  ^^ source.ada meta.declaration.procedure.body.ada meta.declaration.package.body.ada keyword.ada
 >      procedure C is begin null; end C;
-#^^^^^^ source.ada meta.declaration.package.body.ada
-#      ^^^^^^^^^ source.ada meta.declaration.package.body.ada meta.declaration.procedure.body.ada keyword.ada
-#               ^ source.ada meta.declaration.package.body.ada meta.declaration.procedure.body.ada
-#                ^ source.ada meta.declaration.package.body.ada meta.declaration.procedure.body.ada entity.name.function.ada
-#                 ^ source.ada meta.declaration.package.body.ada meta.declaration.procedure.body.ada
-#                  ^^ source.ada meta.declaration.package.body.ada meta.declaration.procedure.body.ada keyword.ada
-#                    ^ source.ada meta.declaration.package.body.ada meta.declaration.procedure.body.ada
-#                     ^^^^^ source.ada meta.declaration.package.body.ada meta.declaration.procedure.body.ada keyword.ada
-#                          ^ source.ada meta.declaration.package.body.ada meta.declaration.procedure.body.ada
-#                           ^^^^ source.ada meta.declaration.package.body.ada meta.declaration.procedure.body.ada meta.statement.null.ada keyword.ada
-#                               ^ source.ada meta.declaration.package.body.ada meta.declaration.procedure.body.ada meta.statement.null.ada punctuation.ada
-#                                ^ source.ada meta.declaration.package.body.ada meta.declaration.procedure.body.ada
-#                                 ^^^ source.ada meta.declaration.package.body.ada meta.declaration.procedure.body.ada keyword.ada
-#                                    ^ source.ada meta.declaration.package.body.ada meta.declaration.procedure.body.ada
-#                                     ^ source.ada meta.declaration.package.body.ada meta.declaration.procedure.body.ada entity.name.function.ada
-#                                      ^ source.ada meta.declaration.package.body.ada meta.declaration.procedure.body.ada punctuation.ada
+#^^^^^^ source.ada meta.declaration.procedure.body.ada meta.declaration.package.body.ada
+#      ^^^^^^^^^ source.ada meta.declaration.procedure.body.ada meta.declaration.package.body.ada meta.declaration.procedure.body.ada keyword.ada
+#               ^ source.ada meta.declaration.procedure.body.ada meta.declaration.package.body.ada meta.declaration.procedure.body.ada
+#                ^ source.ada meta.declaration.procedure.body.ada meta.declaration.package.body.ada meta.declaration.procedure.body.ada entity.name.function.ada
+#                 ^ source.ada meta.declaration.procedure.body.ada meta.declaration.package.body.ada meta.declaration.procedure.body.ada
+#                  ^^ source.ada meta.declaration.procedure.body.ada meta.declaration.package.body.ada meta.declaration.procedure.body.ada keyword.ada
+#                    ^ source.ada meta.declaration.procedure.body.ada meta.declaration.package.body.ada meta.declaration.procedure.body.ada
+#                     ^^^^^ source.ada meta.declaration.procedure.body.ada meta.declaration.package.body.ada meta.declaration.procedure.body.ada keyword.ada
+#                          ^ source.ada meta.declaration.procedure.body.ada meta.declaration.package.body.ada meta.declaration.procedure.body.ada
+#                           ^^^^ source.ada meta.declaration.procedure.body.ada meta.declaration.package.body.ada meta.declaration.procedure.body.ada meta.statement.null.ada keyword.ada
+#                               ^ source.ada meta.declaration.procedure.body.ada meta.declaration.package.body.ada meta.declaration.procedure.body.ada meta.statement.null.ada punctuation.ada
+#                                ^ source.ada meta.declaration.procedure.body.ada meta.declaration.package.body.ada meta.declaration.procedure.body.ada
+#                                 ^^^ source.ada meta.declaration.procedure.body.ada meta.declaration.package.body.ada meta.declaration.procedure.body.ada keyword.ada
+#                                    ^ source.ada meta.declaration.procedure.body.ada meta.declaration.package.body.ada meta.declaration.procedure.body.ada
+#                                     ^ source.ada meta.declaration.procedure.body.ada meta.declaration.package.body.ada meta.declaration.procedure.body.ada entity.name.function.ada
+#                                      ^ source.ada meta.declaration.procedure.body.ada meta.declaration.package.body.ada meta.declaration.procedure.body.ada punctuation.ada
 >   end B;
-#^^^ source.ada meta.declaration.package.body.ada
-#   ^^^ source.ada meta.declaration.package.body.ada keyword.ada
-#      ^ source.ada meta.declaration.package.body.ada
-#       ^ source.ada meta.declaration.package.body.ada entity.name.package.ada
-#        ^ source.ada meta.declaration.package.body.ada punctuation.ada
+#^^^ source.ada meta.declaration.procedure.body.ada meta.declaration.package.body.ada
+#   ^^^ source.ada meta.declaration.procedure.body.ada meta.declaration.package.body.ada keyword.ada
+#      ^ source.ada meta.declaration.procedure.body.ada meta.declaration.package.body.ada
+#       ^ source.ada meta.declaration.procedure.body.ada meta.declaration.package.body.ada entity.name.package.ada
+#        ^ source.ada meta.declaration.procedure.body.ada meta.declaration.package.body.ada punctuation.ada
 >begin
-#^^^^^ source.ada keyword.ada
+#^^^^^ source.ada meta.declaration.procedure.body.ada keyword.ada
 >end Main;
-#^^^ source.ada keyword.ada
-#   ^^^^^^^ source.ada
+#^^^ source.ada meta.declaration.procedure.body.ada keyword.ada
+#   ^ source.ada meta.declaration.procedure.body.ada
+#    ^^^^ source.ada meta.declaration.procedure.body.ada entity.name.function.ada
+#        ^ source.ada meta.declaration.procedure.body.ada punctuation.ada

--- a/integration/vscode/ada/testsuite_grammar/types/types.ads.snap.advanced
+++ b/integration/vscode/ada/testsuite_grammar/types/types.ads.snap.advanced
@@ -7,210 +7,210 @@
 >
 >    type Incomplete;
 #^^^^ source.ada meta.declaration.package.specification.ada
-#    ^^^^ source.ada meta.declaration.package.specification.ada keyword.ada
-#        ^ source.ada meta.declaration.package.specification.ada
-#         ^^^^^^^^^^ source.ada meta.declaration.package.specification.ada entity.name.type.ada
-#                   ^ source.ada meta.declaration.package.specification.ada punctuation.ada
+#    ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada keyword.ada
+#        ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#         ^^^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada entity.name.type.ada
+#                   ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada punctuation.ada
 >
 >    type Taggle_Incomplete is tagged;
 #^^^^ source.ada meta.declaration.package.specification.ada
-#    ^^^^ source.ada meta.declaration.package.specification.ada keyword.ada
-#        ^ source.ada meta.declaration.package.specification.ada
-#         ^^^^^^ source.ada meta.declaration.package.specification.ada entity.name.type.ada
-#               ^ source.ada meta.declaration.package.specification.ada entity.name.type.ada punctuation.ada
-#                ^^^^^^^^^^ source.ada meta.declaration.package.specification.ada entity.name.type.ada
-#                          ^ source.ada meta.declaration.package.specification.ada
-#                           ^^ source.ada meta.declaration.package.specification.ada keyword.ada
-#                             ^ source.ada meta.declaration.package.specification.ada
-#                              ^^^^^^ source.ada meta.declaration.package.specification.ada storage.modifier.ada
-#                                    ^ source.ada meta.declaration.package.specification.ada punctuation.ada
+#    ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada keyword.ada
+#        ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#         ^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada entity.name.type.ada
+#               ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada entity.name.type.ada punctuation.ada
+#                ^^^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada entity.name.type.ada
+#                          ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#                           ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada keyword.ada
+#                             ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#                              ^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada storage.modifier.ada
+#                                    ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada punctuation.ada
 >
 >    type Day    is (Mon, Tue, Wed, Thu, Fri, Sat, Sun);
 #^^^^ source.ada meta.declaration.package.specification.ada
-#    ^^^^ source.ada meta.declaration.package.specification.ada keyword.ada
-#        ^ source.ada meta.declaration.package.specification.ada
-#         ^^^ source.ada meta.declaration.package.specification.ada entity.name.type.ada
-#            ^^^^ source.ada meta.declaration.package.specification.ada
-#                ^^ source.ada meta.declaration.package.specification.ada keyword.ada
-#                  ^ source.ada meta.declaration.package.specification.ada
-#                   ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
-#                    ^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada variable.name.ada
-#                       ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
-#                        ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada
-#                         ^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada variable.name.ada
-#                            ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
-#                             ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada
-#                              ^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada variable.name.ada
-#                                 ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
-#                                  ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada
-#                                   ^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada variable.name.ada
-#                                      ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
-#                                       ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada
-#                                        ^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada variable.name.ada
-#                                           ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
-#                                            ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada
-#                                             ^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada variable.name.ada
-#                                                ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
-#                                                 ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada
-#                                                  ^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada variable.name.ada
-#                                                     ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
-#                                                      ^ source.ada meta.declaration.package.specification.ada punctuation.ada
+#    ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada keyword.ada
+#        ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#         ^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada entity.name.type.ada
+#            ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#                ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada keyword.ada
+#                  ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#                   ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
+#                    ^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada variable.name.ada
+#                       ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
+#                        ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada
+#                         ^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada variable.name.ada
+#                            ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
+#                             ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada
+#                              ^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada variable.name.ada
+#                                 ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
+#                                  ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada
+#                                   ^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada variable.name.ada
+#                                      ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
+#                                       ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada
+#                                        ^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada variable.name.ada
+#                                           ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
+#                                            ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada
+#                                             ^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada variable.name.ada
+#                                                ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
+#                                                 ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada
+#                                                  ^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada variable.name.ada
+#                                                     ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
+#                                                      ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada punctuation.ada
 >    type Suit   is 
 #^^^^ source.ada meta.declaration.package.specification.ada
-#    ^^^^ source.ada meta.declaration.package.specification.ada keyword.ada
-#        ^ source.ada meta.declaration.package.specification.ada
-#         ^^^^ source.ada meta.declaration.package.specification.ada entity.name.type.ada
-#             ^^^ source.ada meta.declaration.package.specification.ada
-#                ^^ source.ada meta.declaration.package.specification.ada keyword.ada
-#                  ^^ source.ada meta.declaration.package.specification.ada
+#    ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada keyword.ada
+#        ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#         ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada entity.name.type.ada
+#             ^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#                ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada keyword.ada
+#                  ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
 >        (Clubs, Diamonds, Hearts, Spades);
-#^^^^^^^^ source.ada meta.declaration.package.specification.ada
-#        ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
-#         ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada variable.name.ada
-#              ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
-#               ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada
-#                ^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada variable.name.ada
-#                        ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
-#                         ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada
-#                          ^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada variable.name.ada
-#                                ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
-#                                 ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada
-#                                  ^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada variable.name.ada
-#                                        ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
-#                                         ^ source.ada meta.declaration.package.specification.ada punctuation.ada
+#^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#        ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
+#         ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada variable.name.ada
+#              ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
+#               ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada
+#                ^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada variable.name.ada
+#                        ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
+#                         ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada
+#                          ^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada variable.name.ada
+#                                ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
+#                                 ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada
+#                                  ^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada variable.name.ada
+#                                        ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
+#                                         ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada punctuation.ada
 >    type Gender is 
 #^^^^ source.ada meta.declaration.package.specification.ada
-#    ^^^^ source.ada meta.declaration.package.specification.ada keyword.ada
-#        ^ source.ada meta.declaration.package.specification.ada
-#         ^^^^^^ source.ada meta.declaration.package.specification.ada entity.name.type.ada
-#               ^ source.ada meta.declaration.package.specification.ada
-#                ^^ source.ada meta.declaration.package.specification.ada keyword.ada
-#                  ^^ source.ada meta.declaration.package.specification.ada
+#    ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada keyword.ada
+#        ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#         ^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada entity.name.type.ada
+#               ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#                ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada keyword.ada
+#                  ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
 >        (
-#^^^^^^^^ source.ada meta.declaration.package.specification.ada
-#        ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
+#^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#        ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
 >            M,
-#^^^^^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada
-#            ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada variable.name.ada
-#             ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
+#^^^^^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada
+#            ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada variable.name.ada
+#             ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
 >            F
-#^^^^^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada
-#            ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada variable.name.ada
+#^^^^^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada
+#            ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada variable.name.ada
 >        );
-#^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada
-#        ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
-#         ^ source.ada meta.declaration.package.specification.ada punctuation.ada
+#^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada
+#        ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
+#         ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada punctuation.ada
 >    type Level  is 
 #^^^^ source.ada meta.declaration.package.specification.ada
-#    ^^^^ source.ada meta.declaration.package.specification.ada keyword.ada
-#        ^ source.ada meta.declaration.package.specification.ada
-#         ^^^^^ source.ada meta.declaration.package.specification.ada entity.name.type.ada
-#              ^^ source.ada meta.declaration.package.specification.ada
-#                ^^ source.ada meta.declaration.package.specification.ada keyword.ada
-#                  ^^ source.ada meta.declaration.package.specification.ada
+#    ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada keyword.ada
+#        ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#         ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada entity.name.type.ada
+#              ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#                ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada keyword.ada
+#                  ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
 >        (Low, 
-#^^^^^^^^ source.ada meta.declaration.package.specification.ada
-#        ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
-#         ^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada variable.name.ada
-#            ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
-#             ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada
+#^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#        ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
+#         ^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada variable.name.ada
+#            ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
+#             ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada
 >        Medium,
-#^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada
-#        ^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada variable.name.ada
-#              ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
+#^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada
+#        ^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada variable.name.ada
+#              ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
 >        -- This is a comment
-#^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada
-#        ^^^^^^^^^^^^^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada comment.line.double-dash.ada
+#^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada
+#        ^^^^^^^^^^^^^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada comment.line.double-dash.ada
 >        Urgent);
-#^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada
-#        ^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada variable.name.ada
-#              ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
-#               ^ source.ada meta.declaration.package.specification.ada punctuation.ada
+#^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada
+#        ^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada variable.name.ada
+#              ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
+#               ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada punctuation.ada
 >    type Light  is (Red, Amber, Green); -- Red and Green are overloaded
 #^^^^ source.ada meta.declaration.package.specification.ada
-#    ^^^^ source.ada meta.declaration.package.specification.ada keyword.ada
-#        ^ source.ada meta.declaration.package.specification.ada
-#         ^^^^^ source.ada meta.declaration.package.specification.ada entity.name.type.ada
-#              ^^ source.ada meta.declaration.package.specification.ada
-#                ^^ source.ada meta.declaration.package.specification.ada keyword.ada
-#                  ^ source.ada meta.declaration.package.specification.ada
-#                   ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
-#                    ^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada variable.name.ada
-#                       ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
-#                        ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada
-#                         ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada variable.name.ada
-#                              ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
-#                               ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada
-#                                ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada variable.name.ada
-#                                     ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
-#                                      ^ source.ada meta.declaration.package.specification.ada punctuation.ada
+#    ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada keyword.ada
+#        ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#         ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada entity.name.type.ada
+#              ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#                ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada keyword.ada
+#                  ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#                   ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
+#                    ^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada variable.name.ada
+#                       ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
+#                        ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada
+#                         ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada variable.name.ada
+#                              ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
+#                               ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada
+#                                ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada variable.name.ada
+#                                     ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
+#                                      ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada punctuation.ada
 #                                       ^ source.ada meta.declaration.package.specification.ada
 #                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.ada meta.declaration.package.specification.ada comment.line.double-dash.ada
 >
 >    type Hexa   is ('A', 'B', 'C', 'D', 'E', 'F');
 #^^^^ source.ada meta.declaration.package.specification.ada
-#    ^^^^ source.ada meta.declaration.package.specification.ada keyword.ada
-#        ^ source.ada meta.declaration.package.specification.ada
-#         ^^^^ source.ada meta.declaration.package.specification.ada entity.name.type.ada
-#             ^^^ source.ada meta.declaration.package.specification.ada
-#                ^^ source.ada meta.declaration.package.specification.ada keyword.ada
-#                  ^ source.ada meta.declaration.package.specification.ada
-#                   ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
-#                    ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada
-#                     ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada variable.name.ada
-#                      ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada
-#                       ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
-#                        ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada
-#                          ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada variable.name.ada
-#                           ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada
-#                            ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
-#                             ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada
-#                               ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada variable.name.ada
-#                                ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada
-#                                 ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
-#                                  ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada
-#                                    ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada variable.name.ada
-#                                     ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada
-#                                      ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
-#                                       ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada
-#                                         ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada variable.name.ada
-#                                          ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada
-#                                           ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
-#                                            ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada
-#                                              ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada variable.name.ada
-#                                               ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada
-#                                                ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
-#                                                 ^ source.ada meta.declaration.package.specification.ada punctuation.ada
+#    ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada keyword.ada
+#        ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#         ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada entity.name.type.ada
+#             ^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#                ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada keyword.ada
+#                  ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#                   ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
+#                    ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada
+#                     ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada variable.name.ada
+#                      ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada
+#                       ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
+#                        ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada
+#                          ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada variable.name.ada
+#                           ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada
+#                            ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
+#                             ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada
+#                               ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada variable.name.ada
+#                                ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada
+#                                 ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
+#                                  ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada
+#                                    ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada variable.name.ada
+#                                     ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada
+#                                      ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
+#                                       ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada
+#                                         ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada variable.name.ada
+#                                          ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada
+#                                           ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
+#                                            ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada
+#                                              ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada variable.name.ada
+#                                               ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada
+#                                                ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
+#                                                 ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada punctuation.ada
 >    type Mixed  is ('A', 'B', '*', B, None, '?', '%');
 #^^^^ source.ada meta.declaration.package.specification.ada
-#    ^^^^ source.ada meta.declaration.package.specification.ada keyword.ada
-#        ^ source.ada meta.declaration.package.specification.ada
-#         ^^^^^ source.ada meta.declaration.package.specification.ada entity.name.type.ada
-#              ^^ source.ada meta.declaration.package.specification.ada
-#                ^^ source.ada meta.declaration.package.specification.ada keyword.ada
-#                  ^ source.ada meta.declaration.package.specification.ada
-#                   ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
-#                    ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada
-#                     ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada variable.name.ada
-#                      ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada
-#                       ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
-#                        ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada
-#                          ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada variable.name.ada
-#                           ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada
-#                            ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
-#                             ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada
-#                                 ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
-#                                  ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada
-#                                   ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada variable.name.ada
-#                                    ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
-#                                     ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada
-#                                      ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada variable.name.ada
-#                                          ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
-#                                           ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada
-#                                               ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
-#                                                ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada
-#                                                    ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
-#                                                     ^ source.ada meta.declaration.package.specification.ada punctuation.ada
+#    ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada keyword.ada
+#        ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#         ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada entity.name.type.ada
+#              ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#                ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada keyword.ada
+#                  ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#                   ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
+#                    ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada
+#                     ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada variable.name.ada
+#                      ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada
+#                       ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
+#                        ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada
+#                          ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada variable.name.ada
+#                           ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada
+#                            ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
+#                             ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada
+#                                 ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
+#                                  ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada
+#                                   ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada variable.name.ada
+#                                    ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
+#                                     ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada
+#                                      ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada variable.name.ada
+#                                          ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
+#                                           ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada
+#                                               ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
+#                                                ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada
+#                                                    ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.enumeration.ada punctuation.ada
+#                                                     ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada punctuation.ada
 >
 >    subtype Weekday is 
 #^^^^ source.ada meta.declaration.package.specification.ada
@@ -222,12 +222,12 @@
 #                      ^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada
 >        Day range Mon .. Fri;
 #^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada
-#        ^^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada meta.declaration.indication.subtype.ada entity.name.type.ada
-#           ^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada meta.declaration.indication.subtype.ada
-#            ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada meta.declaration.indication.subtype.ada storage.modifier.ada
-#                 ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada meta.declaration.indication.subtype.ada
-#                      ^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada meta.declaration.indication.subtype.ada keyword.ada
-#                        ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada meta.declaration.indication.subtype.ada
+#        ^^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada entity.name.type.ada
+#           ^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada
+#            ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada storage.modifier.ada
+#                 ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada
+#                      ^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada keyword.ada
+#                        ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada
 #                            ^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada punctuation.ada
 >    subtype Major   is Suit  range Hearts .. Spades;
 #^^^^ source.ada meta.declaration.package.specification.ada
@@ -237,12 +237,12 @@
 #                 ^^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada
 #                    ^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada keyword.ada
 #                      ^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada
-#                       ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada meta.declaration.indication.subtype.ada entity.name.type.ada
-#                           ^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada meta.declaration.indication.subtype.ada
-#                             ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada meta.declaration.indication.subtype.ada storage.modifier.ada
-#                                  ^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada meta.declaration.indication.subtype.ada
-#                                          ^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada meta.declaration.indication.subtype.ada keyword.ada
-#                                            ^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada meta.declaration.indication.subtype.ada
+#                       ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada entity.name.type.ada
+#                           ^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada
+#                             ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada storage.modifier.ada
+#                                  ^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada
+#                                          ^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada keyword.ada
+#                                            ^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada
 #                                                   ^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada punctuation.ada
 >    subtype Rainbow is Color range Red .. Blue;  --  the Color Red, not the Light
 #^^^^ source.ada meta.declaration.package.specification.ada
@@ -252,54 +252,54 @@
 #                   ^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada
 #                    ^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada keyword.ada
 #                      ^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada
-#                       ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada meta.declaration.indication.subtype.ada entity.name.type.ada
-#                            ^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada meta.declaration.indication.subtype.ada
-#                             ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada meta.declaration.indication.subtype.ada storage.modifier.ada
-#                                  ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada meta.declaration.indication.subtype.ada
-#                                       ^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada meta.declaration.indication.subtype.ada keyword.ada
-#                                         ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada meta.declaration.indication.subtype.ada
+#                       ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada entity.name.type.ada
+#                            ^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada
+#                             ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada storage.modifier.ada
+#                                  ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada
+#                                       ^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada keyword.ada
+#                                         ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada
 #                                              ^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada punctuation.ada
 #                                               ^^ source.ada meta.declaration.package.specification.ada
 #                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.ada meta.declaration.package.specification.ada comment.line.double-dash.ada
 >
 >    type Page_Num  is range 1 .. 2_000;
 #^^^^ source.ada meta.declaration.package.specification.ada
-#    ^^^^ source.ada meta.declaration.package.specification.ada keyword.ada
-#        ^ source.ada meta.declaration.package.specification.ada
-#         ^^^^ source.ada meta.declaration.package.specification.ada entity.name.type.ada
-#             ^ source.ada meta.declaration.package.specification.ada entity.name.type.ada punctuation.ada
-#              ^^^ source.ada meta.declaration.package.specification.ada entity.name.type.ada
-#                 ^^ source.ada meta.declaration.package.specification.ada
-#                   ^^ source.ada meta.declaration.package.specification.ada keyword.ada
-#                     ^ source.ada meta.declaration.package.specification.ada
-#                      ^^^^^ source.ada meta.declaration.package.specification.ada storage.modifier.ada
-#                           ^ source.ada meta.declaration.package.specification.ada
-#                            ^ source.ada meta.declaration.package.specification.ada constant.numeric.ada
-#                             ^ source.ada meta.declaration.package.specification.ada
-#                              ^^ source.ada meta.declaration.package.specification.ada keyword.ada
-#                                ^ source.ada meta.declaration.package.specification.ada
-#                                 ^ source.ada meta.declaration.package.specification.ada constant.numeric.ada
-#                                  ^ source.ada meta.declaration.package.specification.ada constant.numeric.ada punctuation.ada
-#                                   ^^^ source.ada meta.declaration.package.specification.ada constant.numeric.ada
-#                                      ^ source.ada meta.declaration.package.specification.ada punctuation.ada
+#    ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada keyword.ada
+#        ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#         ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada entity.name.type.ada
+#             ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada entity.name.type.ada punctuation.ada
+#              ^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada entity.name.type.ada
+#                 ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#                   ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada keyword.ada
+#                     ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#                      ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada storage.modifier.ada
+#                           ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#                            ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada constant.numeric.ada
+#                             ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#                              ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada keyword.ada
+#                                ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#                                 ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada constant.numeric.ada
+#                                  ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada constant.numeric.ada punctuation.ada
+#                                   ^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada constant.numeric.ada
+#                                      ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada punctuation.ada
 >    type Line_Size is
 #^^^^ source.ada meta.declaration.package.specification.ada
-#    ^^^^ source.ada meta.declaration.package.specification.ada keyword.ada
-#        ^ source.ada meta.declaration.package.specification.ada
-#         ^^^^ source.ada meta.declaration.package.specification.ada entity.name.type.ada
-#             ^ source.ada meta.declaration.package.specification.ada entity.name.type.ada punctuation.ada
-#              ^^^^ source.ada meta.declaration.package.specification.ada entity.name.type.ada
-#                  ^ source.ada meta.declaration.package.specification.ada
-#                   ^^ source.ada meta.declaration.package.specification.ada keyword.ada
+#    ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada keyword.ada
+#        ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#         ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada entity.name.type.ada
+#             ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada entity.name.type.ada punctuation.ada
+#              ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada entity.name.type.ada
+#                  ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#                   ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada keyword.ada
 >        range 1 .. Max_Line_Size;
-#^^^^^^^^ source.ada meta.declaration.package.specification.ada
-#        ^^^^^ source.ada meta.declaration.package.specification.ada storage.modifier.ada
-#             ^ source.ada meta.declaration.package.specification.ada
-#              ^ source.ada meta.declaration.package.specification.ada constant.numeric.ada
-#               ^ source.ada meta.declaration.package.specification.ada
-#                ^^ source.ada meta.declaration.package.specification.ada keyword.ada
-#                  ^^^^^^^^^^^^^^ source.ada meta.declaration.package.specification.ada
-#                                ^ source.ada meta.declaration.package.specification.ada punctuation.ada
+#^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#        ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada storage.modifier.ada
+#             ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#              ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada constant.numeric.ada
+#               ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#                ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada keyword.ada
+#                  ^^^^^^^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#                                ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada punctuation.ada
 >
 >    subtype Small_Int   is Integer   range -10 .. 10;
 #^^^^ source.ada meta.declaration.package.specification.ada
@@ -311,16 +311,16 @@
 #                     ^^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada
 #                        ^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada keyword.ada
 #                          ^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada
-#                           ^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada meta.declaration.indication.subtype.ada entity.name.type.ada
-#                                  ^^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada meta.declaration.indication.subtype.ada
-#                                     ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada meta.declaration.indication.subtype.ada storage.modifier.ada
-#                                          ^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada meta.declaration.indication.subtype.ada
-#                                           ^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada meta.declaration.indication.subtype.ada keyword.operator.adding.ada
-#                                            ^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada meta.declaration.indication.subtype.ada constant.numeric.ada
-#                                              ^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada meta.declaration.indication.subtype.ada
-#                                               ^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada meta.declaration.indication.subtype.ada keyword.ada
-#                                                 ^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada meta.declaration.indication.subtype.ada
-#                                                  ^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada meta.declaration.indication.subtype.ada constant.numeric.ada
+#                           ^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada entity.name.type.ada
+#                                  ^^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada
+#                                     ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada storage.modifier.ada
+#                                          ^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada
+#                                           ^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada keyword.operator.adding.ada
+#                                            ^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada constant.numeric.ada
+#                                              ^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada
+#                                               ^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada keyword.ada
+#                                                 ^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada
+#                                                  ^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada constant.numeric.ada
 #                                                    ^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada punctuation.ada
 >    subtype Column_Ptr  is Line_Size range 1 .. 10;
 #^^^^ source.ada meta.declaration.package.specification.ada
@@ -332,17 +332,17 @@
 #                      ^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada
 #                        ^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada keyword.ada
 #                          ^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada
-#                           ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada meta.declaration.indication.subtype.ada entity.name.type.ada
-#                               ^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada meta.declaration.indication.subtype.ada entity.name.type.ada punctuation.ada
-#                                ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada meta.declaration.indication.subtype.ada entity.name.type.ada
-#                                    ^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada meta.declaration.indication.subtype.ada
-#                                     ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada meta.declaration.indication.subtype.ada storage.modifier.ada
-#                                          ^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada meta.declaration.indication.subtype.ada
-#                                           ^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada meta.declaration.indication.subtype.ada constant.numeric.ada
-#                                            ^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada meta.declaration.indication.subtype.ada
-#                                             ^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada meta.declaration.indication.subtype.ada keyword.ada
-#                                               ^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada meta.declaration.indication.subtype.ada
-#                                                ^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada meta.declaration.indication.subtype.ada constant.numeric.ada
+#                           ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada entity.name.type.ada
+#                               ^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada entity.name.type.ada punctuation.ada
+#                                ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada entity.name.type.ada
+#                                    ^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada
+#                                     ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada storage.modifier.ada
+#                                          ^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada
+#                                           ^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada constant.numeric.ada
+#                                            ^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada
+#                                             ^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada keyword.ada
+#                                               ^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada
+#                                                ^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada constant.numeric.ada
 #                                                  ^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada punctuation.ada
 >    subtype Buffer_Size is Integer   range 0 .. Max;
 #^^^^ source.ada meta.declaration.package.specification.ada
@@ -354,559 +354,563 @@
 #                       ^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada
 #                        ^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada keyword.ada
 #                          ^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada
-#                           ^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada meta.declaration.indication.subtype.ada entity.name.type.ada
-#                                  ^^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada meta.declaration.indication.subtype.ada
-#                                     ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada meta.declaration.indication.subtype.ada storage.modifier.ada
-#                                          ^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada meta.declaration.indication.subtype.ada
-#                                           ^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada meta.declaration.indication.subtype.ada constant.numeric.ada
-#                                            ^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada meta.declaration.indication.subtype.ada
-#                                             ^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada meta.declaration.indication.subtype.ada keyword.ada
-#                                               ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada meta.declaration.indication.subtype.ada
+#                           ^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada entity.name.type.ada
+#                                  ^^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada
+#                                     ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada storage.modifier.ada
+#                                          ^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada
+#                                           ^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada constant.numeric.ada
+#                                            ^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada
+#                                             ^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada keyword.ada
+#                                               ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada
 #                                                   ^ source.ada meta.declaration.package.specification.ada meta.declaration.subtype.ada punctuation.ada
 >
 >    type Byte        is mod 256; -- an unsigned byte
 #^^^^ source.ada meta.declaration.package.specification.ada
-#    ^^^^ source.ada meta.declaration.package.specification.ada keyword.ada
-#        ^ source.ada meta.declaration.package.specification.ada
-#         ^^^^ source.ada meta.declaration.package.specification.ada entity.name.type.ada
-#             ^^^^^^^^ source.ada meta.declaration.package.specification.ada
-#                     ^^ source.ada meta.declaration.package.specification.ada keyword.ada
-#                       ^ source.ada meta.declaration.package.specification.ada
-#                        ^^^ source.ada meta.declaration.package.specification.ada storage.modifier.ada
-#                           ^ source.ada meta.declaration.package.specification.ada
-#                            ^^^ source.ada meta.declaration.package.specification.ada constant.numeric.ada
-#                               ^ source.ada meta.declaration.package.specification.ada punctuation.ada
+#    ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada keyword.ada
+#        ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#         ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada entity.name.type.ada
+#             ^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#                     ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada keyword.ada
+#                       ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#                        ^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada storage.modifier.ada
+#                           ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#                            ^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada constant.numeric.ada
+#                               ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada punctuation.ada
 #                                ^ source.ada meta.declaration.package.specification.ada
 #                                 ^^^^^^^^^^^^^^^^^^^ source.ada meta.declaration.package.specification.ada comment.line.double-dash.ada
 >    type Hash_Index  is
 #^^^^ source.ada meta.declaration.package.specification.ada
-#    ^^^^ source.ada meta.declaration.package.specification.ada keyword.ada
-#        ^ source.ada meta.declaration.package.specification.ada
-#         ^^^^ source.ada meta.declaration.package.specification.ada entity.name.type.ada
-#             ^ source.ada meta.declaration.package.specification.ada entity.name.type.ada punctuation.ada
-#              ^^^^^ source.ada meta.declaration.package.specification.ada entity.name.type.ada
-#                   ^^ source.ada meta.declaration.package.specification.ada
-#                     ^^ source.ada meta.declaration.package.specification.ada keyword.ada
+#    ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada keyword.ada
+#        ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#         ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada entity.name.type.ada
+#             ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada entity.name.type.ada punctuation.ada
+#              ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada entity.name.type.ada
+#                   ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#                     ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada keyword.ada
 >        mod 97;  -- modulus is prime
-#^^^^^^^^ source.ada meta.declaration.package.specification.ada
-#        ^^^ source.ada meta.declaration.package.specification.ada storage.modifier.ada
-#           ^ source.ada meta.declaration.package.specification.ada
-#            ^^ source.ada meta.declaration.package.specification.ada constant.numeric.ada
-#              ^ source.ada meta.declaration.package.specification.ada punctuation.ada
+#^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#        ^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada storage.modifier.ada
+#           ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#            ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada constant.numeric.ada
+#              ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada punctuation.ada
 #               ^^ source.ada meta.declaration.package.specification.ada
 #                 ^^^^^^^^^^^^^^^^^^^ source.ada meta.declaration.package.specification.ada comment.line.double-dash.ada
 >
 >    type Vector     is array(Integer  range <>) of Real;
 #^^^^ source.ada meta.declaration.package.specification.ada
-#    ^^^^ source.ada meta.declaration.package.specification.ada keyword.ada
-#        ^ source.ada meta.declaration.package.specification.ada
-#         ^^^^^^ source.ada meta.declaration.package.specification.ada entity.name.type.ada
-#               ^^^^^ source.ada meta.declaration.package.specification.ada
-#                    ^^ source.ada meta.declaration.package.specification.ada keyword.ada
-#                      ^ source.ada meta.declaration.package.specification.ada
-#                       ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada storage.modifier.ada
-#                            ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada punctuation.ada
-#                             ^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada entity.name.type.ada
-#                                    ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada
-#                                      ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada storage.modifier.ada
-#                                           ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada
-#                                            ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada keyword.modifier.unknown.ada
-#                                              ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada punctuation.ada
-#                                               ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada
-#                                                ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada storage.modifier.ada
-#                                                  ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada
-#                                                   ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada entity.name.type.ada
-#                                                       ^ source.ada meta.declaration.package.specification.ada punctuation.ada
+#    ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada keyword.ada
+#        ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#         ^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada entity.name.type.ada
+#               ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#                    ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada keyword.ada
+#                      ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#                       ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada storage.modifier.ada
+#                            ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada punctuation.ada
+#                             ^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada entity.name.type.ada
+#                                    ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada
+#                                      ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada storage.modifier.ada
+#                                           ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada
+#                                            ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada keyword.modifier.unknown.ada
+#                                              ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada punctuation.ada
+#                                               ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada
+#                                                ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada storage.modifier.ada
+#                                                  ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada
+#                                                   ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada entity.name.type.ada
+#                                                       ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada punctuation.ada
 >    type Matrix     is 
 #^^^^ source.ada meta.declaration.package.specification.ada
-#    ^^^^ source.ada meta.declaration.package.specification.ada keyword.ada
-#        ^ source.ada meta.declaration.package.specification.ada
-#         ^^^^^^ source.ada meta.declaration.package.specification.ada entity.name.type.ada
-#               ^^^^^ source.ada meta.declaration.package.specification.ada
-#                    ^^ source.ada meta.declaration.package.specification.ada keyword.ada
-#                      ^^ source.ada meta.declaration.package.specification.ada
+#    ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada keyword.ada
+#        ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#         ^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada entity.name.type.ada
+#               ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#                    ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada keyword.ada
+#                      ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
 >        array(Integer  range <>, Integer range <>) of Real;
-#^^^^^^^^ source.ada meta.declaration.package.specification.ada
-#        ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada storage.modifier.ada
-#             ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada punctuation.ada
-#              ^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada entity.name.type.ada
-#                     ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada
-#                       ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada storage.modifier.ada
-#                            ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada
-#                             ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada keyword.modifier.unknown.ada
-#                               ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada punctuation.ada
-#                                ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada
-#                                 ^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada entity.name.type.ada
-#                                        ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada
-#                                         ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada storage.modifier.ada
-#                                              ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada
-#                                               ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada keyword.modifier.unknown.ada
-#                                                 ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada punctuation.ada
-#                                                  ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada
-#                                                   ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada storage.modifier.ada
-#                                                     ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada
-#                                                      ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada entity.name.type.ada
-#                                                          ^ source.ada meta.declaration.package.specification.ada punctuation.ada
+#^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#        ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada storage.modifier.ada
+#             ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada punctuation.ada
+#              ^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada entity.name.type.ada
+#                     ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada
+#                       ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada storage.modifier.ada
+#                            ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada
+#                             ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada keyword.modifier.unknown.ada
+#                               ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada punctuation.ada
+#                                ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada
+#                                 ^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada entity.name.type.ada
+#                                        ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada
+#                                         ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada storage.modifier.ada
+#                                              ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada
+#                                               ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada keyword.modifier.unknown.ada
+#                                                 ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada punctuation.ada
+#                                                  ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada
+#                                                   ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada storage.modifier.ada
+#                                                     ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada
+#                                                      ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada entity.name.type.ada
+#                                                          ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada punctuation.ada
 >    type Bit_Vector is 
 #^^^^ source.ada meta.declaration.package.specification.ada
-#    ^^^^ source.ada meta.declaration.package.specification.ada keyword.ada
-#        ^ source.ada meta.declaration.package.specification.ada
-#         ^^^ source.ada meta.declaration.package.specification.ada entity.name.type.ada
-#            ^ source.ada meta.declaration.package.specification.ada entity.name.type.ada punctuation.ada
-#             ^^^^^^ source.ada meta.declaration.package.specification.ada entity.name.type.ada
-#                   ^ source.ada meta.declaration.package.specification.ada
-#                    ^^ source.ada meta.declaration.package.specification.ada keyword.ada
-#                      ^^ source.ada meta.declaration.package.specification.ada
+#    ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada keyword.ada
+#        ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#         ^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada entity.name.type.ada
+#            ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada entity.name.type.ada punctuation.ada
+#             ^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada entity.name.type.ada
+#                   ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#                    ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada keyword.ada
+#                      ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
 >        array(
-#^^^^^^^^ source.ada meta.declaration.package.specification.ada
-#        ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada storage.modifier.ada
-#             ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada punctuation.ada
+#^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#        ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada storage.modifier.ada
+#             ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada punctuation.ada
 >            Integer  range <>
-#^^^^^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada
-#            ^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada entity.name.type.ada
-#                   ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada
-#                     ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada storage.modifier.ada
-#                          ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada
-#                           ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada keyword.modifier.unknown.ada
+#^^^^^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada
+#            ^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada entity.name.type.ada
+#                   ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada
+#                     ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada storage.modifier.ada
+#                          ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada
+#                           ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada keyword.modifier.unknown.ada
 >        ) of Boolean;
-#^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada
-#        ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada punctuation.ada
-#         ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada
-#          ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada storage.modifier.ada
-#            ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada
-#             ^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada entity.name.type.ada
-#                    ^ source.ada meta.declaration.package.specification.ada punctuation.ada
+#^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada
+#        ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada punctuation.ada
+#         ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada
+#          ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada storage.modifier.ada
+#            ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada
+#             ^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada entity.name.type.ada
+#                    ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada punctuation.ada
 >    type Roman      is array(Positive range <>) of Roman_Digit;
 #^^^^ source.ada meta.declaration.package.specification.ada
-#    ^^^^ source.ada meta.declaration.package.specification.ada keyword.ada
-#        ^ source.ada meta.declaration.package.specification.ada
-#         ^^^^^ source.ada meta.declaration.package.specification.ada entity.name.type.ada
-#              ^^^^^^ source.ada meta.declaration.package.specification.ada
-#                    ^^ source.ada meta.declaration.package.specification.ada keyword.ada
-#                      ^ source.ada meta.declaration.package.specification.ada
-#                       ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada storage.modifier.ada
-#                            ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada punctuation.ada
-#                             ^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada entity.name.type.ada
-#                                     ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada
-#                                      ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada storage.modifier.ada
-#                                           ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada
-#                                            ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada keyword.modifier.unknown.ada
-#                                              ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada punctuation.ada
-#                                               ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada
-#                                                ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada storage.modifier.ada
-#                                                  ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada
-#                                                   ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada entity.name.type.ada
-#                                                        ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada entity.name.type.ada punctuation.ada
-#                                                         ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada entity.name.type.ada
-#                                                              ^ source.ada meta.declaration.package.specification.ada punctuation.ada
+#    ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada keyword.ada
+#        ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#         ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada entity.name.type.ada
+#              ^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#                    ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada keyword.ada
+#                      ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#                       ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada storage.modifier.ada
+#                            ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada punctuation.ada
+#                             ^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada entity.name.type.ada
+#                                     ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada
+#                                      ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada storage.modifier.ada
+#                                           ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada
+#                                            ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada keyword.modifier.unknown.ada
+#                                              ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada punctuation.ada
+#                                               ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada
+#                                                ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada storage.modifier.ada
+#                                                  ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada
+#                                                   ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada entity.name.type.ada
+#                                                        ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada entity.name.type.ada punctuation.ada
+#                                                         ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada entity.name.type.ada
+#                                                              ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada punctuation.ada
 >    type Table    is array(1 .. 10) of Integer;
 #^^^^ source.ada meta.declaration.package.specification.ada
-#    ^^^^ source.ada meta.declaration.package.specification.ada keyword.ada
-#        ^ source.ada meta.declaration.package.specification.ada
-#         ^^^^^ source.ada meta.declaration.package.specification.ada entity.name.type.ada
-#              ^^^^ source.ada meta.declaration.package.specification.ada
-#                  ^^ source.ada meta.declaration.package.specification.ada keyword.ada
-#                    ^ source.ada meta.declaration.package.specification.ada
-#                     ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada storage.modifier.ada
-#                          ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada punctuation.ada
-#                           ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada constant.numeric.ada
-#                            ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada
-#                             ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada keyword.ada
-#                               ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada
-#                                ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada constant.numeric.ada
-#                                  ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada punctuation.ada
-#                                   ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada
-#                                    ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada storage.modifier.ada
-#                                      ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada
-#                                       ^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada entity.name.type.ada
-#                                              ^ source.ada meta.declaration.package.specification.ada punctuation.ada
+#    ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada keyword.ada
+#        ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#         ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada entity.name.type.ada
+#              ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#                  ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada keyword.ada
+#                    ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#                     ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada storage.modifier.ada
+#                          ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada punctuation.ada
+#                           ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada constant.numeric.ada
+#                            ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada
+#                             ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada keyword.ada
+#                               ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada
+#                                ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada constant.numeric.ada
+#                                  ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada punctuation.ada
+#                                   ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada
+#                                    ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada storage.modifier.ada
+#                                      ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada
+#                                       ^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada entity.name.type.ada
+#                                              ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada punctuation.ada
 >    type Schedule is array(Day) of Boolean;
 #^^^^ source.ada meta.declaration.package.specification.ada
-#    ^^^^ source.ada meta.declaration.package.specification.ada keyword.ada
-#        ^ source.ada meta.declaration.package.specification.ada
-#         ^^^^^^^^ source.ada meta.declaration.package.specification.ada entity.name.type.ada
-#                 ^ source.ada meta.declaration.package.specification.ada
-#                  ^^ source.ada meta.declaration.package.specification.ada keyword.ada
-#                    ^ source.ada meta.declaration.package.specification.ada
-#                     ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada storage.modifier.ada
-#                          ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada punctuation.ada
-#                           ^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada entity.name.type.ada
-#                              ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada punctuation.ada
-#                               ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada
-#                                ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada storage.modifier.ada
-#                                  ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada
-#                                   ^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada entity.name.type.ada
-#                                          ^ source.ada meta.declaration.package.specification.ada punctuation.ada
+#    ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada keyword.ada
+#        ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#         ^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada entity.name.type.ada
+#                 ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#                  ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada keyword.ada
+#                    ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#                     ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada storage.modifier.ada
+#                          ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada punctuation.ada
+#                           ^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada entity.name.type.ada
+#                              ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada punctuation.ada
+#                               ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada
+#                                ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada storage.modifier.ada
+#                                  ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada
+#                                   ^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada entity.name.type.ada
+#                                          ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada punctuation.ada
 >    type Line     is array(1 .. Max_Line_Size) of Character;
 #^^^^ source.ada meta.declaration.package.specification.ada
-#    ^^^^ source.ada meta.declaration.package.specification.ada keyword.ada
-#        ^ source.ada meta.declaration.package.specification.ada
-#         ^^^^ source.ada meta.declaration.package.specification.ada entity.name.type.ada
-#             ^^^^^ source.ada meta.declaration.package.specification.ada
-#                  ^^ source.ada meta.declaration.package.specification.ada keyword.ada
-#                    ^ source.ada meta.declaration.package.specification.ada
-#                     ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada storage.modifier.ada
-#                          ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada punctuation.ada
-#                           ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada constant.numeric.ada
-#                            ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada
-#                             ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada keyword.ada
-#                               ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada
-#                                ^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada entity.name.type.ada
-#                                   ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada entity.name.type.ada punctuation.ada
-#                                    ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada entity.name.type.ada
-#                                        ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada entity.name.type.ada punctuation.ada
-#                                         ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada entity.name.type.ada
-#                                             ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada punctuation.ada
-#                                              ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada
-#                                               ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada storage.modifier.ada
-#                                                 ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada
-#                                                  ^^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.array.ada entity.name.type.ada
-#                                                           ^ source.ada meta.declaration.package.specification.ada punctuation.ada
+#    ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada keyword.ada
+#        ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#         ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada entity.name.type.ada
+#             ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#                  ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada keyword.ada
+#                    ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#                     ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada storage.modifier.ada
+#                          ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada punctuation.ada
+#                           ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada constant.numeric.ada
+#                            ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada
+#                             ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada keyword.ada
+#                               ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada
+#                                ^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada entity.name.type.ada
+#                                   ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada entity.name.type.ada punctuation.ada
+#                                    ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada entity.name.type.ada
+#                                        ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada entity.name.type.ada punctuation.ada
+#                                         ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada entity.name.type.ada
+#                                             ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada meta.declaration.type.definition.array.dimensions.ada punctuation.ada
+#                                              ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada
+#                                               ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada storage.modifier.ada
+#                                                 ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada
+#                                                  ^^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.array.ada entity.name.type.ada
+#                                                           ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada punctuation.ada
 >
 >    type Date is
 #^^^^ source.ada meta.declaration.package.specification.ada
-#    ^^^^ source.ada meta.declaration.package.specification.ada keyword.ada
-#        ^ source.ada meta.declaration.package.specification.ada
-#         ^^^^ source.ada meta.declaration.package.specification.ada entity.name.type.ada
-#             ^ source.ada meta.declaration.package.specification.ada
-#              ^^ source.ada meta.declaration.package.specification.ada keyword.ada
+#    ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada keyword.ada
+#        ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#         ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada entity.name.type.ada
+#             ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#              ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada keyword.ada
 >   record
-#^^^ source.ada meta.declaration.package.specification.ada
-#   ^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada storage.modifier.ada
+#^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#   ^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada storage.modifier.ada
 >      Day   : Integer range 1 .. 31;
-#^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada
-#      ^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada variable.name.ada
-#         ^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada
-#            ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada punctuation.ada
-#             ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada
-#              ^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada entity.name.type.ada
-#                     ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada
-#                      ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada storage.modifier.ada
-#                           ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada
-#                            ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada constant.numeric.ada
-#                             ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada
-#                              ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada keyword.ada
-#                                ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada
-#                                 ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada constant.numeric.ada
-#                                   ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada punctuation.ada
+#^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada
+#      ^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada variable.name.ada
+#         ^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada
+#            ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada punctuation.ada
+#             ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada
+#              ^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada entity.name.type.ada
+#                     ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada
+#                      ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada storage.modifier.ada
+#                           ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada
+#                            ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada constant.numeric.ada
+#                             ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada
+#                              ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada keyword.ada
+#                                ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada
+#                                 ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada constant.numeric.ada
+#                                   ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada punctuation.ada
 >      Month : Month_Name;
-#^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada
-#      ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada variable.name.ada
-#           ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada
-#            ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada punctuation.ada
-#             ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada
-#              ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada entity.name.type.ada
-#                   ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada entity.name.type.ada punctuation.ada
-#                    ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada entity.name.type.ada
-#                        ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada punctuation.ada
+#^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada
+#      ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada variable.name.ada
+#           ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada
+#            ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada punctuation.ada
+#             ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada
+#              ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada entity.name.type.ada
+#                   ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada entity.name.type.ada punctuation.ada
+#                    ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada entity.name.type.ada
+#                        ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada punctuation.ada
 >      Year  : Integer range 0 .. 4000;
-#^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada
-#      ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada variable.name.ada
-#          ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada
-#            ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada punctuation.ada
-#             ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada
-#              ^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada entity.name.type.ada
-#                     ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada
-#                      ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada storage.modifier.ada
-#                           ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada
-#                            ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada constant.numeric.ada
-#                             ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada
-#                              ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada keyword.ada
-#                                ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada
-#                                 ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada constant.numeric.ada
-#                                     ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada punctuation.ada
+#^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada
+#      ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada variable.name.ada
+#          ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada
+#            ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada punctuation.ada
+#             ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada
+#              ^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada entity.name.type.ada
+#                     ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada
+#                      ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada storage.modifier.ada
+#                           ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada
+#                            ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada constant.numeric.ada
+#                             ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada
+#                              ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada keyword.ada
+#                                ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada
+#                                 ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada constant.numeric.ada
+#                                     ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada punctuation.ada
 >   end record;
-#^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada
-#   ^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada keyword.ada
-#      ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada
-#       ^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada storage.modifier.ada
-#             ^ source.ada meta.declaration.package.specification.ada punctuation.ada
+#^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada
+#   ^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada keyword.ada
+#      ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada
+#       ^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada storage.modifier.ada
+#             ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada punctuation.ada
 >
 >    type Complex is
 #^^^^ source.ada meta.declaration.package.specification.ada
-#    ^^^^ source.ada meta.declaration.package.specification.ada keyword.ada
-#        ^ source.ada meta.declaration.package.specification.ada
-#         ^^^^^^^ source.ada meta.declaration.package.specification.ada entity.name.type.ada
-#                ^ source.ada meta.declaration.package.specification.ada
-#                 ^^ source.ada meta.declaration.package.specification.ada keyword.ada
+#    ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada keyword.ada
+#        ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#         ^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada entity.name.type.ada
+#                ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#                 ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada keyword.ada
 >    record
-#^^^^ source.ada meta.declaration.package.specification.ada
-#    ^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada storage.modifier.ada
+#^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#    ^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada storage.modifier.ada
 >        Re : Real := 0.0;
-#^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada
-#        ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada variable.name.ada
-#          ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada
-#           ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada punctuation.ada
-#            ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada
-#             ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada entity.name.type.ada
-#                 ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada
-#                  ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada keyword.operator.new.ada
-#                    ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada
-#                     ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada constant.numeric.ada
-#                      ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada constant.numeric.ada punctuation.radix-point.ada
-#                       ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada constant.numeric.ada
-#                        ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada punctuation.ada
+#^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada
+#        ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada variable.name.ada
+#          ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada
+#           ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada punctuation.ada
+#            ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada
+#             ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada entity.name.type.ada
+#                 ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada
+#                  ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada keyword.operator.new.ada
+#                    ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada
+#                     ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada constant.numeric.ada
+#                      ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada constant.numeric.ada punctuation.radix-point.ada
+#                       ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada constant.numeric.ada
+#                        ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada punctuation.ada
 >        -- Comment
-#^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada
-#        ^^^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada comment.line.double-dash.ada
+#^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada
+#        ^^^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada comment.line.double-dash.ada
 >        Im : Real := 0.0;
-#^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada
-#        ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada variable.name.ada
-#          ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada
-#           ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada punctuation.ada
-#            ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada
-#             ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada entity.name.type.ada
-#                 ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada
-#                  ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada keyword.operator.new.ada
-#                    ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada
-#                     ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada constant.numeric.ada
-#                      ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada constant.numeric.ada punctuation.radix-point.ada
-#                       ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada constant.numeric.ada
-#                        ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada punctuation.ada
+#^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada
+#        ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada variable.name.ada
+#          ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada
+#           ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada punctuation.ada
+#            ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada
+#             ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada entity.name.type.ada
+#                 ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada
+#                  ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada keyword.operator.new.ada
+#                    ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada
+#                     ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada constant.numeric.ada
+#                      ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada constant.numeric.ada punctuation.radix-point.ada
+#                       ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada constant.numeric.ada
+#                        ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada punctuation.ada
 >    end record;
-#^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada
-#    ^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada keyword.ada
-#       ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada
-#        ^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada storage.modifier.ada
-#              ^ source.ada meta.declaration.package.specification.ada punctuation.ada
+#^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada
+#    ^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada keyword.ada
+#       ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada
+#        ^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada storage.modifier.ada
+#              ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada punctuation.ada
 >
 >    type Peripheral(Unit : Device := Disk) is record
 #^^^^ source.ada meta.declaration.package.specification.ada
-#    ^^^^ source.ada meta.declaration.package.specification.ada keyword.ada
-#        ^ source.ada meta.declaration.package.specification.ada
-#         ^^^^^^^^^^ source.ada meta.declaration.package.specification.ada entity.name.type.ada
-#                   ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.discriminant.ada punctuation.ada
-#                    ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.discriminant.ada variable.name.ada
-#                        ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.discriminant.ada
-#                         ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.discriminant.ada punctuation.ada
-#                          ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.discriminant.ada
-#                           ^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.discriminant.ada entity.name.type.ada
-#                                 ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.discriminant.ada
-#                                  ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.discriminant.ada keyword.operator.new.ada
-#                                    ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.discriminant.ada
-#                                         ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.discriminant.ada punctuation.ada
-#                                          ^ source.ada meta.declaration.package.specification.ada
-#                                           ^^ source.ada meta.declaration.package.specification.ada keyword.ada
-#                                             ^ source.ada meta.declaration.package.specification.ada
-#                                              ^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada storage.modifier.ada
+#    ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada keyword.ada
+#        ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#         ^^^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada entity.name.type.ada
+#                   ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.discriminant.ada punctuation.ada
+#                    ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.discriminant.ada variable.name.ada
+#                        ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.discriminant.ada
+#                         ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.discriminant.ada punctuation.ada
+#                          ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.discriminant.ada
+#                           ^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.discriminant.ada entity.name.type.ada
+#                                 ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.discriminant.ada
+#                                  ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.discriminant.ada keyword.operator.new.ada
+#                                    ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.discriminant.ada
+#                                         ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.discriminant.ada punctuation.ada
+#                                          ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#                                           ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada keyword.ada
+#                                             ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#                                              ^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada storage.modifier.ada
 >        Status : State;
-#^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada
-#        ^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada variable.name.ada
-#              ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada
-#               ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada punctuation.ada
-#                ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada
-#                 ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada entity.name.type.ada
-#                      ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada punctuation.ada
+#^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada
+#        ^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada variable.name.ada
+#              ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada
+#               ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada punctuation.ada
+#                ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada
+#                 ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada entity.name.type.ada
+#                      ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.type.definition.record.component.ada punctuation.ada
 >        case Unit is
-#^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada
-#        ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada keyword.ada
-#            ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada
-#             ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada variable.name.ada
-#                 ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada
-#                  ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada keyword.ada
+#^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada
+#        ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada keyword.ada
+#            ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada
+#             ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada variable.name.ada
+#                 ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada
+#                  ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada keyword.ada
 >            when Printer =>
-#^^^^^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada
-#            ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada keyword.ada
-#                ^^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada
-#                         ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada keyword.other.ada
+#^^^^^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada
+#            ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada keyword.ada
+#                ^^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada
+#                         ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada keyword.other.ada
 >                Line_Count : Integer range 1 .. Page_Size;
-#^^^^^^^^^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada
-#                ^^^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada meta.declaration.type.definition.record.component.ada variable.name.ada
-#                          ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada meta.declaration.type.definition.record.component.ada
-#                           ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada meta.declaration.type.definition.record.component.ada punctuation.ada
-#                            ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada meta.declaration.type.definition.record.component.ada
-#                             ^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada meta.declaration.type.definition.record.component.ada entity.name.type.ada
-#                                    ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada meta.declaration.type.definition.record.component.ada
-#                                     ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada meta.declaration.type.definition.record.component.ada storage.modifier.ada
-#                                          ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada meta.declaration.type.definition.record.component.ada
-#                                           ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada meta.declaration.type.definition.record.component.ada constant.numeric.ada
-#                                            ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada meta.declaration.type.definition.record.component.ada
-#                                             ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada meta.declaration.type.definition.record.component.ada keyword.ada
-#                                               ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada meta.declaration.type.definition.record.component.ada
-#                                                ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada meta.declaration.type.definition.record.component.ada entity.name.type.ada
-#                                                    ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada meta.declaration.type.definition.record.component.ada entity.name.type.ada punctuation.ada
-#                                                     ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada meta.declaration.type.definition.record.component.ada entity.name.type.ada
-#                                                         ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada meta.declaration.type.definition.record.component.ada punctuation.ada
+#^^^^^^^^^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada
+#                ^^^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada meta.declaration.type.definition.record.component.ada variable.name.ada
+#                          ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada meta.declaration.type.definition.record.component.ada
+#                           ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada meta.declaration.type.definition.record.component.ada punctuation.ada
+#                            ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada meta.declaration.type.definition.record.component.ada
+#                             ^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada meta.declaration.type.definition.record.component.ada entity.name.type.ada
+#                                    ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada meta.declaration.type.definition.record.component.ada
+#                                     ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada meta.declaration.type.definition.record.component.ada storage.modifier.ada
+#                                          ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada meta.declaration.type.definition.record.component.ada
+#                                           ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada meta.declaration.type.definition.record.component.ada constant.numeric.ada
+#                                            ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada meta.declaration.type.definition.record.component.ada
+#                                             ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada meta.declaration.type.definition.record.component.ada keyword.ada
+#                                               ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada meta.declaration.type.definition.record.component.ada
+#                                                ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada meta.declaration.type.definition.record.component.ada entity.name.type.ada
+#                                                    ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada meta.declaration.type.definition.record.component.ada entity.name.type.ada punctuation.ada
+#                                                     ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada meta.declaration.type.definition.record.component.ada entity.name.type.ada
+#                                                         ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada meta.declaration.type.definition.record.component.ada punctuation.ada
 >            when others =>
-#^^^^^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada
-#            ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada keyword.ada
-#                ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada
-#                 ^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada keyword.ada
-#                       ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada
-#                        ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada keyword.other.ada
+#^^^^^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada
+#            ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada keyword.ada
+#                ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada
+#                 ^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada keyword.ada
+#                       ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada
+#                        ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada keyword.other.ada
 >                Cylinder   : Cylinder_Index;
-#^^^^^^^^^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada
-#                ^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada meta.declaration.type.definition.record.component.ada variable.name.ada
-#                        ^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada meta.declaration.type.definition.record.component.ada
-#                           ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada meta.declaration.type.definition.record.component.ada punctuation.ada
-#                            ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada meta.declaration.type.definition.record.component.ada
-#                             ^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada meta.declaration.type.definition.record.component.ada entity.name.type.ada
-#                                     ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada meta.declaration.type.definition.record.component.ada entity.name.type.ada punctuation.ada
-#                                      ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada meta.declaration.type.definition.record.component.ada entity.name.type.ada
-#                                           ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada meta.declaration.type.definition.record.component.ada punctuation.ada
+#^^^^^^^^^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada
+#                ^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada meta.declaration.type.definition.record.component.ada variable.name.ada
+#                        ^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada meta.declaration.type.definition.record.component.ada
+#                           ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada meta.declaration.type.definition.record.component.ada punctuation.ada
+#                            ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada meta.declaration.type.definition.record.component.ada
+#                             ^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada meta.declaration.type.definition.record.component.ada entity.name.type.ada
+#                                     ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada meta.declaration.type.definition.record.component.ada entity.name.type.ada punctuation.ada
+#                                      ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada meta.declaration.type.definition.record.component.ada entity.name.type.ada
+#                                           ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada meta.declaration.type.definition.record.component.ada punctuation.ada
 >                -- Another comment
-#^^^^^^^^^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada
-#                ^^^^^^^^^^^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada comment.line.double-dash.ada
+#^^^^^^^^^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada
+#                ^^^^^^^^^^^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada comment.line.double-dash.ada
 >                Track      : Track_Number;
-#^^^^^^^^^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada
-#                ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada meta.declaration.type.definition.record.component.ada variable.name.ada
-#                     ^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada meta.declaration.type.definition.record.component.ada
-#                           ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada meta.declaration.type.definition.record.component.ada punctuation.ada
-#                            ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada meta.declaration.type.definition.record.component.ada
-#                             ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada meta.declaration.type.definition.record.component.ada entity.name.type.ada
-#                                  ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada meta.declaration.type.definition.record.component.ada entity.name.type.ada punctuation.ada
-#                                   ^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada meta.declaration.type.definition.record.component.ada entity.name.type.ada
-#                                         ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada meta.declaration.type.definition.record.component.ada punctuation.ada
+#^^^^^^^^^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada
+#                ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada meta.declaration.type.definition.record.component.ada variable.name.ada
+#                     ^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada meta.declaration.type.definition.record.component.ada
+#                           ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada meta.declaration.type.definition.record.component.ada punctuation.ada
+#                            ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada meta.declaration.type.definition.record.component.ada
+#                             ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada meta.declaration.type.definition.record.component.ada entity.name.type.ada
+#                                  ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada meta.declaration.type.definition.record.component.ada entity.name.type.ada punctuation.ada
+#                                   ^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada meta.declaration.type.definition.record.component.ada entity.name.type.ada
+#                                         ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada meta.declaration.type.definition.record.component.ada punctuation.ada
 >            end case;
-#^^^^^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada
-#            ^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada keyword.ada
-#               ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada
-#                ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada keyword.ada
-#                    ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada
+#^^^^^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada
+#            ^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada keyword.ada
+#               ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada
+#                ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada keyword.ada
+#                    ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada meta.declaration.variant.ada
 >        end record;
-#^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada
-#        ^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada keyword.ada
-#           ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada
-#            ^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.record.ada storage.modifier.ada
-#                  ^ source.ada meta.declaration.package.specification.ada punctuation.ada
+#^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada
+#        ^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada keyword.ada
+#           ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada
+#            ^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.record.ada storage.modifier.ada
+#                  ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada punctuation.ada
 >
 >    type Peripheral_Ref is not null access Peripheral;  --  see 3.8.1
 #^^^^ source.ada meta.declaration.package.specification.ada
-#    ^^^^ source.ada meta.declaration.package.specification.ada keyword.ada
-#        ^ source.ada meta.declaration.package.specification.ada
-#         ^^^^^^^^^^ source.ada meta.declaration.package.specification.ada entity.name.type.ada
-#                   ^ source.ada meta.declaration.package.specification.ada entity.name.type.ada punctuation.ada
-#                    ^^^ source.ada meta.declaration.package.specification.ada entity.name.type.ada
-#                       ^ source.ada meta.declaration.package.specification.ada
-#                        ^^ source.ada meta.declaration.package.specification.ada keyword.ada
-#                          ^ source.ada meta.declaration.package.specification.ada
-#                           ^^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.access.ada storage.visibility.ada
-#                                    ^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.access.ada storage.visibility.ada
-#                                          ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.access.ada
-#                                           ^^^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.access.ada entity.name.type.ada
-#                                                     ^ source.ada meta.declaration.package.specification.ada punctuation.ada
+#    ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada keyword.ada
+#        ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#         ^^^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada entity.name.type.ada
+#                   ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada entity.name.type.ada punctuation.ada
+#                    ^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada entity.name.type.ada
+#                       ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#                        ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada keyword.ada
+#                          ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#                           ^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada keyword.operator.highest-precedence.ada
+#                              ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#                               ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada constant.language.ada
+#                                   ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#                                    ^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.access.ada storage.visibility.ada
+#                                          ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.access.ada
+#                                           ^^^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.access.ada entity.name.type.ada
+#                                                     ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada punctuation.ada
 #                                                      ^^ source.ada meta.declaration.package.specification.ada
 #                                                        ^^^^^^^^^^^^^ source.ada meta.declaration.package.specification.ada comment.line.double-dash.ada
 >    type Binop_Ptr is 
 #^^^^ source.ada meta.declaration.package.specification.ada
-#    ^^^^ source.ada meta.declaration.package.specification.ada keyword.ada
-#        ^ source.ada meta.declaration.package.specification.ada
-#         ^^^^^ source.ada meta.declaration.package.specification.ada entity.name.type.ada
-#              ^ source.ada meta.declaration.package.specification.ada entity.name.type.ada punctuation.ada
-#               ^^^ source.ada meta.declaration.package.specification.ada entity.name.type.ada
-#                  ^ source.ada meta.declaration.package.specification.ada
-#                   ^^ source.ada meta.declaration.package.specification.ada keyword.ada
-#                     ^^ source.ada meta.declaration.package.specification.ada
+#    ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada keyword.ada
+#        ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#         ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada entity.name.type.ada
+#              ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada entity.name.type.ada punctuation.ada
+#               ^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada entity.name.type.ada
+#                  ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#                   ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada keyword.ada
+#                     ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
 >        access all Binary_Operation'Class;
-#^^^^^^^^ source.ada meta.declaration.package.specification.ada
-#        ^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.access.ada storage.visibility.ada
-#              ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.access.ada
-#               ^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.access.ada storage.visibility.ada
-#                  ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.access.ada
-#                   ^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.access.ada entity.name.type.ada
-#                         ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.access.ada entity.name.type.ada punctuation.ada
-#                          ^^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.access.ada entity.name.type.ada
-#                                   ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.access.ada
-#                                    ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.access.ada entity.name.type.ada
-#                                         ^ source.ada meta.declaration.package.specification.ada punctuation.ada
+#^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#        ^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.access.ada storage.visibility.ada
+#              ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.access.ada
+#               ^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.access.ada storage.visibility.ada
+#                  ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.access.ada
+#                   ^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.access.ada entity.name.type.ada
+#                         ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.access.ada entity.name.type.ada punctuation.ada
+#                          ^^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.access.ada entity.name.type.ada
+#                                   ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.access.ada meta.attribute.ada punctuation.ada
+#                                    ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.access.ada meta.attribute.ada entity.other.attribute-name.ada
+#                                         ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada punctuation.ada
 >
 >    type Local_Coordinate is new Coordinate;   --  two different types
 #^^^^ source.ada meta.declaration.package.specification.ada
-#    ^^^^ source.ada meta.declaration.package.specification.ada keyword.ada
-#        ^ source.ada meta.declaration.package.specification.ada
-#         ^^^^^ source.ada meta.declaration.package.specification.ada entity.name.type.ada
-#              ^ source.ada meta.declaration.package.specification.ada entity.name.type.ada punctuation.ada
-#               ^^^^^^^^^^ source.ada meta.declaration.package.specification.ada entity.name.type.ada
-#                         ^ source.ada meta.declaration.package.specification.ada
-#                          ^^ source.ada meta.declaration.package.specification.ada keyword.ada
-#                            ^ source.ada meta.declaration.package.specification.ada
-#                             ^^^ source.ada meta.declaration.package.specification.ada storage.modifier.ada
-#                                ^ source.ada meta.declaration.package.specification.ada
-#                                 ^^^^^^^^^^ source.ada meta.declaration.package.specification.ada entity.name.type.ada
-#                                           ^ source.ada meta.declaration.package.specification.ada punctuation.ada
+#    ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada keyword.ada
+#        ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#         ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada entity.name.type.ada
+#              ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada entity.name.type.ada punctuation.ada
+#               ^^^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada entity.name.type.ada
+#                         ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#                          ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada keyword.ada
+#                            ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#                             ^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada storage.modifier.ada
+#                                ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#                                 ^^^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada entity.name.type.ada
+#                                           ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada punctuation.ada
 #                                            ^^^ source.ada meta.declaration.package.specification.ada
 #                                               ^^^^^^^^^^^^^^^^^^^^^^^ source.ada meta.declaration.package.specification.ada comment.line.double-dash.ada
 >    type Midweek is new Day range Tue .. Thu;  --  see 3.5.1
 #^^^^ source.ada meta.declaration.package.specification.ada
-#    ^^^^ source.ada meta.declaration.package.specification.ada keyword.ada
-#        ^ source.ada meta.declaration.package.specification.ada
-#         ^^^^^^^ source.ada meta.declaration.package.specification.ada entity.name.type.ada
-#                ^ source.ada meta.declaration.package.specification.ada
-#                 ^^ source.ada meta.declaration.package.specification.ada keyword.ada
-#                   ^ source.ada meta.declaration.package.specification.ada
-#                    ^^^ source.ada meta.declaration.package.specification.ada storage.modifier.ada
-#                       ^ source.ada meta.declaration.package.specification.ada
-#                        ^^^ source.ada meta.declaration.package.specification.ada entity.name.type.ada
-#                           ^ source.ada meta.declaration.package.specification.ada
-#                            ^^^^^ source.ada meta.declaration.package.specification.ada storage.modifier.ada
-#                                 ^^^^^ source.ada meta.declaration.package.specification.ada
-#                                      ^^ source.ada meta.declaration.package.specification.ada keyword.ada
-#                                        ^^^^ source.ada meta.declaration.package.specification.ada
-#                                            ^ source.ada meta.declaration.package.specification.ada punctuation.ada
+#    ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada keyword.ada
+#        ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#         ^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada entity.name.type.ada
+#                ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#                 ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada keyword.ada
+#                   ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#                    ^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada storage.modifier.ada
+#                       ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#                        ^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada entity.name.type.ada
+#                           ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#                            ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada entity.name.type.ada
+#                                 ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#                                  ^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada entity.name.type.ada
+#                                     ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#                                         ^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada entity.name.type.ada
+#                                            ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada punctuation.ada
 #                                             ^^ source.ada meta.declaration.package.specification.ada
 #                                               ^^^^^^^^^^^^^ source.ada meta.declaration.package.specification.ada comment.line.double-dash.ada
 >    type Counter is new Positive;              --  same range as Positive 
 #^^^^ source.ada meta.declaration.package.specification.ada
-#    ^^^^ source.ada meta.declaration.package.specification.ada keyword.ada
-#        ^ source.ada meta.declaration.package.specification.ada
-#         ^^^^^^^ source.ada meta.declaration.package.specification.ada entity.name.type.ada
-#                ^ source.ada meta.declaration.package.specification.ada
-#                 ^^ source.ada meta.declaration.package.specification.ada keyword.ada
-#                   ^ source.ada meta.declaration.package.specification.ada
-#                    ^^^ source.ada meta.declaration.package.specification.ada storage.modifier.ada
-#                       ^ source.ada meta.declaration.package.specification.ada
-#                        ^^^^^^^^ source.ada meta.declaration.package.specification.ada entity.name.type.ada
-#                                ^ source.ada meta.declaration.package.specification.ada punctuation.ada
+#    ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada keyword.ada
+#        ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#         ^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada entity.name.type.ada
+#                ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#                 ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada keyword.ada
+#                   ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#                    ^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada storage.modifier.ada
+#                       ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#                        ^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada entity.name.type.ada
+#                                ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada punctuation.ada
 #                                 ^^^^^^^^^^^^^^ source.ada meta.declaration.package.specification.ada
 #                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.ada meta.declaration.package.specification.ada comment.line.double-dash.ada
 >
 >
 >    type Queue is limited interface;
 #^^^^ source.ada meta.declaration.package.specification.ada
-#    ^^^^ source.ada meta.declaration.package.specification.ada keyword.ada
-#        ^ source.ada meta.declaration.package.specification.ada
-#         ^^^^^ source.ada meta.declaration.package.specification.ada entity.name.type.ada
-#              ^ source.ada meta.declaration.package.specification.ada
-#               ^^ source.ada meta.declaration.package.specification.ada keyword.ada
-#                 ^ source.ada meta.declaration.package.specification.ada
-#                  ^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.interface.ada storage.modifier.ada
-#                         ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.interface.ada
-#                          ^^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.interface.ada storage.modifier.ada
-#                                   ^ source.ada meta.declaration.package.specification.ada punctuation.ada
+#    ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada keyword.ada
+#        ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#         ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada entity.name.type.ada
+#              ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#               ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada keyword.ada
+#                 ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#                  ^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.interface.ada storage.modifier.ada
+#                         ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.interface.ada
+#                          ^^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.interface.ada storage.modifier.ada
+#                                   ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada punctuation.ada
 >    type Synchronized_Queue is synchronized interface and Queue; -- see 9.11
 #^^^^ source.ada meta.declaration.package.specification.ada
-#    ^^^^ source.ada meta.declaration.package.specification.ada keyword.ada
-#        ^ source.ada meta.declaration.package.specification.ada
-#         ^^^^^^^^^^^^ source.ada meta.declaration.package.specification.ada entity.name.type.ada
-#                     ^ source.ada meta.declaration.package.specification.ada entity.name.type.ada punctuation.ada
-#                      ^^^^^ source.ada meta.declaration.package.specification.ada entity.name.type.ada
-#                           ^ source.ada meta.declaration.package.specification.ada
-#                            ^^ source.ada meta.declaration.package.specification.ada keyword.ada
-#                              ^ source.ada meta.declaration.package.specification.ada
-#                               ^^^^^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.interface.ada storage.modifier.ada
-#                                           ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.interface.ada
-#                                            ^^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.interface.ada storage.modifier.ada
-#                                                     ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.interface.ada
-#                                                      ^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.interface.ada storage.modifier.ada
-#                                                         ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.interface.ada
-#                                                          ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.interface.ada entity.name.type.ada
-#                                                               ^ source.ada meta.declaration.package.specification.ada punctuation.ada
+#    ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada keyword.ada
+#        ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#         ^^^^^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada entity.name.type.ada
+#                     ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada entity.name.type.ada punctuation.ada
+#                      ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada entity.name.type.ada
+#                           ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#                            ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada keyword.ada
+#                              ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#                               ^^^^^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.interface.ada storage.modifier.ada
+#                                           ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.interface.ada
+#                                            ^^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.interface.ada storage.modifier.ada
+#                                                     ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.interface.ada
+#                                                      ^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.interface.ada storage.modifier.ada
+#                                                         ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.interface.ada
+#                                                          ^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.interface.ada entity.name.type.ada
+#                                                               ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada punctuation.ada
 #                                                                ^ source.ada meta.declaration.package.specification.ada
 #                                                                 ^^^^^^^^^^^ source.ada meta.declaration.package.specification.ada comment.line.double-dash.ada
 >    type Serial_Device is task interface;  -- see 9.1
 #^^^^ source.ada meta.declaration.package.specification.ada
-#    ^^^^ source.ada meta.declaration.package.specification.ada keyword.ada
-#        ^ source.ada meta.declaration.package.specification.ada
-#         ^^^^^^ source.ada meta.declaration.package.specification.ada entity.name.type.ada
-#               ^ source.ada meta.declaration.package.specification.ada entity.name.type.ada punctuation.ada
-#                ^^^^^^ source.ada meta.declaration.package.specification.ada entity.name.type.ada
-#                      ^ source.ada meta.declaration.package.specification.ada
-#                       ^^ source.ada meta.declaration.package.specification.ada keyword.ada
-#                         ^ source.ada meta.declaration.package.specification.ada
-#                          ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.interface.ada storage.modifier.ada
-#                              ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.interface.ada
-#                               ^^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.interface.ada storage.modifier.ada
-#                                        ^ source.ada meta.declaration.package.specification.ada punctuation.ada
+#    ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada keyword.ada
+#        ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#         ^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada entity.name.type.ada
+#               ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada entity.name.type.ada punctuation.ada
+#                ^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada entity.name.type.ada
+#                      ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#                       ^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada keyword.ada
+#                         ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada
+#                          ^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.interface.ada storage.modifier.ada
+#                              ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.interface.ada
+#                               ^^^^^^^^^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada meta.declaration.type.definition.interface.ada storage.modifier.ada
+#                                        ^ source.ada meta.declaration.package.specification.ada meta.declaration.type.definition.regular.ada punctuation.ada
 #                                         ^^ source.ada meta.declaration.package.specification.ada
 #                                           ^^^^^^^^^^ source.ada meta.declaration.package.specification.ada comment.line.double-dash.ada
 >


### PR DESCRIPTION
Hello,
As mentioned in some issues (#495, #496 & #497), the highlighting can look a bit strange sometimes, and some words are highlighted in a strange way with some themes. Look at the screenshot bellow for a such example.
![image](https://user-images.githubusercontent.com/34268335/87986829-f11cc880-cadd-11ea-9cbf-675152dad5cf.png)

This PR tries to improve this. I don't pretend that everything is working fine, but it improves the highlighting to something better. I already know limitation and cases where it doesn't work. I can work on it with the limited time that I have to make it event much better. But first I would like to have a feedback on this work. I also put another screenshot bellow to see the difference, but I strongly encourage you to test it by yourself.
![image](https://user-images.githubusercontent.com/34268335/87987276-af405200-cade-11ea-88d3-6781eaf66ab0.png)

The screenshots are made with the theme Community Material Theme Ocean. 