### PR TITLE
U308-004 catch "assertion_failure" an an expected exception

### DIFF
--- a/source/server/lsp-servers.adb
+++ b/source/server/lsp-servers.adb
@@ -15,6 +15,7 @@
 -- of the license.                                                          --
 ------------------------------------------------------------------------------
 
+with Ada.Assertions;
 with Ada.Characters.Latin_1;
 with Ada.Exceptions;             use Ada.Exceptions;
 with Ada.IO_Exceptions;
@@ -1140,8 +1141,14 @@ package body LSP.Servers is
             & Exception_Name (E) & ASCII.LF &
               Symbolic_Traceback (E));
 
-         if Exception_Identity (E) = Property_Error'Identity
-           or Exception_Identity (E) = Precondition_Failure'Identity
+         if Exception_Identity (E) in
+           --  Libadalang / Langkit might raise these when working on
+           --  invalid Ada Code
+           Property_Error'Identity | Precondition_Failure'Identity
+
+           --  Some versions of Libadalang_Tools raise Assertion_Error
+           --  on invalid Ada Code
+             | Ada.Assertions.Assertion_Error'Identity
          then
             return True;
          end if;

--- a/testsuite/ada_lsp/S510-020.exceptions_reporting/test.json
+++ b/testsuite/ada_lsp/S510-020.exceptions_reporting/test.json
@@ -26,26 +26,15 @@
             "request": {
                 "jsonrpc":"2.0",
                 "id":"references-1",
-                "method":"textDocument/references",
-                "params":{
-                    "textDocument": {
-                        "uri": "DOES NOT EXIST"
-                    },
-                    "position": {
-                        "line": 1,
-                        "character": 12
-                    },
-                    "context": {
-                        "includeDeclaration":true
-                    }
-                }
+                "method":"a method name that does not exist",
+                "params":{}
             },
             "comment": " -- we expect an exception here, code -32603",
             "wait":[{
                 "jsonrpc": "2.0",
                 "id": "references-1",
                 "error": {
-                    "code":-32603,
+                    "code":-32601,
                     "message":"<ANY>"
                 }
             }]


### PR DESCRIPTION
The stable version of libadalang_tools uses this for invalid
code.

Adjust a test driver to catch another exception.