### PR TITLE
SA11-038 Improve Refactoring Rename

### DIFF
--- a/source/ada/lsp-ada_handlers.adb
+++ b/source/ada/lsp-ada_handlers.adb
@@ -50,6 +50,7 @@ with Langkit_Support.Text;
 with Laltools.Call_Hierarchy;
 with Laltools.Common;
 with Laltools.Refactor_Imports;
+with Laltools.Refactor.Rename;
 
 with Libadalang.Analysis;
 with Libadalang.Common;    use Libadalang.Common;
@@ -2643,52 +2644,63 @@ package body LSP.Ada_Handlers is
       Value     : LSP.Messages.RenameParams renames Request.params;
       Response  : LSP.Messages.Server_Responses.Rename_Response
         (Is_Error => False);
+      --  If a rename problem is found when Process_Context is called,
+      --  then Refs.Problems will not be empty. This Response will be discarded
+      --  and a new response with an error meessage is returned instead.
+      --  If no problems are found, then this Response will contain all the
+      --  references to be renamed and is returned by this function.
 
       Document  : constant LSP.Ada_Documents.Document_Access :=
                    Get_Open_Document (Self, Value.textDocument.uri);
 
+      Refs      : Laltools.Refactor.Rename.Renamable_References;
+
       procedure Process_Context (C : Context_Access);
-      --  Process the rename request for the given context, and add
-      --  the results to response.
+      --  Process the rename request for the given context, and add the
+      --  results to Response.
 
       ---------------------
       -- Process_Context --
       ---------------------
 
       procedure Process_Context (C : Context_Access) is
-         Position : constant LSP.Messages.TextDocumentPositionParams :=
-                      (Value.textDocument, Value.position);
+         Position   : constant LSP.Messages.TextDocumentPositionParams :=
+           (Value.textDocument, Value.position);
 
-         Name_Node  : constant Name := Laltools.Common.Get_Node_As_Name
+         Node      : Ada_Node := C.Get_Node_At (Document, Position);
+         Name_Node : Name := Laltools.Common.Get_Node_As_Name
            (C.Get_Node_At (Document, Position));
 
-         Definition : Defining_Name;
-         Imprecise  : Boolean;
-         Empty      : LSP.Messages.TextEdit_Vector;
-         Count      : Cancel_Countdown := 0;
+         Empty     : LSP.Messages.TextEdit_Vector;
+
+         --  Analysis unit of the reference that is being added to Response
+         Unit      : Analysis_Unit;
 
          procedure Process_Comments
            (Node : Ada_Node;
             Uri  : LSP.Messages.DocumentUri);
          --  Iterate over all comments and include them in the response when
-         --  they contain a renamed word
+         --  they contain a renamed word.
 
-         procedure Callback
-           (Node   : Libadalang.Analysis.Base_Id;
-            Kind   : Libadalang.Common.Ref_Result_Kind;
-            Cancel : in out Boolean);
+         procedure Process_Reference
+           (Unit_Filename : String;
+            Sloc_Range    : Langkit_Support.Slocs.Source_Location_Range);
+         --  Add a reference to Response if it has not been added yet
 
-         --------------
-         -- Callback --
-         --------------
+         -----------------------
+         -- Process_Reference --
+         -----------------------
 
-         procedure Callback
-           (Node   : Libadalang.Analysis.Base_Id;
-            Kind   : Libadalang.Common.Ref_Result_Kind;
-            Cancel : in out Boolean)
+         procedure Process_Reference
+           (Unit_Filename : String;
+            Sloc_Range    : Langkit_Support.Slocs.Source_Location_Range)
          is
             Location : constant LSP.Messages.Location :=
-              Get_Node_Location (Node.As_Ada_Node);
+              (uri     => LSP.Ada_Contexts.File_To_URI
+                 (To_Unbounded_Wide_String
+                      (To_Wide_String (Unit_Filename))),
+               span    => To_Span (Sloc_Range),
+               alsKind => <>);
             Item     : constant LSP.Messages.TextEdit :=
               (span    => Location.span,
                newText => Value.newName);
@@ -2699,8 +2711,12 @@ package body LSP.Ada_Handlers is
                Response.result.changes.Insert (Location.uri, Empty);
 
                --  Process comments if it is needed
+
                if Self.Options.Refactoring.Renaming.In_Comments then
-                  Process_Comments (Node.As_Ada_Node, Location.uri);
+                  Process_Comments
+                    (Unit.Root.Lookup
+                       ((Sloc_Range.Start_Line, Sloc_Range.Start_Column)),
+                     Location.uri);
                end if;
             end if;
 
