### PR TITLE
T306-003 GNAT Studio's relocate-build-tree switch

### DIFF
--- a/doc/settings.md
+++ b/doc/settings.md
@@ -53,7 +53,7 @@ files from disk by specifying an `defaultCharset` key. The default is
 ## relocateBuildTree
 That is, real object, library or exec directories are relocated to the
 current working directory or dir if specified. Ensure that it is full
-normalized patch ended with the directory separator.
+normalized path ended with the directory separator.
 ```javascript
     'relocateBuildTree': '/home/user/project/build/'
 ```
@@ -61,7 +61,7 @@ normalized patch ended with the directory separator.
 ## rootDir
 This option is to be used with relocateBuildTree above and cannot be
 specified alone. This option specifies the root directory for artifacts
-for proper relocation. Ensure that it is full normalized patch ended
+for proper relocation. Ensure that it is full normalized path ended
 with the directory separator.
 ```javascript
     'relocateBuildTree': '/home/user/project/'

--- a/doc/settings.md
+++ b/doc/settings.md
@@ -51,9 +51,10 @@ files from disk by specifying an `defaultCharset` key. The default is
 ```
 
 ## relocateBuildTree
-That is, real object, library or exec directories are relocated to the
-current working directory or dir if specified. Ensure that it is full
-normalized path ended with the directory separator. Visit
+With this option it is possible to achieve out-of-tree build.That is,
+real object, library or exec directories are relocated to the current
+working directory or dir if specified. Ensure that it is full normalized
+path ended with the directory separator. Visit
 https://docs.adacore.com/gprbuild-docs/html/gprbuild_ug/building_with_gprbuild.html#switches
 for more details about the corresponding grpbuild switch.
 ```javascript

--- a/doc/settings.md
+++ b/doc/settings.md
@@ -55,7 +55,7 @@ That is, real object, library or exec directories are relocated to the
 current working directory or dir if specified. Ensure that it is full
 normalized patch ended with the directory separator.
 ```javascript
-    'relocateBuildTree': '~/home/user/project/build/'
+    'relocateBuildTree': '/home/user/project/build/'
 ```
 
 ## rootDir
@@ -64,7 +64,7 @@ specified alone. This option specifies the root directory for artifacts
 for proper relocation. Ensure that it is full normalized patch ended
 with the directory separator.
 ```javascript
-    'relocateBuildTree': '~/home/user/project/'
+    'relocateBuildTree': '/home/user/project/'
 ```
 
 ## enableDiagnostics

--- a/doc/settings.md
+++ b/doc/settings.md
@@ -53,7 +53,9 @@ files from disk by specifying an `defaultCharset` key. The default is
 ## relocateBuildTree
 That is, real object, library or exec directories are relocated to the
 current working directory or dir if specified. Ensure that it is full
-normalized path ended with the directory separator.
+normalized path ended with the directory separator. Visit
+https://docs.adacore.com/gprbuild-docs/html/gprbuild_ug/building_with_gprbuild.html#switches
+for more details about the corresponding grpbuild switch.
 ```javascript
     'relocateBuildTree': '/home/user/project/build/'
 ```
@@ -62,7 +64,9 @@ normalized path ended with the directory separator.
 This option is to be used with relocateBuildTree above and cannot be
 specified alone. This option specifies the root directory for artifacts
 for proper relocation. Ensure that it is full normalized path ended
-with the directory separator.
+with the directory separator. Visit
+https://docs.adacore.com/gprbuild-docs/html/gprbuild_ug/building_with_gprbuild.html#switches
+for more details about the corresponding grpbuild switch.
 ```javascript
     'relocateBuildTree': '/home/user/project/'
 ```

--- a/doc/settings.md
+++ b/doc/settings.md
@@ -56,7 +56,7 @@ real object, library or exec directories are relocated to the current
 working directory or dir if specified. Ensure that it is full normalized
 path ended with the directory separator. Visit
 https://docs.adacore.com/gprbuild-docs/html/gprbuild_ug/building_with_gprbuild.html#switches
-for more details about the corresponding grpbuild switch.
+for more details about the corresponding gprbuild switch.
 ```javascript
     'relocateBuildTree': '/home/user/project/build/'
 ```
@@ -67,7 +67,7 @@ specified alone. This option specifies the root directory for artifacts
 for proper relocation. Ensure that it is full normalized path ended
 with the directory separator. Visit
 https://docs.adacore.com/gprbuild-docs/html/gprbuild_ug/building_with_gprbuild.html#switches
-for more details about the corresponding grpbuild switch.
+for more details about the corresponding gprbuild switch.
 ```javascript
     'relocateBuildTree': '/home/user/project/'
 ```

--- a/doc/settings.md
+++ b/doc/settings.md
@@ -6,6 +6,8 @@ Ada Language Server understands these settings:
  * [projectFile](#projectFile)
  * [scenarioVariables](#scenarioVariables)
  * [defaultCharset](#defaultCharset)
+ * [relocateBuildTree](#relocateBuildTree)
+ * [rootDir](#rootDir)
  * [enableDiagnostics](#enableDiagnostics)
  * [enableIndexing](#enableIndexing)
  * [renameInComments](#renameInComments)
@@ -46,6 +48,23 @@ files from disk by specifying an `defaultCharset` key. The default is
 
 ```javascript
     'defaultCharset': 'UTF-8'
