### PR TITLE
T618-028 Mark invisible symbol completion labels

### DIFF
--- a/source/ada/lsp-ada_documents.adb
+++ b/source/ada/lsp-ada_documents.adb
@@ -1847,6 +1847,8 @@ package body LSP.Ada_Documents is
 
       if not Is_Visible then
          Item.sortText := (True, '~' & Item.label);
+         Item.insertText := (True, Item.label);
+         Item.label := Item.label & " (invisible)";
       end if;
 
       --  Property_Errors can occur when calling
@@ -1891,8 +1893,9 @@ package body LSP.Ada_Documents is
       end;
 
       --  Return immediately if the client does not support completion
-      --  snippets.
-      if not Snippets_Enabled then
+      --  snippets. Also don't provide snippets for invisible symbols, because
+      --  we don't know if this is a "dot call" or normal one.
+      if not Snippets_Enabled or not Is_Visible then
          return Item;
       end if;
 

--- a/testsuite/ada_lsp/completion.invisible/aaa.ads
+++ b/testsuite/ada_lsp/completion.invisible/aaa.ads
@@ -1,3 +1,5 @@
 package Aaa is
    Invisible : Integer;
+   
+   function Invisible_Function (X, Y : Integer) return Integer is (0);
 end;

--- a/testsuite/ada_lsp/completion.invisible/test.json
+++ b/testsuite/ada_lsp/completion.invisible/test.json
@@ -144,7 +144,18 @@
                   "isIncomplete": false,
                   "items": [
                      {
-                        "label": "Invisible",
+                        "label": "Invisible_Function (invisible)",
+                        "kind": 3,
+                        "detail": "function Invisible_Function (X, Y : Integer) return Integer",
+                        "documentation": "at aaa.ads (4:4)",
+                        "sortText": "~Invisible_Function",
+                        "insertText": "Invisible_Function",
+                        "additionalTextEdits": [
+                        ]
+                      },
+                     {
+                        "label": "Invisible (invisible)",
+                        "insertText": "Invisible",
                         "kind": 6,
                         "detail": "Invisible : Integer;",
                         "documentation": "at aaa.ads (2:4)",
@@ -231,7 +242,8 @@
                   "isIncomplete": false,
                   "items": [
                      {
-                        "label": "Invisible",
+                        "label": "Invisible (invisible)",
+                        "insertText": "Invisible",
                         "kind": 6,
                         "detail": "Invisible : Integer;",
                         "documentation": "at aaa.ads (3:4)",
@@ -284,7 +296,18 @@
                   "isIncomplete": false,
                   "items": [
                      {
-                        "label": "Invisible",
+                        "label": "Invisible_Function (invisible)",
+                        "kind": 3,
+                        "detail": "function Invisible_Function (X, Y : Integer) return Integer",
+                        "documentation": "at aaa.ads (4:4)",
+                        "sortText": "~Invisible_Function",
+                        "insertText": "Invisible_Function",
+                        "additionalTextEdits": [
+                        ]
+                      },
+                     {
+                        "label": "Invisible (invisible)",
+                        "insertText": "Invisible",
                         "kind": 6,
                         "detail": "Invisible : Integer;",
                         "documentation": "at aaa.ads (2:4)",

--- a/testsuite/ada_lsp/completion.subp_parameters/test.json
+++ b/testsuite/ada_lsp/completion.subp_parameters/test.json
@@ -396,24 +396,6 @@
                   "result": {
                       "isIncomplete": false,
                       "items": [
-                          {
-                              "label": "A",
-                              "kind": 5,
-                              "detail": "A : Integer;",
-                              "documentation": "at bar.ads (4:7)",
-                              "sortText": "~A",
-                              "additionalTextEdits": [
-                            ]
-                          },
-                          {
-                              "label": "A",
-                              "kind": 6,
-                              "detail": "A :Integer",
-                              "documentation": "at bar.ads (7:40)",
-                              "sortText": "~A",
-                              "additionalTextEdits": [
-                              ]
-                          },
                         {
                            "label": "A",
                            "kind": 6,
@@ -422,7 +404,28 @@
                            "additionalTextEdits": []
                         },
                           {
-                              "label": "A",
+                              "label": "A (invisible)",
+                              "insertText": "A",
+                              "kind": 5,
+                              "detail": "A : Integer;",
+                              "documentation": "at bar.ads (4:7)",
+                              "sortText": "~A",
+                              "additionalTextEdits": [
+                            ]
+                          },
+                          {
+                              "label": "A (invisible)",
+                              "insertText": "A",
+                              "kind": 6,
+                              "detail": "A :Integer",
+                              "documentation": "at bar.ads (7:40)",
+                              "sortText": "~A",
+                              "additionalTextEdits": [
+                              ]
+                          },
+                          {
+                              "label": "A (invisible)",
+                              "insertText": "A",
                               "kind": 6,
                               "detail": "A, B : Integer",
                               "documentation": "at main.adb (6:18)",


### PR DESCRIPTION
with '(invisible)' text. Also don't provide snippets for
invisible symbols in completions, because we don't know
if this is a "dot call" or normal one.