@@ -2708,20 +2724,13 @@ package body LSP.Ada_Handlers is
             --  projects), it's possible to encounter the same
             --  definitions more than once, so verify that the result
             --  is not already recorded before adding it.
+
             if not Response.result.changes
               (Location.uri).Contains (Item)
             then
                Response.result.changes (Location.uri).Append (Item);
             end if;
-
-            Cancel := Count = 0 and then Request.Canceled;
-
-            Count := Count - 1;
-
-            if Kind = Libadalang.Common.Imprecise then
-               Imprecise := True;
-            end if;
-         end Callback;
+         end Process_Reference;
 
          -----------------------
          --  Process_Comments --
@@ -2874,45 +2883,81 @@ package body LSP.Ada_Handlers is
             end loop;
          end Process_Comments;
 
+         use Laltools.Refactor.Rename;
+
+         Unit_Cursor : Unit_Slocs_Maps.Cursor;
+         Sloc_Cursor : Slocs_Maps.Cursor;
+
+         use Unit_Slocs_Maps;
+         use Slocs_Maps;
       begin
-         if Name_Node = No_Name then
+
+         Refs := Find_All_Renamable_References
+           (Node           => Node,
+            New_Name       => To_Unbounded_Text_Type (Value.newName),
+            Units          => C.Analysis_Units,
+            Algorithm_Kind => Analyse_AST);
+
+         --  Call to Find_All_Renamable_References above reparses all analysis
+         --  units, therefore, Node and Name_Node need to be recomputed.
+
+         Node := C.Get_Node_At (Document, Position);
+         Name_Node := Laltools.Common.Get_Node_As_Name
+           (C.Get_Node_At (Document, Position));
+
+         --  If problems were found, do not continue processing references.
+         if not Refs.Problems.Is_Empty then
             return;
          end if;
 
