### PR TITLE
T122-009: Change textDocument/definition behavior

### DIFF
--- a/source/ada/lsp-ada_handlers.adb
+++ b/source/ada/lsp-ada_handlers.adb
@@ -1155,6 +1155,14 @@ package body LSP.Ada_Handlers is
 
             Decl_For_Find_Overrides := Definition.P_Basic_Decl;
 
+            --  Search for overriding subprograms only if we are on an
+            --  abstract subprogram.
+            if Decl_For_Find_Overrides.Kind
+              not in Ada_Abstract_Subp_Decl_Range
+            then
+               Decl_For_Find_Overrides := No_Basic_Decl;
+            end if;
+
             if Other_Part = No_Defining_Name then
                --  No next part is found. Check first defining name
                Other_Part := Find_Canonical_Part (Definition, Self.Trace);

--- a/testsuite/ada_lsp/definition_parents/test.json
+++ b/testsuite/ada_lsp/definition_parents/test.json
@@ -239,54 +239,6 @@
                   {
                      "range": {
                         "start": {
-                           "line": 4,
-                           "character": 13
-                        },
-                        "end": {
-                           "line": 4,
-                           "character": 19
-                        }
-                     },
-                     "alsKind": [
-                        "parent"
-                     ],
-                     "uri": "$URI{pack.ads}"
-                  },
-                  {
-                     "range": {
-                        "start": {
-                           "line": 12,
-                           "character": 24
-                        },
-                        "end": {
-                           "line": 12,
-                           "character": 30
-                        }
-                     },
-                     "alsKind": [
-                        "child"
-                     ],
-                     "uri": "$URI{pack.ads}"
-                  },
-                  {
-                     "range": {
-                        "start": {
-                           "line": 16,
-                           "character": 24
-                        },
-                        "end": {
-                           "line": 16,
-                           "character": 30
-                        }
-                     },
-                     "alsKind": [
-                        "child"
-                     ],
-                     "uri": "$URI{pack.ads}"
-                  },
-                  {
-                     "range": {
-                        "start": {
                            "line": 2,
                            "character": 24
                         },
@@ -322,40 +274,7 @@
          "wait": [
             {
                "id": 7,
-               "result": [
-                  {
-                     "range": {
-                        "start": {
-                           "line": 4,
-                           "character": 13
-                        },
-                        "end": {
-                           "line": 4,
-                           "character": 19
-                        }
-                     },
-                     "alsKind": [
-                        "parent"
-                     ],
-                     "uri": "$URI{pack.ads}"
-                  },
-                  {
-                     "range": {
-                        "start": {
-                           "line": 8,
-                           "character": 24
-                        },
-                        "end": {
-                           "line": 8,
-                           "character": 30
-                        }
-                     },
-                     "alsKind": [
-                        "parent"
-                     ],
-                     "uri": "$URI{pack.ads}"
-                  }
-               ]
+               "result": []
             }
          ]
       }
@@ -381,38 +300,6 @@
             {
                "id": 10,
                "result": [
-                  {
-                     "range": {
-                        "start": {
-                           "line": 4,
-                           "character": 13
-                        },
-                        "end": {
-                           "line": 4,
-                           "character": 19
-                        }
-                     },
-                     "alsKind": [
-                        "parent"
-                     ],
-                     "uri": "$URI{pack.ads}"
-                  },
-                  {
-                     "range": {
-                        "start": {
-                           "line": 8,
-                           "character": 24
-                        },
-                        "end": {
-                           "line": 8,
-                           "character": 30
-                        }
-                     },
-                     "alsKind": [
-                        "parent"
-                     ],
-                     "uri": "$URI{pack.ads}"
-                  },
                   {
                      "range": {
                         "start": {


### PR DESCRIPTION
List the overriding subprograms only if we are clicking on a 'usage'
name (e.g: subprogram call) or on abstract subprogram declarations.