### PR TITLE
Revert "T717-032 Make run-tests python3 only"

### DIFF
--- a/testsuite/run-tests
+++ b/testsuite/run-tests
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 import testsuite
 import os
 import yaml


### PR DESCRIPTION
This doesn't work under Windows.