### PR TITLE
T916-036 Re-install the tester scripts as part of install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,8 @@ endif
 install:
 	gprinstall -f -P gnat/lsp_server.gpr -p -r --mode=usage \
 		--prefix=$(DESTDIR) $(LIBRARY_FLAGS)
+	gprinstall -f -P gnat/tester.gpr -p --prefix=$(DESTDIR) $(LIBRARY_FLAGS)
+	gprinstall -f -P gnat/codec_test.gpr -p --prefix=$(DESTDIR) $(LIBRARY_FLAGS)
 	gprinstall -f -P gnat/lsp_client.gpr -p -r	\
 		--mode=dev				\
 		--prefix=$(DESTDIR)			\


### PR DESCRIPTION
Temporarily: this is needed for the testing infrastructure
internal to AdaCore.