### PR TITLE
T812-022: Imprecise results for text/Definition

### DIFF
--- a/source/ada/lsp-ada_handlers.adb
+++ b/source/ada/lsp-ada_handlers.adb
@@ -1300,7 +1300,7 @@ package body LSP.Ada_Handlers is
             end if;
          else  --  If we are on a defining_name already
             Other_Part := Laltools.Common.Find_Next_Part
-              (Definition, Self.Trace);
+              (Definition, Self.Trace, Imprecise_Fallback => True);
 
             Decl_For_Find_Overrides := Definition.P_Basic_Decl;
 
@@ -1318,7 +1318,7 @@ package body LSP.Ada_Handlers is
             if Other_Part = No_Defining_Name then
                --  No next part is found. Check first defining name
                Other_Part := Laltools.Common.Find_Canonical_Part
-                 (Definition, Self.Trace);
+                 (Definition, Self.Trace, Imprecise_Fallback => True);
             end if;
 
             if Other_Part /= No_Defining_Name then

--- a/testsuite/ada_lsp/SA11-040.definition.fallback/test.json
+++ b/testsuite/ada_lsp/SA11-040.definition.fallback/test.json
@@ -1,7 +1,8 @@
 [
    {
       "comment": [
-         "test the fallback navigation to subprograms that don't have an exact profile"
+         "test the fallback navigation to subprograms that don't have an",
+         "exact profile"
       ]
    },
    {
@@ -121,13 +122,6 @@
          },
          "wait": [
             {
-               "params": {
-                  "message": "The result of 'definition' is approximate.",
-                  "type": 2
-               },
-               "method": "window/showMessage"
-            },
-            {
                "id": 2,
                "result": [
                   {
@@ -165,7 +159,6 @@
          "wait": []
       }
    },
-   {"comment": "--------- expecting an empty result for the definition of a procedure which 'is null' -------"},
    {
       "send": {
          "request": {
@@ -185,7 +178,21 @@
          "wait": [
             {
                "id": 3,
-               "result": []
+               "result": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 7,
+                           "character": 16
+                        },
+                        "end": {
+                           "line": 7,
+                           "character": 19
+                        }
+                     },
+                     "uri": "$URI{p.ads}"
+                  }
+               ]
             }
          ]
       }

--- a/testsuite/ada_lsp/SC16-095.fallback_when_no_body/test.json
+++ b/testsuite/ada_lsp/SC16-095.fallback_when_no_body/test.json
@@ -206,7 +206,21 @@
          "wait": [
             {
                "id": 4,
-               "result": []
+               "result": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 11,
+                           "character": 13
+                        },
+                        "end": {
+                           "line": 11,
+                           "character": 19
+                        }
+                     },
+                     "uri": "$URI{pack.adb}"
+                  }
+               ]
             }
          ]
       }

--- a/testsuite/ada_lsp/T812-022.declaration.imprecise/foo.adb
+++ b/testsuite/ada_lsp/T812-022.declaration.imprecise/foo.adb
@@ -1,0 +1,18 @@
+with Ada.Text_IO; use Ada.Text_IO;
+with Pack;
+
+procedure Foo2 is
+begin
+   declare
+      procedure Hello;
+      procedure Hello (J : Float) is
+      begin
+         Put_Line ("Hello World");
+      end Hello;
+   begin
+      Hello;
+      Hello (1);
+      Pack.Hello (1);
+      Pack.Hello;
+   end;
+end Foo2;

--- a/testsuite/ada_lsp/T812-022.declaration.imprecise/pack.adb
+++ b/testsuite/ada_lsp/T812-022.declaration.imprecise/pack.adb
@@ -1,0 +1,7 @@
+package body Pack is
+
+   procedure Hello (I : Integer) is
+   begin
+      null;
+   end Hello;
+end Pack;

--- a/testsuite/ada_lsp/T812-022.declaration.imprecise/pack.ads
+++ b/testsuite/ada_lsp/T812-022.declaration.imprecise/pack.ads
@@ -1,0 +1,5 @@
+package Pack is
+
+   procedure Hello (I : Integer);
+
+end Pack;

--- a/testsuite/ada_lsp/T812-022.declaration.imprecise/test.gpr
+++ b/testsuite/ada_lsp/T812-022.declaration.imprecise/test.gpr
@@ -1,0 +1,3 @@
+project Test is
+   for Main use ("foo.adb");
+end Test;