+```
+
+## relocateBuildTree
+That is, real object, library or exec directories are relocated to the
+current working directory or dir if specified. Ensure that it is full
+normalized patch ended with the directory separator.
+```javascript
+    'relocateBuildTree': '~/home/user/project/build/'
+```
+
+## rootDir
+This option is to be used with relocateBuildTree above and cannot be
+specified alone. This option specifies the root directory for artifacts
+for proper relocation. Ensure that it is full normalized patch ended
+with the directory separator.
+```javascript
+    'relocateBuildTree': '~/home/user/project/'
 ```
 
 ## enableDiagnostics

--- a/doc/settings.md
+++ b/doc/settings.md
@@ -51,7 +51,7 @@ files from disk by specifying an `defaultCharset` key. The default is
 ```
 
 ## relocateBuildTree
-With this option it is possible to achieve out-of-tree build.That is,
+With this option it is possible to achieve out-of-tree build. That is,
 real object, library or exec directories are relocated to the current
 working directory or dir if specified. Ensure that it is full normalized
 path ended with the directory separator. Visit

--- a/source/ada/lsp-ada_handlers.adb
+++ b/source/ada/lsp-ada_handlers.adb
@@ -2844,8 +2844,8 @@ package body LSP.Ada_Handlers is
       File      : LSP.Types.LSP_String;
       Charset   : Unbounded_String;
       Variables : LSP.Types.LSP_Any;
-      Relocate  : Virtual_File;
-      Root      : Virtual_File;
+      Relocate  : Virtual_File := No_File;
+      Root      : Virtual_File := No_File;
    begin
       if Ada.Kind = GNATCOLL.JSON.JSON_Object_Type then
          if Ada.Has_Field (relocateBuildTree) then

--- a/source/ada/lsp-ada_handlers.adb
+++ b/source/ada/lsp-ada_handlers.adb
@@ -189,11 +189,11 @@ package body LSP.Ada_Handlers is
 
    procedure Load_Project
      (Self                : access Message_Handler;
-      Relocate_Build_Tree : Virtual_File;
-      Root_Dir            : Virtual_File;
       GPR                 : Virtual_File;
       Scenario            : LSP.Types.LSP_Any;
-      Charset             : String);
+      Charset             : String;
+      Relocate_Build_Tree : Virtual_File := No_File;
+      Root_Dir            : Virtual_File := No_File);
    --  Attempt to load the given project file, with the scenario provided.
    --  This unloads all currently loaded project contexts.
 
@@ -515,7 +515,7 @@ package body LSP.Ada_Handlers is
          --  We have not found exactly one .gpr file: load the default
          --  project.
          Self.Trace.Trace ("Loading " & GPR.Display_Base_Name);
-         Self.Load_Project (No_File, No_File, GPR, No_Any, "iso-8859-1");
+         Self.Load_Project (GPR, No_Any, "iso-8859-1");
       else
          --  We have found more than one project: warn the user!
 
@@ -2935,7 +2935,7 @@ package body LSP.Ada_Handlers is
             end if;
 
             Self.Load_Project
-              (Relocate, Root, GPR, Variables, To_String (Charset));
+              (GPR, Variables, To_String (Charset), Relocate, Root);
          end;
       end if;
 
@@ -2948,11 +2948,11 @@ package body LSP.Ada_Handlers is
 
    procedure Load_Project
      (Self                : access Message_Handler;
-      Relocate_Build_Tree : Virtual_File;
-      Root_Dir            : Virtual_File;
       GPR                 : Virtual_File;
       Scenario            : LSP.Types.LSP_Any;
-      Charset             : String)
+      Charset             : String;
+      Relocate_Build_Tree : Virtual_File := No_File;
+      Root_Dir            : Virtual_File := No_File)
    is
       use GNATCOLL.Projects;
       Errors        : LSP.Messages.ShowMessageParams;


### PR DESCRIPTION
"relocateBuildTree" and "rootDir" configuration options have
 been added to take in account corresponding GNAT Studio switches