### PR TITLE
U304-005 Add basic support for preprocessor directives

### DIFF
--- a/source/ada/lsp-ada_contexts.ads
+++ b/source/ada/lsp-ada_contexts.ads
@@ -216,6 +216,9 @@ package LSP.Ada_Contexts is
    --  call Callback for each. Name could contain a stale reference if the File
    --  was updated since last indexing operation.
 
+   function Charset (Self : Context) return String;
+   --  Return the charset for this context
+
 private
 
    type Context (Trace : GNATCOLL.Traces.Trace_Handle) is tagged limited record

--- a/source/ada/lsp-ada_documents.adb
+++ b/source/ada/lsp-ada_documents.adb
@@ -42,6 +42,7 @@ with LSP.Ada_Contexts; use LSP.Ada_Contexts;
 with LSP.Ada_Id_Iterators;
 with LSP.Predefined_Completion;
 with LSP.Common; use LSP.Common;
+with LSP.Preprocessor;
 with LSP.Lal_Utils;
 
 with Pp.Scanner;
@@ -2508,8 +2509,10 @@ package body LSP.Ada_Documents is
    is
       File : constant LSP.Types.LSP_String := URI_To_File (Self.URI);
    begin
-      return Context.LAL_Context.Get_From_File
-        (Filename => LSP.Types.To_UTF_8_String (File),
+      return LSP.Preprocessor.Get_From_File
+        (Context.LAL_Context,
+         Filename => LSP.Types.To_UTF_8_String (File),
+         Charset  => Context.Charset,
          Reparse  => False);
    end Unit;
 

--- a/source/ada/lsp-ada_handlers.adb
+++ b/source/ada/lsp-ada_handlers.adb
@@ -43,6 +43,7 @@ with LSP.Errors;
 with LSP.Lal_Utils;    use LSP.Lal_Utils;
 with LSP.Messages.Client_Requests;
 with LSP.Messages.Server_Notifications;
+with LSP.Preprocessor;
 with LSP.Servers.FS_Watch;
 with LSP.Types;        use LSP.Types;
 
@@ -965,7 +966,11 @@ package body LSP.Ada_Handlers is
                               Filename : constant String := +VF.Full_Name;
                            begin
                               Units_Vector.Append
-                                (Context.LAL_Context.Get_From_File (Filename));
+                                (LSP.Preprocessor.Get_From_File
+                                   (Context.LAL_Context, Filename,
+                                    --  ??? What is the charset for predefined
+                                    --  files?
+                                    ""));
                            end;
                         end loop;
 

--- a/source/ada/lsp-preprocessor.adb
+++ b/source/ada/lsp-preprocessor.adb
@@ -1,0 +1,189 @@
+------------------------------------------------------------------------------
+--                         Language Server Protocol                         --
+--                                                                          --
+--                       Copyright (C) 2021, AdaCore                        --
+--                                                                          --
+-- This is free software;  you can redistribute it  and/or modify it  under --
+-- terms of the  GNU General Public License as published  by the Free Soft- --
+-- ware  Foundation;  either version 3,  or (at your option) any later ver- --
+-- sion.  This software is distributed in the hope  that it will be useful, --
+-- but WITHOUT ANY WARRANTY;  without even the implied warranty of MERCHAN- --
+-- TABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public --
+-- License for  more details.  You should have  received  a copy of the GNU --
+-- General  Public  License  distributed  with  this  software;   see  file --
+-- COPYING3.  If not, go to http://www.gnu.org/licenses for a complete copy --
+-- of the license.                                                          --
+------------------------------------------------------------------------------
+
+with Ada.Characters.Handling;
+
+with GNAT.Strings;
+
+with GNATCOLL.VFS;   use GNATCOLL.VFS;
+with GNATCOLL.Iconv; use GNATCOLL.Iconv;
+
+with VSS.Strings.Conversions;
+with VSS.String_Vectors;
+
+package body LSP.Preprocessor is
+
+   package LAL renames Libadalang.Analysis;
+
+   function Preprocess_Buffer
+     (Buffer : Virtual_String) return Unbounded_String
+   is
+      Vect       : VSS.String_Vectors.Virtual_String_Vector;
+      Result     : Unbounded_String := Null_Unbounded_String;
+
+      procedure Process_One_Line (Line : Virtual_String);
+      --  Process one line of decoded output. This is the function that handles
+      --  preprocessing support.
+
+      --  Preprocessor hack: at the moment we consider that all the 'if'
+      --  branches of preprocessing are active but remove all 'else' branches.
+      --  We do this so that code of the form
+      --
+      --  #if something then
+      --     procedure foo (
+      --  #else
+      --     procedure foo (
+      --  #end if
+      --
+      --  ... still processable, even in degraded mode, by the language
+      --  server.
+
+      Currently_Preprocessing : Boolean := False;
+      This_branch_Evaluates_To_True : Boolean := False;
+
+      function Eval (Line : Virtual_String) return Boolean is
+         (Line.Starts_With (To_Virtual_String ("#if")));
+      --  Placeholder. This is where to insert "real" preprocessor logic.
+      --  For now the first branch after #if is considered true, the #else
+      --  branches are dropped - see above.
+
+      procedure Process_One_Line (Line : Virtual_String) is
+      begin
+         if Line.Starts_With (To_Virtual_String ("#if")) then
+            Currently_Preprocessing := True;
+            This_branch_Evaluates_To_True := Eval (Line);
+         elsif Line.Starts_With (To_Virtual_String ("#el")) then
+            This_branch_Evaluates_To_True := Eval (Line);
+         elsif Line.Starts_With (To_Virtual_String (("#end"))) then
+            Currently_Preprocessing := False;
+         end if;
+
+         if (not Currently_Preprocessing)
+           or else This_branch_Evaluates_To_True
+         then
+            Append
+              (Result,
+               VSS.Strings.Conversions.To_UTF_8_String (Line) & ASCII.LF);
+         else
+            Append (Result, "" & ASCII.LF);
+         end if;
+      end Process_One_Line;
+
+   begin
+      Vect := Buffer.Split_Lines;
+
+      for Line of Vect loop
+         Process_One_Line (Line);
+      end loop;
+
+      return Result;
+   end Preprocess_Buffer;
+
+   ------------------
+   -- Process_File --
+   ------------------
+
+   function Preprocess_File (Filename : String; Charset : String)
+                          return Unbounded_String
+   is
+      use type GNAT.Strings.String_Access;
+      Raw        : GNAT.Strings.String_Access;
+      Decoded    : Virtual_String;
+   begin
+      --  Read the file (this call uses MMAP)
+      Raw := Create (+Filename).Read_File;
+
+      if Raw = null then
+         return Null_Unbounded_String;
+      end if;
+
+      --  Convert the file if it's not already encoded in utf-8
+
+      if Ada.Characters.Handling.To_Lower (Charset) /= "utf-8" then
+         declare
+            State        : constant Iconv_T := Iconv_Open (UTF8, Charset);
+            Outbuf       : Byte_Sequence (1 .. Raw'Length * 4);
+            Input_Index  : Positive := Raw'First;
+            Conv_Result  : Iconv_Result;
+            Output_Index : Positive := 1;
+         begin
+            Iconv (State => State,
+                   Inbuf => Raw.all,
+                   Input_Index => Input_Index,
+                   Outbuf => Outbuf,
+                   Output_Index => Output_Index,
+                   Result => Conv_Result);
+
+            GNAT.Strings.Free (Raw);
+
+            case Conv_Result is
+               when Success =>
+                  --  The conversion was successful
+                  Raw := new String'(Outbuf (1 .. Output_Index - 1));
+               when others =>
+                  --  TODO: transmit the result to the user
+                  return Null_Unbounded_String;
+            end case;
+         exception
+            when others =>
+               --  TODO: transmit the result to the user
+               return Null_Unbounded_String;
+         end;
+      end if;
+
+      --  Convert the string to a Virtual_String for easier handling
+
+      Decoded := VSS.Strings.Conversions.To_Virtual_String (Raw.all);
+      GNAT.Strings.Free (Raw);
+
+      return Preprocess_Buffer (Decoded);
+   exception
+      when others =>
+         if Raw /= null then
+            GNAT.Strings.Free (Raw);
+         end if;
+
+         --  TODO: transmit this to the user
+         return Null_Unbounded_String;
+   end Preprocess_File;
+
+   -------------------
+   -- Get_From_File --
+   -------------------
+
+   function Get_From_File
+     (Context  : Libadalang.Analysis.Analysis_Context;
+      Filename : String;
+      Charset  : String;
+      Reparse  : Boolean := False;
+      Rule     : Grammar_Rule := Default_Grammar_Rule)
+      return Libadalang.Analysis.Analysis_Unit is
+      Buffer   : Unbounded_String;
+   begin
+      if not Reparse
+        and then Context.Has_Unit (Filename)
+      then
+         return LAL.Get_With_Error
+           (Context, Filename, "", Charset);
+      end if;
+      Buffer := Preprocess_File (Filename, Charset);
+
+      return LAL.Get_From_Buffer
+        (Context, Filename, Charset, Buffer, Rule);
+   end Get_From_File;
+
+end LSP.Preprocessor;

--- a/source/ada/lsp-preprocessor.ads
+++ b/source/ada/lsp-preprocessor.ads
@@ -1,0 +1,55 @@
+------------------------------------------------------------------------------
+--                         Language Server Protocol                         --
+--                                                                          --
+--                       Copyright (C) 2021, AdaCore                        --
+--                                                                          --
+-- This is free software;  you can redistribute it  and/or modify it  under --
+-- terms of the  GNU General Public License as published  by the Free Soft- --
+-- ware  Foundation;  either version 3,  or (at your option) any later ver- --
+-- sion.  This software is distributed in the hope  that it will be useful, --
+-- but WITHOUT ANY WARRANTY;  without even the implied warranty of MERCHAN- --
+-- TABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public --
+-- License for  more details.  You should have  received  a copy of the GNU --
+-- General  Public  License  distributed  with  this  software;   see  file --
+-- COPYING3.  If not, go to http://www.gnu.org/licenses for a complete copy --
+-- of the license.                                                          --
+------------------------------------------------------------------------------
+
+--  Provide utilities to preprocess buffers before passing them to Libadalang
+
+with Ada.Strings.Unbounded; use Ada.Strings.Unbounded;
+with VSS.Strings;           use VSS.Strings;
+
+with Libadalang.Analysis;
+with Libadalang.Common;     use Libadalang.Common;
+
+package LSP.Preprocessor is
+
+   function Preprocess_Buffer
+     (Buffer : Virtual_String) return Unbounded_String;
+   --  Preprocess a buffer for the needs of the Ada Language Server: take the
+   --  whole buffer as parameter as read on disk or in open editors and
+   --  return a modified version that we want Libadalang to see.
+   --  Buffer must be encoded in UTF-8.
+   --  The resulting string is also encoded in UTF-8.
+   --  Right now this does the following:
+   --     - convert CR / CRLF line terminators to LF
+   --     - handle pre-processing directives
+   --  Note: at the moment this returns an Unbounded_String because this
+   --  is what's most suitable for Libadalang.
+
+   function Preprocess_File
+     (Filename : String; Charset : String) return Unbounded_String;
+   --  Load a file form disk and preprocess it with Preprocess_Buffer
+
+   function Get_From_File
+     (Context  : Libadalang.Analysis.Analysis_Context;
+      Filename : String;
+      Charset  : String;
+      Reparse  : Boolean := False;
+      Rule     : Grammar_Rule := Default_Grammar_Rule)
+      return Libadalang.Analysis.Analysis_Unit;
+   --  Behaves like Libadalang.Analysis.Get_From_File, but preprocesses
+   --  the file using Preprocess_Buffer above.
+
+end LSP.Preprocessor;

--- a/source/ada/lsp-unit_providers.adb
+++ b/source/ada/lsp-unit_providers.adb
@@ -1,0 +1,207 @@
+------------------------------------------------------------------------------
+--                         Language Server Protocol                         --
+--                                                                          --
+--                       Copyright (C) 2021, AdaCore                        --
+--                                                                          --
+-- This is free software;  you can redistribute it  and/or modify it  under --
+-- terms of the  GNU General Public License as published  by the Free Soft- --
+-- ware  Foundation;  either version 3,  or (at your option) any later ver- --
+-- sion.  This software is distributed in the hope  that it will be useful, --
+-- but WITHOUT ANY WARRANTY;  without even the implied warranty of MERCHAN- --
+-- TABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public --
+-- License for  more details.  You should have  received  a copy of the GNU --
+-- General  Public  License  distributed  with  this  software;   see  file --
+-- COPYING3.  If not, go to http://www.gnu.org/licenses for a complete copy --
+-- of the license.                                                          --
+------------------------------------------------------------------------------
+
+with Ada.Strings.Unbounded; use Ada.Strings.Unbounded;
+with GNATCOLL.VFS;          use GNATCOLL.VFS;
+
+with Libadalang.Unit_Files;
+with Langkit_Support.Text; use Langkit_Support.Text;
+
+with LSP.Preprocessor; use LSP.Preprocessor;
+
+package body LSP.Unit_Providers is
+
+   package US renames Ada.Strings.Unbounded;
+   use type US.Unbounded_String;
+
+   type Project_Unit_Provider is new LAL.Unit_Provider_Interface with record
+      Tree             : Prj.Project_Tree_Access;
+      Projects         : Prj.Project_Array_Access;
+      Env              : Prj.Project_Environment_Access;
+      Is_Project_Owner : Boolean;
+   end record;
+   --  Unit provider backed up by a project file
+
+   overriding function Get_Unit_Filename
+     (Provider : Project_Unit_Provider;
+      Name     : Text_Type;
+      Kind     : Analysis_Unit_Kind) return String;
+
+   overriding function Get_Unit
+     (Provider    : Project_Unit_Provider;
+      Context     : LAL.Analysis_Context'Class;
+      Name        : Text_Type;
+      Kind        : Analysis_Unit_Kind;
+      Charset     : String := "";
+      Reparse     : Boolean := False) return LAL.Analysis_Unit'Class;
+
+   overriding procedure Release (Provider : in out Project_Unit_Provider);
+   ----------------------------------
+   -- Create_Project_Unit_Provider --
+   ----------------------------------
+
+   function Create_Project_Unit_Provider
+     (Tree             : Prj.Project_Tree_Access;
+      Project          : Prj.Project_Type := Prj.No_Project;
+      Env              : Prj.Project_Environment_Access;
+      Is_Project_Owner : Boolean := True)
+      return LAL.Unit_Provider_Reference
+   is
+      use type Prj.Project_Type;
+   begin
+      --  Sanity checks
+      if Project = Prj.No_Project then
+         raise Program_Error with
+           "this unit provider requires a project";
+      end if;
+
+      if Project.Is_Aggregate_Project then
+         raise Program_Error with
+           "this unit provider does not support aggregate projects";
+      end if;
+
+      declare
+         Provider : constant Project_Unit_Provider :=
+           (Tree             => Tree,
+            Projects         => new Prj.Project_Array'(1 => Project),
+            Env              => Env,
+            Is_Project_Owner => Is_Project_Owner);
+      begin
+         return LAL.Create_Unit_Provider_Reference (Provider);
+      end;
+   end Create_Project_Unit_Provider;
+
+   -----------------------
+   -- Get_Unit_Filename --
+   -----------------------
+
+   overriding function Get_Unit_Filename
+     (Provider : Project_Unit_Provider;
+      Name     : Text_Type;
+      Kind     : Analysis_Unit_Kind) return String
+   is
+      --  Dummy : GNATCOLL.Locks.Scoped_Lock (Libadalang.GPR_Lock.Lock'Access);
+
+      Str_Name : constant String :=
+        Libadalang.Unit_Files.Unit_String_Name (Name);
+   begin
+      --  Look for a source file corresponding to Name/Kind in all projects
+      --  associated to this Provider. Note that unlike what is documented,
+      --  it's not because File_From_Unit returns an non-empty string that the
+      --  unit does belong to the project, so we must also check
+      --  Create_From_Project's result.
+
+      for P of Provider.Projects.all loop
+         declare
+            File : constant Filesystem_String := Prj.File_From_Unit
+              (Project   => P,
+               Unit_Name => Str_Name,
+               Part      => Convert (Kind),
+               Language  => "Ada");
+         begin
+            if File'Length /= 0 then
+               declare
+                  Path : constant GNATCOLL.VFS.Virtual_File :=
+                    Prj.Create_From_Project (P, File).File;
+                  Fullname : constant String := +Path.Full_Name;
+               begin
+                  if Fullname'Length /= 0 then
+                     return Fullname;
+                  end if;
+               end;
+            end if;
+         end;
+      end loop;
+
+      return "";
+   end Get_Unit_Filename;
+
+   --------------
+   -- Get_Unit --
+   --------------
+
+   overriding function Get_Unit
+     (Provider    : Project_Unit_Provider;
+      Context     : LAL.Analysis_Context'Class;
+      Name        : Text_Type;
+      Kind        : Analysis_Unit_Kind;
+      Charset     : String := "";
+      Reparse     : Boolean := False) return LAL.Analysis_Unit'Class
+   is
+      Filename : constant String := Provider.Get_Unit_Filename (Name, Kind);
+      Buffer   : Unbounded_String;
+   begin
+      if Filename /= "" then
+         -------------------------------------------------------------
+         --  NOTE: this is the part of this package which differs from
+         --  the Libadalang Unit provider: see if we can improve code
+         --  reuse.
+
+         --  If Reparse is False and the context already has this unit,
+         --  simply return it...
+         if not Reparse
+           and then Context.Has_Unit (Filename)
+         then
+            return LAL.Get_With_Error
+              (Context, Filename, "", Charset);
+         end if;
+
+         --  ... otherwise, load the file from disk and preprocess it
+         Buffer := Preprocess_File (Filename, Charset);
+
+         return LAL.Get_From_Buffer
+           (Context, Filename, Charset, Buffer);
+
+         --  /NOTE
+         -------------------------------------------------------------
+      else
+         declare
+            Dummy_File : constant String :=
+               Libadalang.Unit_Files.File_From_Unit (Name, Kind);
+            Kind_Name  : constant Text_Type :=
+              (case Kind is
+               when Unit_Specification => "specification file",
+               when Unit_Body          => "body file");
+            Error      : constant Text_Type :=
+               "Could not find source file for " & Name & " (" & Kind_Name
+               & ")";
+         begin
+            return LAL.Get_With_Error (Context, Dummy_File, Error, Charset);
+         end;
+      end if;
+   end Get_Unit;
+
+   -------------
+   -- Release --
+   -------------
+
+   overriding procedure Release (Provider : in out Project_Unit_Provider)
+   is
+      --  Dummy : GNATCOLL.Locks.Scoped_Lock (Libadalang.GPR_Lock.Lock'Access);
+   begin
+      Prj.Unchecked_Free (Provider.Projects);
+      if Provider.Is_Project_Owner then
+         Prj.Unload (Provider.Tree.all);
+         Prj.Free (Provider.Tree);
+         Prj.Free (Provider.Env);
+      end if;
+      Provider.Tree := null;
+      Provider.Env := null;
+      Provider.Is_Project_Owner := False;
+   end Release;
+
+end LSP.Unit_Providers;

--- a/source/ada/lsp-unit_providers.ads
+++ b/source/ada/lsp-unit_providers.ads
@@ -1,0 +1,70 @@
+------------------------------------------------------------------------------
+--                         Language Server Protocol                         --
+--                                                                          --
+--                       Copyright (C) 2021, AdaCore                        --
+--                                                                          --
+-- This is free software;  you can redistribute it  and/or modify it  under --
+-- terms of the  GNU General Public License as published  by the Free Soft- --
+-- ware  Foundation;  either version 3,  or (at your option) any later ver- --
+-- sion.  This software is distributed in the hope  that it will be useful, --
+-- but WITHOUT ANY WARRANTY;  without even the implied warranty of MERCHAN- --
+-- TABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public --
+-- License for  more details.  You should have  received  a copy of the GNU --
+-- General  Public  License  distributed  with  this  software;   see  file --
+-- COPYING3.  If not, go to http://www.gnu.org/licenses for a complete copy --
+-- of the license.                                                          --
+------------------------------------------------------------------------------
+
+--  Provides an Unit Provider which preprocesses the files as they are read
+--  from disk. This is copied from Libadalang, see "NOTE" in the body.
+
+with GNATCOLL.Projects;
+with GNATCOLL.Traces; use GNATCOLL.Traces;
+
+with Libadalang.Analysis;
+with Libadalang.Common; use Libadalang.Common;
+
+package LSP.Unit_Providers is
+
+   package LAL renames Libadalang.Analysis;
+   package Prj renames GNATCOLL.Projects;
+
+   Trace : constant GNATCOLL.Traces.Trace_Handle := GNATCOLL.Traces.Create
+     ("LIBADALANG.PROJECT_PROVIDER", GNATCOLL.Traces.From_Config);
+
+   type Provider_And_Projects is record
+      Provider : LAL.Unit_Provider_Reference;
+      Projects : Prj.Project_Array_Access;
+   end record;
+   --  Associates one project unit provider with all the projects on which it
+   --  has visibility.
+
+   function Create_Project_Unit_Provider
+     (Tree             : Prj.Project_Tree_Access;
+      Project          : Prj.Project_Type := Prj.No_Project;
+      Env              : Prj.Project_Environment_Access;
+      Is_Project_Owner : Boolean := True)
+      return LAL.Unit_Provider_Reference;
+   --  Likewise, but create only one unit provider.
+   --
+   --  If a non-null Project is given, use it to provide units. Raise an
+   --  Invalid_Project exception if an aggregate projects that aggregates more
+   --  than one project is in its closure.
+   --
+   --  If Project is not provided, run Create_Project_Unit_Providers: if it
+   --  returns only one provider, return it, otherwise raise an error.
+   --
+   --  If ``Is_Project_Owner`` is true, the result owns ``Tree``, thus the
+   --  caller must not deallocate it itself.  Otherwise, the project pointed to
+   --  by Project must outlive the returned unit file provider.
+
+   function Convert
+     (Kind : Analysis_Unit_Kind) return GNATCOLL.Projects.Unit_Parts
+   is
+     (case Kind is
+      when Unit_Specification => GNATCOLL.Projects.Unit_Spec,
+      when Unit_Body          => GNATCOLL.Projects.Unit_Body);
+   --  Convert our kind for analysis unit into the corresponding
+   --  ``GNATCOLL.Projects`` value.
+
+end LSP.Unit_Providers;

--- a/testsuite/ada_lsp/preprocessor/a.adb
+++ b/testsuite/ada_lsp/preprocessor/a.adb
@@ -1,0 +1,16 @@
+with mytypes; use mytypes;
+
+procedure A is
+
+   My_Var : recordtype
+   :=
+#if debug="true"
+              (Field1     => Integer'Last,
+#else
+              (Field1     => Integer'First,
+#end if; -- debug="true"
+               Field2 => 42);
+begin
+   My_Var.Field1 := 2;
+   My_Var.Field2 := 2;
+end;

--- a/testsuite/ada_lsp/preprocessor/mytypes.adb
+++ b/testsuite/ada_lsp/preprocessor/mytypes.adb
@@ -1,0 +1,5 @@
+package body mytypes is
+
+   
+
+end mytypes;

--- a/testsuite/ada_lsp/preprocessor/mytypes.ads
+++ b/testsuite/ada_lsp/preprocessor/mytypes.ads
@@ -1,0 +1,24 @@
+package mytypes is
+
+   type recordtype is record
+#if debug="true"
+      Field1 
+#else
+      Field1
+#end if; -- debug="true"
+      : Integer;
+#if debug="true"
+      Field2 : Integer;
+#else
+      Field2 : Integer;
+#end if; -- debug="true"
+   end record;
+
+   My_Var : recordtype :=
+#if debug="true"
+              (Field1     => Integer'Last,
+#else
+              (Field1     => Integer'First,
+#end if; -- debug="true"
+               Field2 => 42);
+end mytypes;

--- a/testsuite/ada_lsp/preprocessor/p.gpr
+++ b/testsuite/ada_lsp/preprocessor/p.gpr
@@ -1,0 +1,2 @@
+project p is
+end p;

--- a/testsuite/ada_lsp/preprocessor/test.json
+++ b/testsuite/ada_lsp/preprocessor/test.json
@@ -1,0 +1,361 @@
+[
+   {
+      "comment": [
+         "test navigation in the presence of disruptive preprocessing"
+      ]
+   },
+   {
+      "start": {
+         "cmd": [
+            "${ALS}"
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": "ada-1",
+            "method": "initialize",
+            "params": {
+               "processId": 131870,
+               "rootUri": "$URI{.}",
+               "capabilities": {
+                  "workspace": {
+                     "applyEdit": true,
+                     "workspaceEdit": {},
+                     "didChangeConfiguration": {},
+                     "didChangeWatchedFiles": {},
+                     "executeCommand": {}
+                  },
+                  "textDocument": {
+                     "synchronization": {},
+                     "completion": {
+                        "dynamicRegistration": true,
+                        "completionItem": {
+                           "snippetSupport": true,
+                           "documentationFormat": [
+                              "plaintext",
+                              "markdown"
+                           ]
+                        }
+                     },
+                     "hover": {},
+                     "signatureHelp": {},
+                     "declaration": {},
+                     "definition": {},
+                     "typeDefinition": {},
+                     "implementation": {},
+                     "references": {},
+                     "documentHighlight": {},
+                     "documentSymbol": {
+                        "hierarchicalDocumentSymbolSupport": true
+                     },
+                     "codeLens": {},
+                     "colorProvider": {},
+                     "formatting": {
+                        "dynamicRegistration": false
+                     },
+                     "rangeFormatting": {
+                        "dynamicRegistration": false
+                     },
+                     "onTypeFormatting": {
+                        "dynamicRegistration": false
+                     },
+                     "foldingRange": {
+                        "lineFoldingOnly": true
+                     },
+                     "selectionRange": {},
+                     "callHierarchy": {}
+                  }
+               }
+            }
+         },
+         "wait": [
+            {
+               "id": "ada-1",
+               "result": {
+                  "capabilities": {
+                     "textDocumentSync": 2,
+                     "completionProvider": {
+                        "triggerCharacters": [
+                           ".",
+                           "("
+                        ],
+                        "resolveProvider": false
+                     },
+                     "hoverProvider": true,
+                     "declarationProvider": true,
+                     "definitionProvider": true,
+                     "typeDefinitionProvider": true,
+                     "implementationProvider": true,
+                     "referencesProvider": true,
+                     "documentHighlightProvider": true,
+                     "documentSymbolProvider": true,
+                     "codeActionProvider": {},
+                     "documentFormattingProvider": true,
+                     "renameProvider": {},
+                     "foldingRangeProvider": true,
+                     "workspaceSymbolProvider": true,
+                     "callHierarchyProvider": {},
+                     "alsCalledByProvider": true,
+                     "alsCallsProvider": true,
+                     "alsShowDepsProvider": true,
+                     "alsReferenceKinds": [
+                        "reference",
+                        "access",
+                        "write",
+                        "call",
+                        "dispatching call",
+                        "parent",
+                        "child"
+                     ]
+                  }
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "initialized"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "workspace/didChangeConfiguration",
+            "params": {
+               "settings": {
+                  "ada": {
+                     "projectFile": "p.gpr",
+                     "scenarioVariables": {},
+                     "defaultCharset": "UTF-8",
+                     "enableDiagnostics": false
+                  }
+               }
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{a.adb}",
+                  "languageId": "Ada",
+                  "version": 0,
+                  "text": "with mytypes; use mytypes;\n\nprocedure A is\n\n   My_Var : recordtype\n   :=\n#if debug=\"true\"\n              (Field1     => Integer'Last,\n#else\n              (Field1     => Integer'First,\n#end if; -- debug=\"true\"\n               Field2 => 42);\nbegin\n   My_Var.Field1 := 2;\n   My_Var.Field2 := 2;\nend;\n"
+               }
+            }
+         },
+         "wait": []
+      }
+   },
+   {"comment": "------------------------ verify that the file on disk (mytypes.ads) could be navigated to, even if it has preprocessing "},
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": "ada-6",
+            "method": "textDocument/definition",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{a.adb}"
+               },
+               "position": {
+                  "line": 14,
+                  "character": 10
+               },
+               "alsDisplayMethodAncestryOnNavigation": "Usage_And_Abstract_Only"
+            }
+         },
+         "wait": [
+            {
+               "id": "ada-6",
+               "result": [
+                  {
+                     "uri": "$URI{mytypes.ads}",
+                     "range": {
+                        "start": {
+                           "line": 10,
+                           "character": 6
+                        },
+                        "end": {
+                           "line": 10,
+                           "character": 12
+                        }
+                     }
+                  }
+               ]
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{mytypes.ads}",
+                  "languageId": "Ada",
+                  "version": 0,
+                  "text": "package mytypes is\n\n   type recordtype is record\n#if debug=\"true\"\n      Field1 \n#else\n      Field1\n#end if; -- debug=\"true\"\n      : Integer;\n#if debug=\"true\"\n      Field2 : Integer;\n#else\n      Field2 : Integer;\n#end if; -- debug=\"true\"\n   end record;\n\n   My_Var : recordtype :=\n#if debug=\"true\"\n              (Field1     => Integer'Last,\n#else\n              (Field1     => Integer'First,\n#end if; -- debug=\"true\"\n               Field2 => 42);\nend mytypes;\n"
+               }
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didClose",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{mytypes.ads}"
+               }
+            }
+         },
+         "wait": []
+      }
+   },
+   {"comment": "------------------------ verify that the file on disk (mytypes.ads) could be navigated to even after it has been closed"},
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": "ada-14",
+            "method": "textDocument/definition",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{a.adb}"
+               },
+               "position": {
+                  "line": 13,
+                  "character": 10
+               },
+               "alsDisplayMethodAncestryOnNavigation": "Usage_And_Abstract_Only"
+            }
+         },
+         "wait": [
+            {
+               "id": "ada-14",
+               "result": [
+                  {
+                     "uri": "$URI{mytypes.ads}",
+                     "range": {
+                        "start": {
+                           "line": 4,
+                           "character": 6
+                        },
+                        "end": {
+                           "line": 4,
+                           "character": 12
+                        }
+                     }
+                  }
+               ]
+            }
+         ]
+      }
+   },
+   {"comment": "------------------------ this navigation is in a preprocessed-out area, should return nothing"},
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": "ada-22",
+            "method": "textDocument/definition",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{a.adb}"
+               },
+               "position": {
+                  "line": 9,
+                  "character": 15
+               },
+               "alsDisplayMethodAncestryOnNavigation": "Usage_And_Abstract_Only"
+            }
+         },
+         "wait": [
+            {
+               "id": "ada-22",
+               "result": []
+            }
+         ]
+      }
+   },  
+   {"comment": "------------------------ check proper navigation after the one which returned no result"},
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": "ada-25",
+            "method": "textDocument/definition",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{a.adb}"
+               },
+               "position": {
+                  "line": 11,
+                  "character": 15
+               },
+               "alsDisplayMethodAncestryOnNavigation": "Usage_And_Abstract_Only"
+            }
+         },
+         "wait": [
+            {
+               "id": "ada-25",
+               "result": [
+                  {
+                     "uri": "$URI{mytypes.ads}",
+                     "range": {
+                        "start": {
+                           "line": 10,
+                           "character": 6
+                        },
+                        "end": {
+                           "line": 10,
+                           "character": 12
+                        }
+                     }
+                  }
+               ]
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": "ada-32",
+            "method": "shutdown"
+         },
+         "wait": [
+            {
+               "id": "ada-32",
+               "result": null
+            }
+         ]
+      }
+   },
+   {
+      "stop": {
+         "exit_code": 0
+      }
+   }
+]

--- a/testsuite/ada_lsp/preprocessor/test.yaml
+++ b/testsuite/ada_lsp/preprocessor/test.yaml
@@ -1,0 +1,1 @@
+title: 'preprocessor'


### PR DESCRIPTION
For now, we do not support an actual preprocessor, but work
in a degraded mode where the "#if" branch of preprocessing is
always chosen.

This allows responding to requests in cases where simply
"ignoring all preprocessing" is not sufficient because it
results in non-valid syntax, for instance

     #if A
        procedure foo (
     # else
        procedure foo (
     # endif

We do this by intercepting buffers before they are sent
to Libadalang, and preprocess on-the-fly.

This also adds support for working with non-LF line terminators:
the line terminators are changed to LF as part of the
preprocessing.