### PR TITLE
TA09-019 Add support for filesystem monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ client provides its-own way to set such settings.
 | `workspace/didChangeWorkspaceFolders` |                    |
 | `workspace/didChangeConfiguration`    | :white_check_mark: |
 | `workspace/didChangeWorkspaceFolders` |                    |
-| `workspace/didChangeWatchedFiles`     |                    |
+| `workspace/didChangeWatchedFiles`     | :white_check_mark: |
 | `workspace/symbol`                    | :white_check_mark: |
 | `workspace/executeCommand`            | :white_check_mark: |
 

--- a/doc/HACKING.md
+++ b/doc/HACKING.md
@@ -1,5 +1,13 @@
 # Developing on the Ada Language Server
 
+## Dependencies
+
+The Ada Language Server depends on the following:
+
+ * VSS: https://github.com/AdaCore/VSS
+ * (optional) ada_libfswatch: https://github.com/AdaCore/ada_libfswatch,
+   to activate filesystem monitoring.
+
 ## Debugging
 
 You can activate traces that show all the server input/output. This is done
@@ -126,6 +134,9 @@ The repository contains the following folders:
 * `source/spawn/` - Process spawn/communication API
 * `source/tester/` - source of the test driver
 * `testsuite/ada_lsp/` - test suite of LSP in form of request/response
+* `subprojects/` - where we store dependencies (VCS, ada_libfswatch)
+* `subprojects/stubs` - the location for "stub" versions of .gpr files, for
+                        dependencies that are optional.
 
 ## Protocol synchronization
 

--- a/gnat/lsp_server.gpr
+++ b/gnat/lsp_server.gpr
@@ -17,6 +17,7 @@
 
 with "libadalang";
 with "lal_tools.gpr";
+with "ada_libfswatch.gpr";
 
 with "lsp";
 
