### PR TITLE
Let Ada problemMatcher work with absolute path

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "ada.projectFile": "gnat/lsp_server.gpr"
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,6 +1,4 @@
 {
-    // See https://go.microsoft.com/fwlink/?LinkId=733558
-    // for the documentation about the tasks.json format
     "version": "2.0.0",
     "tasks": [
         {
@@ -10,7 +8,7 @@
             "args": [
                 "-p",
                 "-P",
-                "${workspaceFolder}/hello.gpr",
+                "${workspaceFolder}/gnat/lsp_server.gpr",
                 "-cargs",
                 "-gnatef"
             ],

--- a/integration/vscode/ada/package.json
+++ b/integration/vscode/ada/package.json
@@ -175,7 +175,7 @@
                 "name": "ada",
                 "label": "Gnat Ada Problem Matcher",
                 "fileLocation": [
-                    "relative",
+                    "autoDetect",
                     "${workspaceRoot}"
                 ],
                 "pattern": [

--- a/integration/vscode/gnatprove/.vscode/tasks.json
+++ b/integration/vscode/gnatprove/.vscode/tasks.json
@@ -14,12 +14,14 @@
                 "-p",
                 "-P",
                 "test.gpr"
+                "-cargs",
+                "-gnatef"
             ],
             "problemMatcher": ["$ada"],
             "group": {
                 "kind": "build",
                 "isDefault": true
-            }             
+            }
         },
         {
             "label": "prove",
@@ -31,11 +33,13 @@
             "args": [
                 "--report=all",
                 "-P",
-                "test.gpr"
+                "test.gpr",
+                "-cargs",
+                "-gnatef"
             ],
             "problemMatcher": [{
                 "owner": "ada",
-                "fileLocation": ["relative", "${workspaceFolder}"],
+                "fileLocation": ["autoDetect", "${workspaceFolder}"],
                 "severity": "error",
                 "pattern": {
                     "regexp": "(\\S+):(\\d+):(\\d+): error: (.+)",
@@ -46,7 +50,7 @@
                 }
             },{
                 "owner": "ada",
-                "fileLocation": ["relative", "${workspaceFolder}"],
+                "fileLocation": ["autoDetect", "${workspaceFolder}"],
                 "severity": "warning",
                 "pattern": {
                     "regexp": "(\\S+):(\\d+):(\\d+): warning: (.+)",
@@ -57,7 +61,7 @@
                 }
             },{
                 "owner": "ada",
-                "fileLocation": ["relative", "${workspaceFolder}"],
+                "fileLocation": ["autoDetect", "${workspaceFolder}"],
                 "severity": "info",
                 "pattern": {
                     "regexp": "(\\S+):(\\d+):(\\d+): info: (.+)",


### PR DESCRIPTION
and fix examples by adding `-gnatef` to `tasks.json`
Refs #541