### PR TITLE
T728-028: Don't propose snippets when providing parameters

### DIFF
--- a/source/ada/lsp-ada_completion_sets.adb
+++ b/source/ada/lsp-ada_completion_sets.adb
@@ -39,7 +39,6 @@ package body LSP.Ada_Completion_Sets is
    procedure Write_Completions
      (Context                  : LSP.Ada_Contexts.Context;
       Names                    : Completion_Maps.Map;
-      Use_Snippets             : Boolean;
       Named_Notation_Threshold : Natural;
       Result                   : in out LSP.Messages.CompletionItem_Vector) is
    begin
@@ -51,13 +50,13 @@ package body LSP.Ada_Completion_Sets is
          begin
             Result.Append
               (LSP.Ada_Documents.Compute_Completion_Item
-                 (Context,
-                  Name.P_Basic_Decl,
-                  Name,
-                  Use_Snippets,
-                  Named_Notation_Threshold,
-                  Is_Dot_Call => Info.Is_Dot_Call,
-                  Is_Visible  => Info.Is_Visible));
+                 (Context                  => Context,
+                  BD                       => Name.P_Basic_Decl,
+                  DN                       => Name,
+                  Use_Snippets             => Info.Use_Snippets,
+                  Named_Notation_Threshold => Named_Notation_Threshold,
+                  Is_Dot_Call              => Info.Is_Dot_Call,
+                  Is_Visible               => Info.Is_Visible));
          end;
       end loop;
    end Write_Completions;

--- a/source/ada/lsp-ada_completion_sets.ads
+++ b/source/ada/lsp-ada_completion_sets.ads
@@ -36,8 +36,9 @@ package LSP.Ada_Completion_Sets is
    --  The ticket for the corresponding compiler bug is T806-020.
 
    type Name_Information is record
-      Is_Dot_Call : Boolean;
-      Is_Visible  : Boolean;
+      Is_Dot_Call  : Boolean;
+      Is_Visible   : Boolean;
+      Use_Snippets : Boolean;
    end record;
 
    package Completion_Maps is new Ada.Containers.Hashed_Maps
@@ -50,7 +51,6 @@ package LSP.Ada_Completion_Sets is
    procedure Write_Completions
      (Context                  : LSP.Ada_Contexts.Context;
       Names                    : Completion_Maps.Map;
-      Use_Snippets             : Boolean;
       Named_Notation_Threshold : Natural;
       Result                   : in out LSP.Messages.CompletionItem_Vector);
 

--- a/source/ada/lsp-ada_documents.ads
+++ b/source/ada/lsp-ada_documents.ads
@@ -127,14 +127,15 @@ package LSP.Ada_Documents is
       Context                  : LSP.Ada_Contexts.Context;
       Position                 : LSP.Messages.Position;
       Named_Notation_Threshold : Natural;
-      Should_Use_Snippets      : in out Boolean;
+      Snippets_Enabled         : Boolean;
       Should_Use_Names         : in out Boolean;
       Names                    : out Ada_Completion_Sets.Completion_Maps.Map;
       Result                   : out LSP.Messages.CompletionList);
    --  Populate Result with completions for given position in the document.
    --  Named_Notation_Threshold defines the number of components at which point
    --  named notation is used for aggregate completion snippets.
-   --  Reset Should_Use_Snippets is snippets have no sence in given position.
+   --  If Use_Snippets is True, completion for subprograms and aggregates
+   --  will be given in the form of snippets when it makes sense.
    --  In case when no defining names could be used for completion (for
    --  instange inside aggregates, pragmas, keywords, etc) set Should_Use_Names
    --  to False. Otherwise set it to True and populate Names instead of Result.
@@ -208,7 +209,7 @@ package LSP.Ada_Documents is
      (Context                  : LSP.Ada_Contexts.Context;
       BD                       : Libadalang.Analysis.Basic_Decl;
       DN                       : Libadalang.Analysis.Defining_Name;
-      Snippets_Enabled         : Boolean;
+      Use_Snippets             : Boolean;
       Named_Notation_Threshold : Natural;
       Is_Dot_Call              : Boolean;
       Is_Visible               : Boolean)
@@ -217,7 +218,7 @@ package LSP.Ada_Documents is
    --  Node is the node from which the completion starts (e.g: 'A' in 'A.').
    --  BD and DN are respectively the basic declaration and the defining name
    --  that should be used to compute the completion item.
-   --  When Snippets_Enabled is True, subprogram completion items are computed
+   --  When Use_Snippets is True, subprogram completion items are computed
    --  as snippets that list all the subprogram's formal parameters.
    --  Named_Notation_Threshold defines the number of parameters at which point
    --  named notation is used for subprogram completion snippets.

