### PR TITLE
Fix an issue with potential read of an uninitialized variable

### DIFF
--- a/source/ada/lsp-ada_handlers.adb
+++ b/source/ada/lsp-ada_handlers.adb
@@ -1187,9 +1187,8 @@ package body LSP.Ada_Handlers is
                   Is_Child);
                Imprecise := Imprecise or This_Imprecise;
             end loop;
+            Imprecise := Imprecise or Find_All_Imprecise;
          end if;
-
-         Imprecise := Imprecise or Find_All_Imprecise;
       end Resolve_In_Context;
 
    begin


### PR DESCRIPTION
Read the value of Find_All_Imprecise in the branch where it is
set.