--- a/testsuite/ada_lsp/T812-022.declaration.imprecise/test.json
+++ b/testsuite/ada_lsp/T812-022.declaration.imprecise/test.json
@@ -1,0 +1,559 @@
+[
+   {
+      "comment": [
+         "Advanced example testing the imprecive fallback of ",
+         "the definition request"
+      ]
+   },
+   {
+      "start": {
+         "cmd": [
+            "${ALS}"
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "capabilities": {
+                  "workspace": {
+                     "applyEdit": false
+                  }
+               },
+               "rootUri": "$URI{.}"
+            },
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize"
+         },
+         "wait": [
+            {
+               "id": 1,
+               "result": {
+                  "capabilities": {
+                     "typeDefinitionProvider": true,
+                     "alsReferenceKinds": [
+                        "reference",
+                         "access",
+                        "write",
+                        "call",
+                        "dispatching call", "parent", "child"
+                     ],
+                     "hoverProvider": true,
+                     "definitionProvider": true,
+                     "renameProvider": {},
+                     "alsCalledByProvider": true,
+                     "referencesProvider": true,
+                     "textDocumentSync": 2,
+                     "completionProvider": {
+                        "triggerCharacters": [
+                            ".",
+                            "("
+                        ],
+                        "resolveProvider": false
+                     },
+                     "documentSymbolProvider": true
+                  }
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "initialized"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "settings": {
+                  "ada": {
+                     "scenarioVariables": {},
+                     "enableDiagnostics": false,
+                     "defaultCharset": "ISO-8859-1"
+                  }
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "workspace/didChangeConfiguration"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}",
+                  "languageId": "Ada",
+                  "version": 0,
+                  "text": "with Ada.Text_IO; use Ada.Text_IO;\nwith Pack;\n\nprocedure Foo2 is\nbegin\n   declare\n      procedure Hello;\n      procedure Hello (J : Float) is\n      begin\n         Put_Line (\"Hello World\");\n      end Hello;\n   begin\n      Hello;\n      Hello (1);\n      Pack.Hello (1);\n      Pack.Hello;\n   end;\nend Foo2;\n"
+               }
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{pack.ads}",
+                  "languageId": "Ada",
+                  "version": 0,
+                  "text": "package Pack is\n\n   procedure Hello (I : Integer);\n\nend Pack;\n"
+               }
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{pack.adb}",
+                  "languageId": "Ada",
+                  "version": 0,
+                  "text": "package body Pack is\n\n   procedure Hello (I : Integer) is\n   begin\n      null;\n   end Hello;\nend Pack;\n"
+               }
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": "ada-6",
+            "method": "textDocument/definition",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}"
+               },
+               "position": {
+                  "line": 12,
+                  "character": 6
+               }
+            }
+         },
+         "wait": [
+            {
+               "id": "ada-6",
+               "result": [
+                  {
+                     "uri": "$URI{foo.adb}",
+                     "range": {
+                        "start": {
+                           "line": 6,
+                           "character": 16
+                        },
+                        "end": {
+                           "line": 6,
+                           "character": 21
+                        }
+                     }
+                  }
+               ]
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": "ada-7",
+            "method": "textDocument/definition",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}"
+               },
+               "position": {
+                  "line": 6,
+                  "character": 16
+               }
+            }
+         },
+         "wait": [
+            {
+               "id": "ada-7",
+               "result": [
+                  {
+                     "uri": "$URI{foo.adb}",
+                     "range": {
+                        "start": {
+                           "line": 7,
+                           "character": 16
+                        },
+                        "end": {
+                           "line": 7,
+                           "character": 21
+                        }
+                     }
+                  }
+               ]
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": "ada-8",
+            "method": "textDocument/definition",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}"
+               },
+               "position": {
+                  "line": 10,
+                  "character": 10
+               }
+            }
+         },
+         "wait": [
+            {
+               "id": "ada-8",
+               "result": [
+                  {
+                     "uri": "$URI{foo.adb}",
+                     "range": {
+                        "start": {
+                           "line": 7,
+                           "character": 16
+                        },
+                        "end": {
+                           "line": 7,
+                           "character": 21
+                        }
+                     }
+                  }
+               ]
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": "ada-9",
+            "method": "textDocument/definition",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}"
+               },
+               "position": {
+                  "line": 13,
+                  "character": 6
+               }
+            }
+         },
+         "wait": [
+            {
+               "method": "window/showMessage",
+               "params": {
+                  "type": 3,
+                  "message": "Imprecise fallback used to compute cross-references on entity at:\n   foo.adb\n   line: 13\n   column: 6"
+               }
+            },
+            {
+               "id": "ada-9",
+               "result": [
+                  {
+                     "uri": "$URI{foo.adb}",
+                     "range": {
+                        "start": {
+                           "line": 7,
+                           "character": 16
+                        },
+                        "end": {
+                           "line": 7,
+                           "character": 21
+                        }
+                     }
+                  }
+               ]
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": "ada-10",
+            "method": "textDocument/definition",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}"
+               },
+               "position": {
+                  "line": 14,
+                  "character": 11
+               }
+            }
+         },
+         "wait": [
+            {
+               "id": "ada-10",
+               "result": [
+                  {
+                     "uri": "$URI{pack.ads}",
+                     "range": {
+                        "start": {
+                           "line": 2,
+                           "character": 13
+                        },
+                        "end": {
+                           "line": 2,
+                           "character": 18
+                        }
+                     }
+                  }
+               ]
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": "ada-12",
+            "method": "textDocument/definition",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{pack.ads}"
+               },
+               "position": {
+                  "line": 2,
+                  "character": 13
+               }
+            }
+         },
+         "wait": [
+            {
+               "id": "ada-12",
+               "result": [
+                  {
+                     "uri": "$URI{pack.adb}",
+                     "range": {
+                        "start": {
+                           "line": 2,
+                           "character": 13
+                        },
+                        "end": {
+                           "line": 2,
+                           "character": 18
+                        }
+                     }
+                  }
+               ]
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": "ada-14",
+            "method": "textDocument/definition",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{pack.adb}"
+               },
+               "position": {
+                  "line": 2,
+                  "character": 13
+               }
+            }
+         },
+         "wait": [
+            {
+               "id": "ada-14",
+               "result": [
+                  {
+                     "uri": "$URI{pack.ads}",
+                     "range": {
+                        "start": {
+                           "line": 2,
+                           "character": 13
+                        },
+                        "end": {
+                           "line": 2,
+                           "character": 18
+                        }
+                     }
+                  }
+               ]
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": "ada-17",
+            "method": "textDocument/definition",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{pack.adb}"
+               },
+               "position": {
+                  "line": 5,
+                  "character": 7
+               }
+            }
+         },
+         "wait": [
+            {
+               "id": "ada-17",
+               "result": [
+                  {
+                     "uri": "$URI{pack.ads}",
+                     "range": {
+                        "start": {
+                           "line": 2,
+                           "character": 13
+                        },
+                        "end": {
+                           "line": 2,
+                           "character": 18
+                        }
+                     }
+                  }
+               ]
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": "ada-21",
+            "method": "textDocument/definition",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}"
+               },
+               "position": {
+                  "line": 15,
+                  "character": 11
+               }
+            }
+         },
+         "wait": [
+            {
+               "method": "window/showMessage",
+               "params": {
+                  "type": 3,
+                  "message": "Imprecise fallback used to compute cross-references on entity at:\n   foo.adb\n   line: 15\n   column: 11"
+               }
+            },
+            {
+               "id": "ada-21",
+               "result": [
+                  {
+                     "uri": "$URI{pack.ads}",
+                     "range": {
+                        "start": {
+                           "line": 2,
+                           "character": 13
+                        },
+                        "end": {
+                           "line": 2,
+                           "character": 18
+                        }
+                     }
+                  }
+               ]
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didClose",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}"
+               }
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didClose",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{pack.adb}"
+               }
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didClose",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{pack.ads}"
+               }
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": "ada-23",
+            "method": "shutdown"
+         },
+         "wait": [
+            {
+               "id": "ada-23",
+               "result": null
+            }
+         ]
+      }
+   },
+   {
+      "stop": {
+         "exit_code": 0
+      }
+   }
+]

