### PR TITLE
T908-028 Correct "<" of References_By_Subprogram

### DIFF
--- a/source/ada/lsp-lal_utils.ads
+++ b/source/ada/lsp-lal_utils.ads
@@ -123,11 +123,14 @@ package LSP.Lal_Utils is
      (Base_Id);
 
    function "<" (Left, Right : Defining_Name) return Boolean is
-     (Left.Text <= Right.Text);
+     (Left.Text < Right.Text
+      or else (Left.Text = Right.Text
+               and then Left.Full_Sloc_Image < Right.Full_Sloc_Image));
    --  The Ordered_Maps is using the "<" in its Equivalent_Keys function:
    --  this is too basic and it will assume that Left.Text = Right.Text implies
    --  Left = Right which is wrong.
-   --  By using "<=" we are breaking the equality and we are keeping the order.
+   --  If Left.Text = Right.Text then Full_Sloc_Image will sort first by
+   --  file and then by Sloc (first by line and then by column).
 
    package References_By_Subprogram is new Ada.Containers.Ordered_Maps
      (Key_Type     => Defining_Name,

--- a/testsuite/ada_lsp/T709-018.is_called_by.name_collision/test.json
+++ b/testsuite/ada_lsp/T709-018.is_called_by.name_collision/test.json
@@ -134,56 +134,6 @@
                            "range": {
                               "start": {
                                  "line": 4, 
-                                 "character": 20
-                              }, 
-                              "end": {
-                                 "line": 4, 
-                                 "character": 23
-                              }
-                           }, 
-                           "alsKind": [
-                              "call"
-                           ], 
-                           "uri": "$URI{pack2.adb}"
-                        }, 
-                        {
-                           "range": {
-                              "start": {
-                                 "line": 4, 
-                                 "character": 33
-                              }, 
-                              "end": {
-                                 "line": 4, 
-                                 "character": 36
-                              }
-                           }, 
-                           "alsKind": [
-                              "call"
-                           ], 
-                           "uri": "$URI{pack2.adb}"
-                        }
-                     ], 
-                     "location": {
-                        "range": {
-                           "start": {
-                              "line": 6, 
-                              "character": 23
-                           }, 
-                           "end": {
-                              "line": 6, 
-                              "character": 29
-                           }
-                        }, 
-                        "uri": "$URI{pack2.ads}"
-                     }, 
-                     "name": "Create"
-                  }, 
-                  {
-                     "refs": [
-                        {
-                           "range": {
-                              "start": {
-                                 "line": 4, 
                                  "character": 37
                               }, 
                               "end": {
@@ -257,6 +207,56 @@
                            }
                         }, 
                         "uri": "$URI{pack1.ads}"
+                     }, 
+                     "name": "Create"
+                  },
+                  {
+                     "refs": [
+                        {
+                           "range": {
+                              "start": {
+                                 "line": 4, 
+                                 "character": 20
+                              }, 
+                              "end": {
+                                 "line": 4, 
+                                 "character": 23
+                              }
+                           }, 
+                           "alsKind": [
+                              "call"
+                           ], 
+                           "uri": "$URI{pack2.adb}"
+                        }, 
+                        {
+                           "range": {
+                              "start": {
+                                 "line": 4, 
+                                 "character": 33
+                              }, 
+                              "end": {
+                                 "line": 4, 
+                                 "character": 36
+                              }
+                           }, 
+                           "alsKind": [
+                              "call"
+                           ], 
+                           "uri": "$URI{pack2.adb}"
+                        }
+                     ], 
+                     "location": {
+                        "range": {
+                           "start": {
+                              "line": 6, 
+                              "character": 23
+                           }, 
+                           "end": {
+                              "line": 6, 
+                              "character": 29
+                           }
+                        }, 
+                        "uri": "$URI{pack2.ads}"
                      }, 
                      "name": "Create"
                   }


### PR DESCRIPTION
Map keys are now sorted by text, then by filename, then by sloc
(first by line and then by column).
Test T709-018.is_called_by.name_collision updated since pack1.ads
results now come first than pack2.ads results.