### PR TITLE
Restore advanced syntax highlighter.

### DIFF
--- a/integration/vscode/ada/package.json
+++ b/integration/vscode/ada/package.json
@@ -81,7 +81,7 @@
             {
                 "language": "ada",
                 "scopeName": "source.ada",
-                "path": "./syntaxes/ada.tmLanguage.json"
+                "path": "./advanced/ada.tmLanguage.json"
             },
             {
                 "language": "ali",


### PR DESCRIPTION
It seems #507 fixed most of the issues and now it looks much
better then before.