### PR TITLE
TB23-030 Fix building libspawn.dll on Windows

### DIFF
--- a/gnat/spawn_glib.gpr
+++ b/gnat/spawn_glib.gpr
@@ -56,6 +56,7 @@ library project Spawn_Glib is
 
       when "Windows_NT" =>
          for Excluded_Source_Files use Common_Excluded;
+         for Library_Options use ("-lglib-2.0");
    end case;
 
    Ada_Switches := ();


### PR DESCRIPTION
when LIBRARY_TYPE=relocatable