### PR TITLE
T923-019 add a test

### DIFF
--- a/testsuite/ada_lsp/T923-019.project_reload.gnatpp/a.adb
+++ b/testsuite/ada_lsp/T923-019.project_reload.gnatpp/a.adb
@@ -1,0 +1,4 @@
+procedure a is
+begin
+  null;
+end a;

--- a/testsuite/ada_lsp/T923-019.project_reload.gnatpp/p.gpr
+++ b/testsuite/ada_lsp/T923-019.project_reload.gnatpp/p.gpr
@@ -1,0 +1,23 @@
+project P is
+
+   type Var_Type is ("A", "B", "C");
+   Var : Var_Type := external("VAR", "A");
+
+   package Pretty_Printer is
+      case Var is
+         when "A" =>
+            for Default_Switches ("ada") use
+              ("--vertical-enum_types", "--max-line-length=12000",
+               "--par-threshold=50");
+         when "B" =>
+            for Default_Switches ("ada") use
+              ("--vertical-enum_types", "--max-line-length=13000",
+               "--par-threshold=30");
+         when "C" =>
+            for Default_Switches ("ada") use
+              ("--vertical-enum_types", "--max-line-length=14000",
+               "--par-threshold=40");
+      end case;
+   end Pretty_Printer;
+
+end P;

--- a/testsuite/ada_lsp/T923-019.project_reload.gnatpp/test.json
+++ b/testsuite/ada_lsp/T923-019.project_reload.gnatpp/test.json
@@ -1,0 +1,271 @@
+[
+   {
+      "comment": [
+         "check memory when reloading projects that contain gnatpp switches"
+      ]
+   },
+   {
+      "start": {
+         "cmd": [
+            "${ALS}"
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": "ada-1",
+            "method": "initialize",
+            "params": {
+               "rootUri": "$URI{.}",
+               "capabilities": {
+                  "workspace": {
+                     "applyEdit": true,
+                     "workspaceEdit": {},
+                     "didChangeConfiguration": {},
+                     "didChangeWatchedFiles": {},
+                     "executeCommand": {}
+                  },
+                  "textDocument": {
+                     "synchronization": {},
+                     "completion": {
+                        "dynamicRegistration": true,
+                        "completionItem": {
+                           "snippetSupport": true,
+                           "documentationFormat": [
+                              "plaintext",
+                              "markdown"
+                           ]
+                        }
+                     },
+                     "hover": {},
+                     "signatureHelp": {},
+                     "declaration": {},
+                     "definition": {},
+                     "typeDefinition": {},
+                     "implementation": {},
+                     "references": {},
+                     "documentHighlight": {},
+                     "documentSymbol": {
+                        "hierarchicalDocumentSymbolSupport": true
+                     },
+                     "codeLens": {},
+                     "colorProvider": {},
+                     "formatting": {
+                        "dynamicRegistration": false
+                     },
+                     "rangeFormatting": {
+                        "dynamicRegistration": false
+                     },
+                     "onTypeFormatting": {
+                        "dynamicRegistration": false
+                     },
+                     "foldingRange": {
+                        "lineFoldingOnly": true
+                     },
+                     "selectionRange": {},
+                     "callHierarchy": {}
+                  }
+               }
+            }
+         },
+         "wait": [
+            {
+               "id": "ada-1",
+               "result": {
+                  "capabilities": {
+                     "textDocumentSync": 2,
+                     "completionProvider": {
+                        "triggerCharacters": [
+                           ".",
+                           "("
+                        ],
+                        "resolveProvider": false
+                     },
+                     "hoverProvider": true,
+                     "declarationProvider": true,
+                     "definitionProvider": true,
+                     "typeDefinitionProvider": true,
+                     "implementationProvider": true,
+                     "referencesProvider": true,
+                     "documentSymbolProvider": true,
+                     "codeActionProvider": {},
+                     "documentFormattingProvider": true,
+                     "renameProvider": {},
+                     "foldingRangeProvider": true,
+                     "executeCommandProvider": {
+                        "commands": [
+                           "als-named-parameters",
+                           "als-refactor-imports"
+                        ]
+                     },
+                     "workspaceSymbolProvider": true,
+                     "alsCalledByProvider": true,
+                     "alsCallsProvider": true,
+                     "alsShowDepsProvider": true,
+                     "alsReferenceKinds": [
+                        "reference",
+                        "access",
+                        "write",
+                        "call",
+                        "dispatching call",
+                        "parent",
+                        "child"
+                     ]
+                  }
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "initialized"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "workspace/didChangeConfiguration",
+            "params": {
+               "settings": {
+                  "ada": {
+                     "projectFile": "p.gpr",
+                     "scenarioVariables": {
+                        "VAR": "A"
+                     },
+                     "defaultCharset": "ISO-8859-1",
+                     "enableDiagnostics": true
+                  }
+               }
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{a.adb}",
+                  "languageId": "Ada",
+                  "version": 0,
+                  "text": "procedure a is\nbegin\n  null;\nend a;\n"
+               }
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "workspace/didChangeConfiguration",
+            "params": {
+               "settings": {
+                  "ada": {
+                     "foldComments": false
+                  }
+               }
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "workspace/didChangeConfiguration",
+            "params": {
+               "settings": {
+                  "ada": {
+                     "projectFile": "p.gpr",
+                     "scenarioVariables": {
+                        "VAR": "B"
+                     },
+                     "defaultCharset": "ISO-8859-1",
+                     "enableDiagnostics": true
+                  }
+               }
+            }
+         },
+         "wait": [
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "workspace/didChangeConfiguration",
+            "params": {
+               "settings": {
+                  "ada": {
+                     "projectFile": "p.gpr",
+                     "scenarioVariables": {
+                        "VAR": "C"
+                     },
+                     "defaultCharset": "ISO-8859-1",
+                     "enableDiagnostics": true
+                  }
+               }
+            }
+         },
+         "wait": [
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didClose",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{a.adb}"
+               }
+            }
+         },
+         "wait": [
+            {
+               "method": "textDocument/publishDiagnostics",
+               "params": {
+                  "uri": "$URI{a.adb}",
+                  "diagnostics": []
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": "ada-6",
+            "method": "shutdown"
+         },
+         "wait": [
+            {
+               "id": "ada-6",
+               "result": null
+            }
+         ]
+      }
+   },
+   {
+      "stop": {
+         "exit_code": 0
+      }
+   }
+]

--- a/testsuite/ada_lsp/T923-019.project_reload.gnatpp/test.yaml
+++ b/testsuite/ada_lsp/T923-019.project_reload.gnatpp/test.yaml
@@ -1,0 +1,1 @@
+title: 'T923-019.project_reload.gnatpp'


### PR DESCRIPTION
This tests for memory corruption when loading several times
a project that defines gnatpp switches. The corresponding fix
is in libadalang-tools.