-         Definition := Laltools.Common.Resolve_Name
-           (Name_Node,
-            Self.Trace,
-            Imprecise => Imprecise);
-
-         --  If we used the imprecise fallback to get to the definition, stop
-         if Imprecise then
-            return;
-         end if;
-
-         if Definition = No_Defining_Name or Request.Canceled then
-            return;
-         end if;
-
-         C.Get_References_For_Renaming
-           (Definition        => Definition,
-            Imprecise_Results => Imprecise,
-            Callback          => Callback'Access);
-
-         if Imprecise then
-            Self.Show_Message
-              ("References are not precise: renamed cancelled",
-               LSP.Messages.Warning);
-            return;
-         end if;
-
+         Unit_Cursor := Refs.References.First;
+         while Has_Element (Unit_Cursor) loop
+            Unit := Key (Unit_Cursor);
+            Sloc_Cursor :=
+              Refs.References.Constant_Reference (Unit_Cursor).First;
+            while Has_Element (Sloc_Cursor) loop
+               for Sloc of
+                 Refs.References.Constant_Reference (Unit_Cursor).
+                 Constant_Reference (Sloc_Cursor)
+               loop
+                  Process_Reference (Key (Unit_Cursor).Get_Filename, Sloc);
+               end loop;
+               Next (Sloc_Cursor);
+            end loop;
+            Next (Unit_Cursor);
+         end loop;
       end Process_Context;
 
    begin
       for C of Self.Contexts_For_URI (Value.textDocument.uri) loop
          Process_Context (C);
 
+         --  If problems were found, send an error message and do not proceed
+         --  with the renames.
+
+         if not Refs.Problems.Is_Empty then
+            return Response : LSP.Messages.Server_Responses.Rename_Response
+              (Is_Error => True)
+            do
+               declare
+                  Error_Message : Unbounded_String;
+               begin
+                  for Problem of Refs.Problems loop
+                     Error_Message := Error_Message
+                       & To_Unbounded_String (Problem.Info & ASCII.LF);
+                  end loop;
+                  Response.error :=
+                    (True,
+                     (code => LSP.Errors.InvalidRequest,
+                      message => +(To_String (Error_Message)),
+                      data    => Empty));
+               end;
+            end return;
+         end if;
+
          exit when Request.Canceled;
       end loop;
+
       return Response;
    end On_Rename_Request;
 

--- a/source/ada/lsp-lal_utils.adb
+++ b/source/ada/lsp-lal_utils.adb
@@ -545,6 +545,19 @@ package body LSP.Lal_Utils is
       end return;
    end To_Call_Hierarchy_Item;
 
+   ----------------------------
+   -- To_Unbounded_Text_Type --
+   ----------------------------
+
+   function To_Unbounded_Text_Type
+     (Item : LSP_String)
+      return Langkit_Support.Text.Unbounded_Text_Type
+   is
+      use Langkit_Support.Text;
+   begin
+      return To_Unbounded_Text (From_UTF8 (To_UTF_8_String (Item)));
+   end To_Unbounded_Text_Type;
+
    -------------------------
    -- Node_Location_Image --
    -------------------------

--- a/source/ada/lsp-lal_utils.ads
+++ b/source/ada/lsp-lal_utils.ads
@@ -27,6 +27,7 @@ with Libadalang.Analysis;  use Libadalang.Analysis;
 with Libadalang.Common;
 
 with Langkit_Support.Slocs;
+with Langkit_Support.Text;
 
 with VSS.Strings;
 
@@ -113,6 +114,14 @@ package LSP.Lal_Utils is
      (Name : Libadalang.Analysis.Defining_Name)
       return LSP.Messages.CallHierarchyItem;
    --  Create CallHierarchyItem for the given subprogram
+
+   function To_Unbounded_Text_Type
+     (Item : LSP.Types.LSP_String)
+      return Langkit_Support.Text.Unbounded_Text_Type;
+   --  Converts a string from LSP_String to Unbounded_Text_Type. The intent
+   --  of this function is to convert names and small strings but not buffers.
+   --  It's dangerous to return a string when the string might be giant,
+   --  therefore, a buffer should not be passed to this function.
 
    function Node_Location_Image
      (Node : Libadalang.Analysis.Ada_Node'Class) return LSP.Types.LSP_String;

--- a/testsuite/ada_lsp/P107-003.refactoring.underscores/test.json
+++ b/testsuite/ada_lsp/P107-003.refactoring.underscores/test.json
@@ -126,6 +126,19 @@
                            "newText": "Hello_1",
                            "range": {
                               "start": {
+                                 "line": 3,
+                                 "character": 13
+                              },
+                              "end": {
+                                 "line": 3,
+                                 "character": 18
+                              }
+                           }
+                        },
+                        {
+                           "newText": "Hello_1",
+                           "range": {
+                              "start": {
                                  "line": 6,
                                  "character": 7
                               },
@@ -145,19 +158,6 @@
                               "end": {
                                  "line": 8,
                                  "character": 8
-                              }
-                           }
-                        },
-                        {
-                           "newText": "Hello_1",
-                           "range": {
-                              "start": {
-                                 "line": 3,
-                                 "character": 13
-                              },
-                              "end": {
-                                 "line": 3,
-                                 "character": 18
                               }
                            }
                         }

--- a/testsuite/ada_lsp/SA11-038_Name_Collision/default.gpr
+++ b/testsuite/ada_lsp/SA11-038_Name_Collision/default.gpr
@@ -1,0 +1,2 @@
+project Default is
+end Default;

--- a/testsuite/ada_lsp/SA11-038_Name_Collision/main.adb
+++ b/testsuite/ada_lsp/SA11-038_Name_Collision/main.adb
@@ -1,0 +1,8 @@
+procedure Main is
+   A : Integer := 0;
+   B : Integer := 1;
+
+begin
+   --  Insert code here.
+   null;
+end Main;

--- a/testsuite/ada_lsp/SA11-038_Name_Collision/test.json
+++ b/testsuite/ada_lsp/SA11-038_Name_Collision/test.json
@@ -1,0 +1,194 @@
+[
+   {
+      "comment": [
+         "test automatically generated"
+      ]
+   },
+   {
+      "start": {
+         "cmd": [
+            "${ALS}"
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": "ada-1",
+            "method": "initialize",
+            "params": {
+               "processId": 142665,
+               "rootUri": "$URI{.}",
+               "capabilities": {
+                  "workspace": {
+                     "applyEdit": true,
+                     "workspaceEdit": {},
+                     "didChangeConfiguration": {},
+                     "didChangeWatchedFiles": {},
+                     "executeCommand": {}
+                  },
+                  "textDocument": {
+                     "synchronization": {},
+                     "completion": {
+                        "dynamicRegistration": true,
+                        "completionItem": {
+                           "snippetSupport": true,
+                           "documentationFormat": [
+                              "plaintext",
+                              "markdown"
+                           ]
+                        }
+                     },
+                     "hover": {},
+                     "signatureHelp": {},
+                     "declaration": {},
+                     "definition": {},
+                     "typeDefinition": {},
+                     "implementation": {},
+                     "references": {},
+                     "documentHighlight": {},
+                     "documentSymbol": {
+                        "hierarchicalDocumentSymbolSupport": true
+                     },
+                     "codeLens": {},
+                     "colorProvider": {},
+                     "formatting": {
+                        "dynamicRegistration": false
+                     },
+                     "rangeFormatting": {
+                        "dynamicRegistration": false
+                     },
+                     "onTypeFormatting": {
+                        "dynamicRegistration": false
+                     },
+                     "foldingRange": {
+                        "lineFoldingOnly": true
+                     },
+                     "selectionRange": {},
+                     "callHierarchy": {}
+                  }
+               }
+            }
+         },
+         "wait": [
+            {
+               "id": "ada-1",
+               "result": {
+                  "capabilities": {
+                     "textDocumentSync": 2,
+                     "renameProvider": {}
+                  }
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "initialized"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "workspace/didChangeConfiguration",
+            "params": {
+               "settings": {
+                  "ada": {
+                     "projectFile": "$URI{default.gpr}",
+                     "scenarioVariables": {},
+                     "defaultCharset": "ISO-8859-1",
+                     "enableDiagnostics": false
+                  }
+               }
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{main.adb}",
+                  "languageId": "Ada",
+                  "version": 0,
+                  "text": "procedure Main is\n   A : Integer := 0;\n   B : Integer := 1;\n\nbegin\n   --  Insert code here.\n   null;\nend Main;\n"
+               }
+            }
+         },
+         "wait": [
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "workspace/didChangeConfiguration",
+            "params": {
+               "settings": {
+               }
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": "ada-4",
+            "method": "textDocument/rename",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{main.adb}"
+               },
+               "position": {
+                  "line": 1,
+                  "character": 3
+               },
+               "newName": "B"
+            }
+         },
+         "wait": [
+            {
+               "id": "ada-4",
+               "error": {
+                  "code": -32600,
+                  "message": "Renaming A to B creates a name collision with <Id \"B\" main.adb:3:4-3:5>\n"
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": "ada-5",
+            "method": "shutdown"
+         },
+         "wait": [
+            {
+               "id": "ada-5",
+               "result": null
+            }
+         ]
+      }
+   },
+   {
+      "stop": {
+         "exit_code": 0
+      }
+   }
+]

--- a/testsuite/ada_lsp/SA11-038_Name_Collision/test.yaml
+++ b/testsuite/ada_lsp/SA11-038_Name_Collision/test.yaml
@@ -1,0 +1,1 @@
+title: 'SA11-038_Name_Collision'

--- a/testsuite/ada_lsp/rename.not_up_to_date/test.json
+++ b/testsuite/ada_lsp/rename.not_up_to_date/test.json
@@ -547,12 +547,12 @@
                            "newText": "Zboob",
                            "range": {
                               "start": {
-                                 "line": 6,
-                                 "character": 40
+                                 "line": 4,
+                                 "character": 3
                               },
                               "end": {
-                                 "line": 6,
-                                 "character": 41
+                                 "line": 4,
+                                 "character": 4
                               }
                            }
                         },
@@ -560,12 +560,12 @@
                            "newText": "Zboob",
                            "range": {
                               "start": {
-                                 "line": 4,
-                                 "character": 3
+                                 "line": 6,
+                                 "character": 40
                               },
                               "end": {
-                                 "line": 4,
-                                 "character": 4
+                                 "line": 6,
+                                 "character": 41
                               }
                            }
                         }

--- a/testsuite/ada_lsp/rename/rename.json
+++ b/testsuite/ada_lsp/rename/rename.json
@@ -185,14 +185,14 @@
                     "changes":{
                         "$URI{main.adb}":[{
                             "range":{
-                                "start":{"line":6,"character":40},
-                                "end":{"line":6,"character":41}
+                                "start":{"line":3,"character":3},
+                                "end":{"line":3,"character":4}
                             },
                             "newText":"BB"
                         },{
                             "range":{
-                                "start":{"line":3,"character":3},
-                                "end":{"line":3,"character":4}
+                                "start":{"line":6,"character":40},
+                                "end":{"line":6,"character":41}
                             },
                             "newText":"BB"
                         }]


### PR DESCRIPTION
The existing rename funcitonality was replaced by Laltools' one.
An error message is return if it is detected that the rename operation will
cause problems.
Added one test for a name collision problem.
Output of rename tests with the changes required were sorted by line number.