### PR TITLE
TA09-019 filesystem monitoring: better handle exiting

### DIFF
--- a/source/ada/lsp-ada_contexts.adb
+++ b/source/ada/lsp-ada_contexts.adb
@@ -778,7 +778,7 @@ package body LSP.Ada_Contexts is
         LSP.Types.To_LSP_String (Unit.Get_Filename);
       URI  : constant LSP.Messages.DocumentUri := File_To_URI (Name);
    begin
-      Self.Source_Files.Flush_File_Index (URI, Unit);
+      Self.Source_Files.Index_File (URI, Unit);
    end Index_File;
 
    --------------------

--- a/source/server/lsp-servers.adb
+++ b/source/server/lsp-servers.adb
@@ -1363,6 +1363,7 @@ package body LSP.Servers is
       procedure Unchecked_Free is new Ada.Unchecked_Deallocation
         (LSP_Monitor, LSP_Monitor_Access);
 
+      Data           : Data_To_Monitor_Access;
       Monitor        : LSP_Monitor_Access;
       Dirs           : GNATCOLL.VFS.File_Array_Access;
       Stop_Requested : Boolean := False;
@@ -1376,9 +1377,10 @@ package body LSP.Servers is
               (Data_To_Monitor : Data_To_Monitor_Access;
                Directories     : GNATCOLL.VFS.File_Array)
             do
+               Data    := Data_To_Monitor;
+
                Monitor := new LSP_Monitor;
                Monitor.The_Server := Data_To_Monitor.Server;
-               Data_To_Monitor.Set_LSP_Monitor (Monitor);
 
                Dirs := new File_Array (1 .. Directories'Length);
                Free_Index := 1;
@@ -1399,12 +1401,16 @@ package body LSP.Servers is
             --  Exit the task
             exit;
          else
-            --  Start monitoring. This call is blocking until
-            --  Monitor.Stop_Monitor is called.
             if Free_Index > 1 then
+               Data.Set_LSP_Monitor (Monitor);
+
+               --  Start monitoring. This call is blocking until
+               --  Monitor.Stop_Monitor is called.
                Monitor.Blocking_Monitor
                  (Dirs (1 .. Free_Index - 1),
                   (Updated, Created, Moved_From, Removed, Moved_To));
+            else
+               Data.Set_LSP_Monitor (null);
             end if;
 
             --  Deallocate memory


### PR DESCRIPTION
Prevent potential call to Stop_Monitor in case the monitor
was never started.