### PR TITLE
Mark incomplete type declaration as target

### DIFF
--- a/source/spawn/spawn-internal__glib.ads
+++ b/source/spawn/spawn-internal__glib.ads
@@ -46,7 +46,7 @@ private package Spawn.Internal is
    type Pipe_Array is array (Pipe_Kinds) of Pipe_Record;
    --  File descriptors array
 
-   type Process;
+   type Process is tagged;
 
    type Process_Reference is record
       Self : access Process'Class;

--- a/source/spawn/spawn-internal__glib_windows.ads
+++ b/source/spawn/spawn-internal__glib_windows.ads
@@ -36,7 +36,7 @@ private package Spawn.Internal is
 
    end Environments;
 
-   type Process;
+   type Process is tagged;
 
    Buffer_Size : constant Ada.Streams.Stream_Element_Count := 512;
 

--- a/source/spawn/spawn-internal__windows.ads
+++ b/source/spawn/spawn-internal__windows.ads
@@ -33,7 +33,7 @@ package Spawn.Internal is
       function "<" (Left, Right : UTF_8_String) return Boolean;
    end Environments;
 
-   type Process;
+   type Process is tagged;
 
    type Pipe_Kinds is (Stdin, Stdout, Stderr);
 


### PR DESCRIPTION
to avoid warnings in newer compiler.