@@ -40,7 +41,6 @@ project LSP_Server is
         LSP.Ada_Switches & ("-gnateDVERSION=""" & VERSION & """");
       for Switches ("s-memory.adb") use ("-g", "-O2", "-gnatpg");
    end Compiler;
-
 
    package Binder is
       for Switches ("ada") use ("-E");

--- a/integration/appveyor/appveyor.sh
+++ b/integration/appveyor/appveyor.sh
@@ -11,7 +11,9 @@ export PATH=$ADALIB_DIR/bin:\
 $PATH
 export ADA_PROJECT_PATH=$ADALIB_DIR/share/gpr:\
 $ADALIB_DIR/libadalang-tools/src:\
-$ADALIB_DIR/VSS/gnat
+$ADALIB_DIR/VSS/gnat:\
+$BUILD_FOLDER/subprojects/stubs
+
 export LIBRARY_TYPE=relocatable
 export CPATH=/mingw64/include
 export LIBRARY_PATH=/mingw64/lib

--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -335,6 +335,8 @@ NOTIFICATIONS = [
      'DidChangeConfigurationParams'),
     ('workspace/didChangeWorkspaceFolders', 'DidChangeWorkspaceFolders',
      'DidChangeWorkspaceFoldersParams'),
+    ('workspace/didChangeWatchedFiles', 'DidChangeWatchedFiles',
+     'DidChangeWatchedFilesParams'),
     ('$/cancelRequest', 'Cancel', 'CancelParams'),
 
     # TODO: rename these to TextDocumentDidOpen/DidChange/DidSave/DidClose?

--- a/source/ada/lsp-ada_context_sets.adb
+++ b/source/ada/lsp-ada_context_sets.adb
@@ -19,6 +19,7 @@ with Ada.Unchecked_Deallocation;
 
 with GNATCOLL.VFS;    use GNATCOLL.VFS;
 
+with LSP.Ada_File_Sets;
 with URIs;
 
 package body LSP.Ada_Context_Sets is
@@ -153,5 +154,31 @@ package body LSP.Ada_Context_Sets is
    begin
       return True;
    end All_Contexts;
+
+   ----------------------------
+   -- All_Source_Directories --
+   ----------------------------
+
+   function All_Source_Directories
+     (Self : Context_Set'Class) return GNATCOLL.VFS.File_Array
+   is
+      Consolidated_Set : LSP.Ada_File_Sets.File_Sets.Set;
+   begin
+      for C of Self.Contexts loop
+         Consolidated_Set.Union (C.List_Source_Directories);
+      end loop;
+
+      declare
+         Result : GNATCOLL.VFS.File_Array
+           (1 .. Integer (Consolidated_Set.Length));
+         J      : Natural := 1;
+      begin
+         for Dir of Consolidated_Set loop
+            Result (J) := Dir;
+            J := J + 1;
+         end loop;
+         return Result;
+      end;
+   end All_Source_Directories;
 
 end LSP.Ada_Context_Sets;

--- a/source/ada/lsp-ada_context_sets.ads
+++ b/source/ada/lsp-ada_context_sets.ads
@@ -17,6 +17,8 @@
 --
 --  This package provides a set of contexts for Ada Language server.
 
+with GNATCOLL.VFS;
+
 with Ada.Containers.Doubly_Linked_Lists;
 with Ada.Containers.Hashed_Maps;
 
@@ -53,6 +55,12 @@ package LSP.Ada_Context_Sets is
 
    function Total_Source_Files (Self : Context_Set'Class) return Natural;
    --  Number of files in all contexts
+
+   function All_Source_Directories
+     (Self : Context_Set'Class) return GNATCOLL.VFS.File_Array;
+   --  Return the list of all source directories for writable projects
+   --  in the context (ie, excluding externally-built projects). Each
+   --  dirctory is present only once in the resulting array.
 
    procedure Cleanup (Self : in out Context_Set'Class);
    --  Free memory referenced by Self

--- a/source/ada/lsp-ada_contexts.adb
+++ b/source/ada/lsp-ada_contexts.adb
@@ -209,6 +209,16 @@ package body LSP.Ada_Contexts is
       return Source_Units;
    end Analysis_Units;
 
+   -----------------------------
+   -- List_Source_Directories --
+   -----------------------------
+
+   function List_Source_Directories
+     (Self : Context) return LSP.Ada_File_Sets.File_Sets.Set is
+   begin
+      return Self.Source_Dirs;
+   end List_Source_Directories;
+
    -------------------------
    -- Find_All_References --
    -------------------------
@@ -406,6 +416,9 @@ package body LSP.Ada_Contexts is
          Definition.P_Basic_Decl;
 
    begin
+      --  Make sure to initialize the "out" variable Imprecise_Results
+      Imprecise_Results := False;
+
       if Decl.Is_Null then
          return;
       end if;
@@ -471,8 +484,7 @@ package body LSP.Ada_Contexts is
          Name : Libadalang.Analysis.Defining_Name;
          Stop : in out Boolean)) is
    begin
-      Self.Source_Files.Get_Any_Symbol_Completion
-        (Prefix, Callback);
+      Self.Source_Files.Get_Any_Symbol_Completion (Prefix, Callback);
    end Get_Any_Symbol_Completion;
 
    -----------------
@@ -559,10 +571,18 @@ package body LSP.Ada_Contexts is
 
          Unchecked_Free (All_Sources);
          Self.Source_Files.Clear;
-         Self.Last_Indexed := GNATCOLL.VFS.No_File;
 
          for Index in 1 .. Free_Index - 1 loop
             Self.Source_Files.Include (All_Ada_Sources (Index));
+         end loop;
+
+         Self.Source_Dirs.Clear;
+         for Dir of Source_Dirs
+           (Project                  => Root,
+            Recursive                => True,
+            Include_Externally_Built => False)
+         loop
+            Self.Source_Dirs.Include (Dir);
          end loop;
       end Update_Source_Files;
 
@@ -660,6 +680,7 @@ package body LSP.Ada_Contexts is
    procedure Free (Self : in out Context) is
    begin
       Self.Source_Files.Clear;
+      Self.Source_Dirs.Clear;
       --  Destroy GnatPP command line
       Utils.Command_Lines.Clear (Self.PP_Options);
    end Free;
@@ -750,16 +771,14 @@ package body LSP.Ada_Contexts is
    is
       Unit : constant Libadalang.Analysis.Analysis_Unit :=
         Self.LAL_Context.Get_From_File
-          (File.Display_Full_Name, Charset => Self.Get_Charset);
+          (File.Display_Full_Name,
+           Charset => Self.Get_Charset,
+           Reparse => True);
       Name : constant LSP.Types.LSP_String :=
         LSP.Types.To_LSP_String (Unit.Get_Filename);
+      URI  : constant LSP.Messages.DocumentUri := File_To_URI (Name);
    begin
-      if Self.Last_Indexed = GNATCOLL.VFS.No_File
-        or else Self.Last_Indexed < File
-      then
-         Self.Source_Files.Index_File (File_To_URI (Name), Unit);
-         Self.Last_Indexed := File;
-      end if;
+      Self.Source_Files.Flush_File_Index (URI, Unit);
    end Index_File;
 
    --------------------

--- a/source/ada/lsp-ada_contexts.ads
+++ b/source/ada/lsp-ada_contexts.ads
@@ -163,6 +163,10 @@ package LSP.Ada_Contexts is
      (Self : Context) return Libadalang.Analysis.Analysis_Unit_Array;
    --  Return the analysis units for all Ada sources known to this context
 
+   function List_Source_Directories
+     (Self : Context) return LSP.Ada_File_Sets.File_Sets.Set;
+   --  List the source directories in non-externally-built projects
+
    procedure Index_File
      (Self : in out Context;
       File : GNATCOLL.VFS.Virtual_File);
@@ -221,8 +225,10 @@ private
 
       Source_Files   : LSP.Ada_File_Sets.Indexed_File_Set;
       --  Cache for the list of Ada source files in the loaded project tree.
-      Last_Indexed   : GNATCOLL.VFS.Virtual_File;
-      --  A file from Source_Files that was indexed in the last iteration
+
+      Source_Dirs    : LSP.Ada_File_Sets.File_Sets.Set;
+      --  All the source dirs in the loaded project, not including
+      --  the externally built projects
 
       PP_Options : Utils.Command_Lines.Command_Line
                     (Pp.Command_Lines.Descriptor'Access);

--- a/source/ada/lsp-ada_file_sets.ads
+++ b/source/ada/lsp-ada_file_sets.ads
@@ -57,11 +57,13 @@ package LSP.Ada_File_Sets is
      (Self : in out Indexed_File_Set'Class;
       URI  : LSP.Messages.DocumentUri;
       Unit : Libadalang.Analysis.Analysis_Unit);
+   --  ??? needs doc
 
    procedure Flush_File_Index
      (Self : in out Indexed_File_Set'Class;
       URI  : LSP.Messages.DocumentUri;
       Unit : Libadalang.Analysis.Analysis_Unit);
+   --  ??? needs doc
 
    procedure Get_Any_Symbol_Completion
      (Self     : Indexed_File_Set'Class;

--- a/source/ada/lsp-ada_handlers.adb
+++ b/source/ada/lsp-ada_handlers.adb
@@ -122,11 +122,15 @@ package body LSP.Ada_Handlers is
    procedure Release_Project_Info (Self : access Message_Handler);
    --  Release the memory associated to project information in Self
 
+   function Contexts_For_File
+     (Self : access Message_Handler;
+      File : Virtual_File)
+      return LSP.Ada_Context_Sets.Context_Lists.List;
    function Contexts_For_URI
      (Self : access Message_Handler;
       URI  : LSP.Messages.DocumentUri)
       return LSP.Ada_Context_Sets.Context_Lists.List;
-   --  Return a list of contexts that are suitable for the given URI:
+   --  Return a list of contexts that are suitable for the given File/URI:
    --  a list of all contexts where the file is known to be part of the
    --  project tree, or is a runtime file for this project. If the file
    --  is not known to any project, return an empty list.
@@ -198,6 +202,10 @@ package body LSP.Ada_Handlers is
    --  Attempt to load the given project file, with the scenario provided.
    --  This unloads all currently loaded project contexts.
 
+   procedure Mark_Source_Files_For_Indexing (Self : access Message_Handler);
+   --  Mark all sources in all projects for indexing. This factorizes code
+   --  between Load_Project and Load_Implicit_Project.
+
    function Hash
      (Value : LSP.Messages.Location) return Ada.Containers.Hash_Type;
 
@@ -213,17 +221,15 @@ package body LSP.Ada_Handlers is
       Hash            => Hash,
       Equivalent_Keys => LSP.Messages."=");
 
-   ----------------------
-   -- Contexts_For_URI --
-   ----------------------
+   -----------------------
+   -- Contexts_For_File --
+   -----------------------
 
-   function Contexts_For_URI
+   function Contexts_For_File
      (Self : access Message_Handler;
-      URI  : LSP.Messages.DocumentUri)
+      File : Virtual_File)
       return LSP.Ada_Context_Sets.Context_Lists.List
    is
-      File : constant Virtual_File := To_File (URI);
-
       function Is_A_Source (Self : LSP.Ada_Contexts.Context) return Boolean is
         (Self.Is_Part_Of_Project (File));
       --  Return True if File is a source of the project held by Context
@@ -242,6 +248,20 @@ package body LSP.Ada_Handlers is
 
       --  List contexts where File is a source of the project hierarchy
       return Self.Contexts.Each_Context (Is_A_Source'Unrestricted_Access);
+   end Contexts_For_File;
+
+   ----------------------
+   -- Contexts_For_URI --
+   ----------------------
+
+   function Contexts_For_URI
+     (Self : access Message_Handler;
+      URI  : LSP.Messages.DocumentUri)
+      return LSP.Ada_Context_Sets.Context_Lists.List
+   is
+      File : constant Virtual_File := To_File (URI);
+   begin
+      return Self.Contexts_For_File (File);
    end Contexts_For_URI;
 
    -----------------------
@@ -350,6 +370,11 @@ package body LSP.Ada_Handlers is
       end if;
       Self.Project_Predefined_Sources.Clear;
       Self.Project_Dirs_Loaded.Clear;
+
+      --  Clear indexing data
+      Self.Files_To_Index.Clear;
+      Self.Total_Files_To_Index := 1;
+      Self.Total_Files_Indexed := 0;
    end Release_Project_Info;
 
    -------------
@@ -460,7 +485,9 @@ package body LSP.Ada_Handlers is
       end loop;
 
       Self.Contexts.Prepend (C);
-      Self.Indexing_Required := True;
+
+      --  Reindex the files from disk in the background after a project reload
+      Self.Mark_Source_Files_For_Indexing;
    end Load_Implicit_Project;
 
    ---------------------------
@@ -2951,6 +2978,52 @@ package body LSP.Ada_Handlers is
       Self.Ensure_Project_Loaded;
    end On_DidChangeConfiguration_Notification;
 
+   -------------------------------------------
+   -- On_DidChangeWatchedFiles_Notification --
+   -------------------------------------------
+
+   overriding procedure On_DidChangeWatchedFiles_Notification
+     (Self  : access Message_Handler;
+      Value : LSP.Messages.DidChangeWatchedFilesParams)
+   is
+      Document : LSP.Ada_Documents.Document_Access;
+   begin
+      --  Look through each changes
+      for Change of Value.changes loop
+         --  A watched file has changed on disk. If there is an open
+         --  document for this file, nothing to do: the document takes
+         --  precedence over the filesystem.
+
+         Document := Self.Get_Open_Document (Change.uri);
+
+         if Document = null then
+            --  If there is no document, reindex the file for each
+            --  context where it is relevant.
+            for C of Self.Contexts_For_URI (Change.uri) loop
+               C.Index_File (To_File (Change.uri));
+            end loop;
+         end if;
+      end loop;
+   end On_DidChangeWatchedFiles_Notification;
+
+   ------------------------------------
+   -- Mark_Source_Files_For_Indexing --
+   ------------------------------------
+
+   procedure Mark_Source_Files_For_Indexing (Self : access Message_Handler) is
+   begin
+      Self.Files_To_Index.Clear;
+      for C of Self.Contexts.Each_Context loop
+         for F in C.List_Files loop
+            Self.Files_To_Index.Include
+              (LSP.Ada_File_Sets.File_Sets.Element (F));
+         end loop;
+      end loop;
+      Self.Total_Files_Indexed := 0;
+      Self.Total_Files_To_Index := Positive'Max
+        (1, Natural (Self.Files_To_Index.Length));
+   end Mark_Source_Files_For_Indexing;
+
    ------------------
    -- Load_Project --
    ------------------
@@ -3091,8 +3164,12 @@ package body LSP.Ada_Handlers is
          end loop;
       end loop;
 
+      --  We have successfully loaded a real project: monitor the filesystem
+      --  for any changes on the sources of the project
+      Self.Server.Monitor_Directories (Self.Contexts.All_Source_Directories);
+
       --  Reindex the files from disk in the background after a project reload
-      Self.Indexing_Required := True;
+      Self.Mark_Source_Files_For_Indexing;
    end Load_Project;
 
    -------------------------------
@@ -3182,8 +3259,6 @@ package body LSP.Ada_Handlers is
          Self.Server.On_Progress (P);
       end Emit_Progress_End;
 
-      Index           : Natural := 1;
-      Total           : constant Natural := Self.Contexts.Total_Source_Files;
       Last_Percent    : Natural := 0;
       Current_Percent : Natural := 0;
    begin
@@ -3195,40 +3270,42 @@ package body LSP.Ada_Handlers is
 
       Emit_Progress_Begin;
 
-      for Context of Self.Contexts.Each_Context loop
-         for F in Context.List_Files loop
-            declare
-               File : constant GNATCOLL.VFS.Virtual_File :=
-                 LSP.Ada_File_Sets.File_Sets.Element (F);
-               URI  : constant LSP.Messages.DocumentUri := File_To_URI
-                 (LSP.Types.To_LSP_String (File.Display_Full_Name));
-            begin
-               if not Self.Open_Documents.Contains (URI) then
-                  Current_Percent := (Index * 100) / Total;
-                  --  If the value of the indexing increased by at least one
-                  --  percent, emit one progress report.
-                  if Current_Percent > Last_Percent then
-                     Emit_Progress_Report (Current_Percent);
-                     Last_Percent := Current_Percent;
-                  end if;
-
-                  Context.Index_File (File);
-                  Index := Index + 1;
-
-                  --  Check whether another request is pending. If so, pause
-                  --  the indexing; it will be resumed later as part of
-                  --  After_Request. if Self.Server.Input_Queue_Length > 0 then
-                  if Self.Server.Has_Pending_Work then
-                     Emit_Progress_End;
-                     return;
-                  end if;
+      while not Self.Files_To_Index.Is_Empty loop
+         declare
+            Cursor : File_Sets.Cursor := Self.Files_To_Index.First;
+            File   : GNATCOLL.VFS.Virtual_File;
+         begin
+            File := File_Sets.Element (Cursor);
+            Self.Files_To_Index.Delete (Cursor);
+            Self.Total_Files_Indexed := Self.Total_Files_Indexed + 1;
+            if not Self.Open_Documents.Contains
+              (File_To_URI (LSP.Types.To_LSP_String (File.Display_Full_Name)))
+            then
+               Current_Percent := (Self.Total_Files_Indexed * 100)
+                 / Self.Total_Files_To_Index;
+               --  If the value of the indexing increased by at least one
+               --  percent, emit one progress report.
+               if Current_Percent > Last_Percent then
+                  Emit_Progress_Report (Current_Percent);
+                  Last_Percent := Current_Percent;
                end if;
-            end;
-         end loop;
+
+               for Context of Self.Contexts_For_File (File) loop
+                  Context.Index_File (File);
+               end loop;
+
+               --  Check whether another request is pending. If so, pause
+               --  the indexing; it will be resumed later as part of
+               --  After_Request. if Self.Server.Input_Queue_Length > 0 then
+               if Self.Server.Has_Pending_Work then
+                  Emit_Progress_End;
+                  return;
+               end if;
+            end if;
+         end;
       end loop;
 
       Emit_Progress_End;
-      Self.Indexing_Required := False;
    end Index_Files;
 
    ------------------------------------------
@@ -3990,7 +4067,7 @@ package body LSP.Ada_Handlers is
    begin
      --  We have finished processing a request or notification:
      --  if it happens that indexing is required, do it now.
-      if Self.Indexing_Required then
+      if not Self.Files_To_Index.Is_Empty then
          Self.Index_Files;
       end if;
    end After_Work;

--- a/source/ada/lsp-fuzz_decorators.adb
+++ b/source/ada/lsp-fuzz_decorators.adb
@@ -80,6 +80,18 @@ package body LSP.Fuzz_Decorators is
       Self.Handler.On_DidChangeWorkspaceFolders_Notification (Value);
    end On_DidChangeWorkspaceFolders_Notification;
 
+   -------------------------------------------
+   -- On_DidChangeWatchedFiles_Notification --
+   -------------------------------------------
+
+   overriding procedure On_DidChangeWatchedFiles_Notification
+     (Self  : access Fuzz_Notification_Decorator;
+      Value : LSP.Messages.DidChangeWatchedFilesParams)
+   is
+   begin
+      Self.Handler.On_DidChangeWatchedFiles_Notification (Value);
+   end On_DidChangeWatchedFiles_Notification;
+
    ----------------------------
    -- On_Cancel_Notification --
    ----------------------------

--- a/source/ada/lsp-fuzz_decorators.ads
+++ b/source/ada/lsp-fuzz_decorators.ads
@@ -60,6 +60,10 @@ package LSP.Fuzz_Decorators is
      (Self  : access Fuzz_Notification_Decorator;
       Value : LSP.Messages.DidChangeWorkspaceFoldersParams);
 
+   overriding procedure On_DidChangeWatchedFiles_Notification
+     (Self  : access Fuzz_Notification_Decorator;
+      Value : LSP.Messages.DidChangeWatchedFilesParams);
+
    overriding procedure On_Cancel_Notification
      (Self  : access Fuzz_Notification_Decorator;
       Value : LSP.Messages.CancelParams);

--- a/source/client/lsp-clients.adb
+++ b/source/client/lsp-clients.adb
@@ -1164,6 +1164,20 @@ package body LSP.Clients is
       Self.Send_Notification ("workspace/didChangeWorkspaceFolders", Message);
    end On_DidChangeWorkspaceFolders_Notification;
 
+   -------------------------------------------
+   -- On_DidChangeWatchedFiles_Notification --
+   -------------------------------------------
+
+   overriding procedure On_DidChangeWatchedFiles_Notification
+     (Self  : access Client;
+      Value : LSP.Messages.DidChangeWatchedFilesParams)
+   is
+      Message : DidChangeWatchedFiles_Notification :=
+        (params => Value, others => <>);
+   begin
+      Self.Send_Notification ("workspace/didChangeWatchedFiles", Message);
+   end On_DidChangeWatchedFiles_Notification;
+
    ---------------------------------------
    -- Workspace_Execute_Command_Request --
    ---------------------------------------

--- a/source/client/lsp-clients.ads
+++ b/source/client/lsp-clients.ads
@@ -53,6 +53,10 @@ package LSP.Clients is
      (Self  : access Client;
       Value : LSP.Messages.DidChangeWorkspaceFoldersParams);
 
+   overriding procedure On_DidChangeWatchedFiles_Notification
+     (Self  : access Client;
+      Value : LSP.Messages.DidChangeWatchedFilesParams);
+
    overriding procedure On_DidOpenTextDocument_Notification
      (Self  : access Client;
       Value : LSP.Messages.DidOpenTextDocumentParams);

--- a/source/protocol/generated/lsp-messages-server_notifications.adb
+++ b/source/protocol/generated/lsp-messages-server_notifications.adb
@@ -65,6 +65,13 @@ package body LSP.Messages.Server_Notifications is
    end Visit;
 
    overriding procedure Visit
+     (Self    : DidChangeWatchedFiles_Notification;
+      Handler : access Server_Notification_Receiver'Class) is
+   begin
+      Handler.On_DidChangeWatchedFiles_Notification (Self.params);
+   end Visit;
+
+   overriding procedure Visit
      (Self    : Cancel_Notification;
       Handler : access Server_Notification_Receiver'Class) is
    begin
@@ -120,6 +127,10 @@ begin
    Map.Insert
      (+"workspace/didChangeWorkspaceFolders",
       DidChangeWorkspaceFolders_Notification'Tag);
+
+   Map.Insert
+     (+"workspace/didChangeWatchedFiles",
+      DidChangeWatchedFiles_Notification'Tag);
 
    Map.Insert
      (+"$/cancelRequest",

--- a/source/protocol/generated/lsp-messages-server_notifications.ads
+++ b/source/protocol/generated/lsp-messages-server_notifications.ads
@@ -68,6 +68,19 @@ package LSP.Messages.Server_Notifications is
      (Self    : DidChangeWorkspaceFolders_Notification;
       Handler : access Server_Notification_Receiver'Class);
 
+   package DidChangeWatchedFiles_Notifications is
+     new LSP.Generic_Notifications
+       (Server_Notification,
+        DidChangeWatchedFilesParams,
+        Server_Notification_Receiver'Class);
+
+   type DidChangeWatchedFiles_Notification is
+     new DidChangeWatchedFiles_Notifications.Notification with null record;
+
+   overriding procedure Visit
+     (Self    : DidChangeWatchedFiles_Notification;
+      Handler : access Server_Notification_Receiver'Class);
+
    package Cancel_Notifications is
      new LSP.Generic_Notifications
        (Server_Notification,

--- a/source/protocol/generated/lsp-server_notification_receivers.ads
+++ b/source/protocol/generated/lsp-server_notification_receivers.ads
@@ -27,6 +27,10 @@ package LSP.Server_Notification_Receivers is
      (Self  : access Server_Notification_Receiver;
       Value : LSP.Messages.DidChangeWorkspaceFoldersParams) is abstract;
 
+   procedure On_DidChangeWatchedFiles_Notification
+     (Self  : access Server_Notification_Receiver;
+      Value : LSP.Messages.DidChangeWatchedFilesParams) is abstract;
+
    procedure On_Cancel_Notification
      (Self  : access Server_Notification_Receiver;
       Value : LSP.Messages.CancelParams) is abstract;

--- a/source/server/lsp-message_loggers.adb
+++ b/source/server/lsp-message_loggers.adb
@@ -617,6 +617,26 @@ package body LSP.Message_Loggers is
    end On_DidChangeWorkspaceFolders_Notification;
 
    -------------------------------------------
+   -- On_DidChangeWatchedFiles_Notification --
+   -------------------------------------------
+
+   overriding procedure On_DidChangeWatchedFiles_Notification
+     (Self  : access Message_Logger;
+      Value : LSP.Messages.DidChangeWatchedFilesParams)
+   is
+      use LSP.Types;
+      Result : LSP.Types.LSP_String;
+   begin
+      for Change of Value.changes loop
+         Append (Result, " " & Change.uri & ": " &
+                   Change.the_type'Wide_Image & ";");
+      end loop;
+
+      Self.Trace.Trace ("DidChangeWatchedFiles_Notification:"
+                        & ASCII.LF & To_UTF_8_String (Result));
+   end On_DidChangeWatchedFiles_Notification;
+
+   -------------------------------------------
    -- On_DidChangeTextDocument_Notification --
    -------------------------------------------
 

--- a/source/server/lsp-message_loggers.ads
+++ b/source/server/lsp-message_loggers.ads
@@ -102,6 +102,10 @@ private
      (Self  : access Message_Logger;
       Value : LSP.Messages.DidChangeWorkspaceFoldersParams);
 
+   overriding procedure On_DidChangeWatchedFiles_Notification
+     (Self  : access Message_Logger;
+      Value : LSP.Messages.DidChangeWatchedFilesParams);
+
    overriding procedure On_DidOpenTextDocument_Notification
      (Self   : access Message_Logger;
       Value  : LSP.Messages.DidOpenTextDocumentParams);

--- a/subprojects/stubs/ada_libfswatch.gpr
+++ b/subprojects/stubs/ada_libfswatch.gpr
@@ -1,0 +1,4 @@
+--  Stub project for libfswatch, which is not supported on Mac OS
+with "gnatcoll";
+project ada_libfswatch is
+end ada_libfswatch;

--- a/subprojects/stubs/libfswatch.ads
+++ b/subprojects/stubs/libfswatch.ads
@@ -1,0 +1,79 @@
+------------------------------------------------------------------------------
+--                         Language Server Protocol                         --
+--                                                                          --
+--                     Copyright (C) 2018-2019, AdaCore                     --
+--                                                                          --
+-- This is free software;  you can redistribute it  and/or modify it  under --
+-- terms of the  GNU General Public License as published  by the Free Soft- --
+-- ware  Foundation;  either version 3,  or (at your option) any later ver- --
+-- sion.  This software is distributed in the hope  that it will be useful, --
+-- but WITHOUT ANY WARRANTY;  without even the implied warranty of MERCHAN- --
+-- TABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public --
+-- License for  more details.  You should have  received  a copy of the GNU --
+-- General  Public  License  distributed  with  this  software;   see  file --
+-- COPYING3.  If not, go to http://www.gnu.org/licenses for a complete copy --
+-- of the license.                                                          --
+------------------------------------------------------------------------------
+
+--  This package contains stubs for the libfswatch API
+
+with Ada.Strings.Unbounded; use Ada.Strings.Unbounded;
+with Ada.Containers.Vectors;
+
+with GNATCOLL.VFS; use GNATCOLL.VFS;
+
+package Libfswatch is
+
+   Libfswatch_Error : exception;
+   --  Used to report any library exception
+
+   type Event_Flags is
+     (No_Op,
+      Platform_Specific,
+      Created,
+      Updated,
+      Removed,
+      Renamed,
+      Owner_Modified,
+      Attribute_Modified,
+      Moved_From,
+      Moved_To,
+      Is_File,
+      Is_Dir,
+      Is_Sym_Link,
+      Link,
+      Overflow);
+
+   package Event_Flags_Vectors is
+     new Ada.Containers.Vectors (Natural, Event_Flags);
+
+   type Event is record
+      Path  : Unbounded_String;
+      Flags : Event_Flags_Vectors.Vector;
+      --  TODO: add a platform-independent time representation
+   end record;
+
+   package Event_Vectors is new Ada.Containers.Vectors (Natural, Event);
+   type Event_Flags_Array is array (Natural range <>) of Event_Flags;
+
+   type Root_Event_Monitor is abstract tagged private;
+
+   procedure Callback (Self   : in out Root_Event_Monitor;
+                       Events : Event_Vectors.Vector) is abstract;
+
+   procedure Blocking_Monitor
+     (Monitor        : in out Root_Event_Monitor'Class;
+      Paths          : File_Array;
+      Events_Allowed : Event_Flags_Array := (1 .. 0 => No_Op)) is null;
+
+   procedure Stop_Monitor (Monitor : in out Root_Event_Monitor'Class) is null;
+   --  Interrupt the monitoring. This is thread-safe.
+
+private
+
+   type Root_Event_Monitor is abstract tagged null record;
+
+   type Event_Filter is new Integer;
+   No_Filter : constant Event_Filter := 0;
+
+end Libfswatch;


### PR DESCRIPTION
This adds support for monitoring the filesystem for changes
that might occur in project directories, outside of the IDE.

Add support for `workspace/didChangeWatchedFiles`.

Add an optional dependency on ada_libfswatch.gpr, and document
it. Add support in the travis CI builder to generate it on Linux.
Add a stub project to make the ALS useable without this dependency.

Rework the way files are indexed, to allow reindexing for any
file that might change on disk. In particular, no longer store
in LSP.Ada_Contexts a reference to the "Last_Indexed" file, which
prevented indexing of new files altogether.