### PR TITLE
T618-028 Improve the test driver

### DIFF
--- a/testsuite/ada_lsp/README.md
+++ b/testsuite/ada_lsp/README.md
@@ -43,10 +43,20 @@ Property value - an object:
 
  * "request" - JSON object to send to LSP server as request.
  * "wait" - array of _wait_ objects to expect them in any order.
- * "sortReply" - an object with properies. Each property has string value of
-a _key_. The property name points to a property in the server reply to
-be sorted; it should be JSON array of object. While _key_ is property name
-in the array item to compare.
+ * "sortReply" - an object describing how to sort a server reply. Let's
+   explain by examples:
+    1.  `"sortReply": {"result", "uri"}` - Server reply should have a property
+       `result`, that is an array of objects, each of them has a property
+       `uri`. Tester driver will sort the array using the `uri` as a sort key.
+    2. `"sortReply": { "result": ["label", "detail"] }` - you can have a
+       composite sort key, if you provide names of properties as an array
+       of strings.
+    3. `"sortReply": { "result": { "items": ["label", "detail"] } }` - if the
+       server reply has a JSON array wrapped in an object, you can nest a sort
+       desriptor into an object. In this case in the server reply `result` is
+       an object, that has a `items` property. Where `items` is an array of
+       objects, that should be sorted using the `label` and `detail` as a
+       composite sort key.
 
 Where _wait_ object is expected server answer. Each property of this object
 should be in server response, but some string values have a special meaning:

--- a/testsuite/ada_lsp/completion.subp_parameters/test.json
+++ b/testsuite/ada_lsp/completion.subp_parameters/test.json
@@ -223,6 +223,7 @@
             "id": 4,
             "method": "textDocument/completion"
          },
+         "sortReply": { "result": {"items": "label"} },
          "wait": [
             {
                "id": 4,
@@ -370,13 +371,37 @@
               "id": 6,
               "method": "textDocument/completion"
           },
+         "sortReply": { "result": {"items": "label"} },
           "wait": [
               {
                   "id": 6,
                   "result": {
                       "isIncomplete": false,
                       "items": [
-                          {
+                        {
+                           "label": "A",
+                           "kind": 6,
+                           "detail": "A : Integer := 3;",
+                           "documentation": "at main.adb (10:4)",
+                           "additionalTextEdits": []
+                        },
+                        {
+                           "label": "ASCII",
+                           "kind": 9,
+                           "detail": "package ASCII ",
+                           "documentation": "at __standard (23:3)",
+                           "additionalTextEdits": []
+                        },
+                        {
+                           "label": "Add",
+                           "kind": 3,
+                           "detail": "function Add (A, B : Integer) return Integer",
+                           "documentation": "at main.adb (6:4)",
+                           "insertText": "Add (${1:A : Integer}, ${2:B : Integer})$0",
+                           "insertTextFormat": 2,
+                           "additionalTextEdits": []
+                        },
+                        {
                               "label": "abort",
                               "kind": 14,
                               "insertText": "abort",
@@ -455,33 +480,7 @@
                               "insertTextFormat": 1,
                               "additionalTextEdits": [
                               ]
-                          },
-                          {
-                              "label": "A",
-                              "kind": 6,
-                              "detail": "A : Integer := 3;",
-                              "documentation": "at main.adb (10:4)",
-                              "additionalTextEdits": [
-                              ]
-                          },
-                          {
-                           "label": "Add",
-                           "kind": 3,
-                           "detail": "function Add (A, B : Integer) return Integer",
-                           "documentation": "at main.adb (6:4)",
-                           "insertText": "Add (${1:A : Integer}, ${2:B : Integer})$0",
-                           "insertTextFormat": 2,
-                           "additionalTextEdits": [
-                           ]
-                       },
-                       {
-                           "label": "ASCII",
-                           "kind": 9,
-                           "detail": "package ASCII ",
-                           "documentation": "at __standard (23:3)",
-                           "additionalTextEdits": [
-                           ]
-                       }
+                          }
 
                       ]
                }


### PR DESCRIPTION
Now the `sortReply` property can contain a composite sorting keys.
It also can point a array nested in an object, like

    sortReply: {result: {items: ["label", "detail"]}}

to sort completions in a form of

    result: {items: [{title: x, detail: y}, {...}]}