--- a/testsuite/ada_lsp/completion.no_snippet_for_params/main.adb
+++ b/testsuite/ada_lsp/completion.no_snippet_for_params/main.adb
@@ -1,0 +1,23 @@
+with Ada.Text_IO;
+
+procedure Main is
+
+   type Subp_Access is access procedure (A : Integer);
+
+   procedure Print_Integer (A : integer);
+
+   procedure Print_Integer (A : integer) is
+   begin
+      Ada.Text_IO.Put_Line (A'Img);
+   end Print_Integer;
+
+   procedure Do_Something (Subp : Subp_Access; A : Integer);
+
+   procedure Do_Something (Subp : Subp_Access; A : Integer) is
+   begin
+      Subp (A);
+   end Do_Something;
+
+begin
+   Do_Something (Pri
+end Main;

--- a/testsuite/ada_lsp/completion.no_snippet_for_params/test.json
+++ b/testsuite/ada_lsp/completion.no_snippet_for_params/test.json
@@ -1,0 +1,285 @@
+[
+   {
+      "comment": [
+          "This test checks that we don't use snippets when giving a ",
+          "subprogram as a parameter."
+      ]
+   },
+   {
+      "start": {
+         "cmd": [
+            "${ALS}"
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+               "processId": 4969,
+               "rootUri": "$URI{.}",
+               "capabilities": {
+                  "workspace": {
+                     "applyEdit": true,
+                     "workspaceEdit": {},
+                     "didChangeConfiguration": {},
+                     "didChangeWatchedFiles": {},
+                     "executeCommand": {}
+                  },
+                  "textDocument": {
+                     "synchronization": {},
+                     "completion": {
+                        "dynamicRegistration": true,
+                        "completionItem": {
+                           "snippetSupport": true,
+                           "documentationFormat": [
+                              "plaintext",
+                              "markdown"
+                           ]
+                        }
+                     },
+                     "hover": {},
+                     "signatureHelp": {},
+                     "declaration": {},
+                     "definition": {},
+                     "typeDefinition": {},
+                     "implementation": {},
+                     "references": {},
+                     "documentHighlight": {},
+                     "documentSymbol": {
+                        "hierarchicalDocumentSymbolSupport": true
+                     },
+                     "codeLens": {},
+                     "colorProvider": {},
+                     "formatting": {
+                        "dynamicRegistration": true
+                     },
+                     "rangeFormatting": {},
+                     "onTypeFormatting": {},
+                     "foldingRange": {
+                        "lineFoldingOnly": true
+                     },
+                     "selectionRange": {}
+                  }
+               }
+            }
+         },
+         "wait": [
+            {
+               "id": 1,
+               "result": {
+                  "capabilities": {
+                     "textDocumentSync": 2,
+                     "completionProvider": {
+                        "triggerCharacters": [
+                           ".",
+                           "("
+                        ],
+                        "resolveProvider": false
+                     },
+                     "hoverProvider": true,
+                     "declarationProvider": true,
+                     "definitionProvider": true,
+                     "typeDefinitionProvider": true,
+                     "implementationProvider": true,
+                     "referencesProvider": true,
+                     "documentSymbolProvider": true,
+                     "codeActionProvider": {},
+                     "documentFormattingProvider": true,
+                     "renameProvider": {},
+                     "foldingRangeProvider": true,
+                     "executeCommandProvider": {
+                        "commands": [
+                           "als-named-parameters"
+                        ]
+                     },
+                     "alsCalledByProvider": true,
+                     "alsCallsProvider": true,
+                     "alsShowDepsProvider": true,
+                     "alsReferenceKinds": [
+                        "reference",
+                        "access",
+                        "write",
+                        "call",
+                        "dispatching call",
+                        "parent",
+                        "child"
+                     ]
+                  }
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "initialized"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "workspace/didChangeConfiguration",
+            "params": {
+               "settings": {
+                  "ada": {
+                      "scenarioVariables": {},
+                      "defaultCharset": "ISO-8859-1",
+                      "enableIndexing": false,
+                      "enableDiagnostics": false
+                  }
+               }
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{main.adb}",
+                  "languageId": "Ada",
+                  "version": 0,
+                  "text": "with Ada.Text_IO;\n\nprocedure Main is\n\n   type Subp_Access is access procedure (A : Integer);\n\n   procedure Print_Integer (A : integer);\n\n   procedure Print_Integer (A : integer) is\n   begin\n      Ada.Text_IO.Put_Line (A'Img);\n   end Print_Integer;\n\n   procedure Do_Something (Subp : Subp_Access; A : Integer);\n\n   procedure Do_Something (Subp : Subp_Access; A : Integer) is\n   begin\n      Subp (A);\n   end Do_Something;\n\nbegin\n   Do_Something (Pri\nend Main;\n"
+               }
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "workspace/didChangeConfiguration",
+            "params": {
+               "settings": {
+                  "ada": {
+                     "foldComments": false
+                  }
+               }
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{main.adb}",
+                  "version": 1
+               },
+               "contentChanges": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 21,
+                           "character": 20
+                        },
+                        "end": {
+                           "line": 21,
+                           "character": 20
+                        }
+                     },
+                     "text": "n"
+                  }
+               ]
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": 4,
+            "method": "textDocument/completion",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{main.adb}"
+               },
+               "position": {
+                  "line": 21,
+                  "character": 21
+               }
+            }
+         },
+         "sortReply": { "result": {"items": ["label", "documentation"]} },
+         "wait": [
+            {
+               "id": 4,
+               "result": {
+                  "isIncomplete": false,
+                  "items": [
+                     {
+                        "label": "Print_Integer",
+                        "kind": 3,
+                        "detail": "procedure Print_Integer (A : integer)",
+                        "documentation": "at main.adb (7:4)",
+                        "additionalTextEdits": []
+                     },
+                     {
+                        "label": "Print_Integer",
+                        "kind": 3,
+                        "detail": "procedure Print_Integer (A : integer)",
+                        "documentation": "at main.adb (9:4)",
+                        "additionalTextEdits": []
+                     }
+                  ]
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didClose",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{main.adb}"
+               }
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": 7,
+            "method": "shutdown"
+         },
+         "wait": [
+            {
+               "id": 7,
+               "result": null
+            }
+         ]
+      }
+   },
+   {
+      "stop": {
+         "exit_code": 0
+      }
+   }
+]

--- a/testsuite/ada_lsp/completion.no_snippet_for_params/test.yaml
+++ b/testsuite/ada_lsp/completion.no_snippet_for_params/test.yaml
@@ -1,0 +1,1 @@
+title: 'completion.no_snippet_for_params'


### PR DESCRIPTION
In particular, we don't want to propose subprogram snippets when
giving a completing a subprogram name for an access-to-subprogram
parameter.

An automatic test has been added.