--- a/testsuite/ada_lsp/T812-022.declaration.imprecise/test.yaml
+++ b/testsuite/ada_lsp/T812-022.declaration.imprecise/test.yaml
@@ -1,0 +1,1 @@
+title: 'T812-022.declaration.imprecise'

--- a/testsuite/ada_lsp/definition_parents/test.json
+++ b/testsuite/ada_lsp/definition_parents/test.json
@@ -209,6 +209,19 @@
                         "child"
                      ],
                      "uri": "$URI{pack.ads}"
+                  },
+                  {
+                     "range": {
+                        "start": {
+                           "line": 4,
+                           "character": 24
+                        },
+                        "end": {
+                           "line": 4,
+                           "character": 30
+                        }
+                     },
+                     "uri": "$URI{pack.adb}"
                   }
                ]
             }
@@ -274,7 +287,20 @@
          "wait": [
             {
                "id": 7,
-               "result": []
+               "result": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 16,
+                           "character": 24
+                        },
+                        "end": {
+                           "line": 16,
+                           "character": 30
+                        }
+                     },
+                     "uri": "$URI{pack.ads}"
+                  }]
             }
          ]
       }


### PR DESCRIPTION
Better handling to navigate between the declaration/body/ref
when the profiles are slightly different (common case:
the user is modifying the spec profile and then wants to
navigate to the body)

Add a test.