### PR TITLE
U304-005 add support for non-latin1 files

### DIFF
--- a/source/ada/lsp-ada_contexts.adb
+++ b/source/ada/lsp-ada_contexts.adb
@@ -625,6 +625,7 @@ package body LSP.Ada_Contexts is
           (Tree             => Tree,
            Project          => Root,
            Env              => Get_Environment (Root),
+           Default_Charset  => Charset,
            Is_Project_Owner => False);
 
       Self.Reload;

--- a/source/ada/lsp-preprocessor.adb
+++ b/source/ada/lsp-preprocessor.adb
@@ -235,16 +235,18 @@ package body LSP.Preprocessor is
       return Libadalang.Analysis.Analysis_Unit is
       Buffer   : Unbounded_String;
    begin
+      --  Preprocessing guarantees that the buffers are known to LAL in
+      --  UTF-8: we can use this safely rather than Charset below.
       if not Reparse
         and then Context.Has_Unit (Filename)
       then
          return LAL.Get_With_Error
-           (Context, Filename, "", Charset);
+           (Context, Filename, "", "utf-8");
       end if;
       Buffer := Preprocess_File (Filename, Charset);
 
       return LAL.Get_From_Buffer
-        (Context, Filename, Charset, Buffer, Rule);
+        (Context, Filename, "utf-8", Buffer, Rule);
    end Get_From_File;
 
 end LSP.Preprocessor;

--- a/source/ada/lsp-unit_providers.ads
+++ b/source/ada/lsp-unit_providers.ads
@@ -37,6 +37,7 @@ package LSP.Unit_Providers is
      (Tree             : Prj.Project_Tree_Access;
       Project          : Prj.Project_Type;
       Env              : Prj.Project_Environment_Access;
+      Default_Charset  : String;
       Is_Project_Owner : Boolean := True)
       return LAL.Unit_Provider_Reference
       with Pre => Project /= Prj.No_Project


### PR DESCRIPTION
The previous work on preprocessing omitted to use
the default charset from the context when reading
files from disk.