### PR TITLE
T226-048: Avoid reparsing when indexing the project

### DIFF
--- a/source/ada/lsp-ada_contexts.adb
+++ b/source/ada/lsp-ada_contexts.adb
@@ -766,14 +766,15 @@ package body LSP.Ada_Contexts is
    ----------------
 
    procedure Index_File
-     (Self : in out Context;
-      File : GNATCOLL.VFS.Virtual_File)
+     (Self    : in out Context;
+      File    : GNATCOLL.VFS.Virtual_File;
+      Reparse : Boolean := True)
    is
       Unit : constant Libadalang.Analysis.Analysis_Unit :=
         Self.LAL_Context.Get_From_File
           (File.Display_Full_Name,
            Charset => Self.Get_Charset,
-           Reparse => True);
+           Reparse => Reparse);
       Name : constant LSP.Types.LSP_String :=
         LSP.Types.To_LSP_String (Unit.Get_Filename);
       URI  : constant LSP.Messages.DocumentUri := File_To_URI (Name);

--- a/source/ada/lsp-ada_contexts.ads
+++ b/source/ada/lsp-ada_contexts.ads
@@ -168,8 +168,9 @@ package LSP.Ada_Contexts is
    --  List the source directories in non-externally-built projects
 
    procedure Index_File
-     (Self : in out Context;
-      File : GNATCOLL.VFS.Virtual_File);
+     (Self    : in out Context;
+      File    : GNATCOLL.VFS.Virtual_File;
+      Reparse : Boolean := True);
    --  Index the given file. This translates to refreshing the Libadalang
    --  Analysis_Unit associated to it.
 

--- a/source/ada/lsp-ada_handlers.adb
+++ b/source/ada/lsp-ada_handlers.adb
@@ -3291,7 +3291,9 @@ package body LSP.Ada_Handlers is
                end if;
 
                for Context of Self.Contexts_For_File (File) loop
-                  Context.Index_File (File);
+                  --  Set Reparse to False to avoid issues with LAL envs
+                  --  for now (see T226-048 for more info).
+                  Context.Index_File (File, Reparse => False);
                end loop;
 
                --  Check whether another request is pending. If so, pause


### PR DESCRIPTION
This can cause somes issues with the LAL envs when indexing
a file that already has an analysis unit (e.g: a file opened
at startup).