### PR TITLE
Highlighting: Add support for gnatprep preprocessor directives

### DIFF
--- a/integration/vscode/ada/advanced/ada.tmLanguage.json
+++ b/integration/vscode/ada/advanced/ada.tmLanguage.json
@@ -479,6 +479,7 @@
 		},
 		"comment": {
 			"patterns": [
+				{ "include": "#preprocessor" },
 				{ "include": "#comment-section" },
 				{ "include": "#comment-doc" },
 				{ "include": "#comment-line" }
@@ -1563,6 +1564,34 @@
 			},
 			"patterns": [
 				{ "include": "#expression" }
+			]
+		},
+		"preprocessor": {
+			"name": "meta.preprocessor.ada",
+			"patterns": [
+				{
+					"match": "^\\s*(#)(if|elsif)\\s+(.*)$",
+					"captures": {
+						"1": { "name": "punctuation.definition.directive.ada" },
+						"2": { "name": "keyword.control.directive.conditional.ada" },
+						"3": { "patterns": [ { "include": "#expression" } ] }
+					}
+				},
+				{
+					"match": "^\\s*(#)(end if)(;)",
+					"captures": {
+						"1": { "name": "punctuation.definition.directive.ada" },
+						"2": { "name": "keyword.control.directive.conditional" },
+						"3": { "name": "punctuation.ada" }
+					}
+				},
+				{
+					"match": "^\\s*(#)(else)",
+					"captures": {
+						"1": { "name": "punctuation.definition.directive.ada" },
+						"2": { "name": "keyword.control.directive.conditional" }
+					}
+				}
 			]
 		},
 		"procedure_body": {


### PR DESCRIPTION
Hello,
This is not a very important change. It just add an highlighting support for preprocessor directives.
Since gnatprep is almost never used, this change is not a big deal, but can be still useful.