### PR TITLE
T723-027: Implement SignatureHelp

### DIFF
--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -283,7 +283,7 @@ REQUESTS = [
     ('textDocument/references', 'References', 'ReferenceParams',
      'Location_Response'),
     ('textDocument/signatureHelp', 'Signature_Help',
-     'TextDocumentPositionParams', 'SignatureHelp_Response'),
+     'SignatureHelpParams', 'SignatureHelp_Response'),
     ('textDocument/documentSymbol', 'Document_Symbols',
      'DocumentSymbolParams', 'Symbol_Response'),
     ('textDocument/rename', 'Rename', 'RenameParams', 'Rename_Response'),

--- a/source/ada/lsp-ada_contexts.adb
+++ b/source/ada/lsp-ada_contexts.adb
@@ -471,6 +471,30 @@ package body LSP.Ada_Contexts is
          Log (Self.Trace, E, "in Is_Called_By");
    end Find_All_Calls;
 
+   ---------------------------
+   -- Find_All_Env_Elements --
+   ---------------------------
+
+   function Find_All_Env_Elements
+     (Self     : Context;
+      Name     : Libadalang.Analysis.Name;
+      Seq      : Boolean := True;
+      Seq_From : Libadalang.Analysis.Ada_Node'Class :=
+        Libadalang.Analysis.No_Ada_Node)
+     return Libadalang.Analysis.Ada_Node_Array is
+   begin
+      return Libadalang.Analysis.P_All_Env_Elements (Name, Seq, Seq_From);
+   exception
+      when E : Libadalang.Common.Property_Error =>
+         Log (Self.Trace, E, "in Find_All_Env_Elements");
+         declare
+            Empty_Node_Array : constant
+              Libadalang.Analysis.Ada_Node_Array (1 .. 0) := (others => <>);
+         begin
+            return Empty_Node_Array;
+         end;
+   end Find_All_Env_Elements;
+
    -------------------------------
    -- Get_Any_Symbol_Completion --
    -------------------------------

--- a/source/ada/lsp-ada_contexts.ads
+++ b/source/ada/lsp-ada_contexts.ads
@@ -142,6 +142,17 @@ package LSP.Ada_Contexts is
    --  Return all the enclosing entities that call Definition in all sources
    --  known to this project.
 
+   function Find_All_Env_Elements
+     (Self     : Context;
+      Name     : Libadalang.Analysis.Name;
+      Seq      : Boolean := True;
+      Seq_From : Libadalang.Analysis.Ada_Node'Class :=
+        Libadalang.Analysis.No_Ada_Node)
+      return Libadalang.Analysis.Ada_Node_Array;
+   --  Return all elements lexically named like Name.
+   --  If Seq is True and Seq_From is not empty, reduce the scope to the
+   --  node above Seq_From.
+
    procedure Get_References_For_Renaming
      (Self              : Context;
       Definition        : Libadalang.Analysis.Defining_Name;

--- a/source/ada/lsp-lal_utils.ads
+++ b/source/ada/lsp-lal_utils.ads
@@ -133,6 +133,29 @@ package LSP.Lal_Utils is
    --  When Ignore_Local it will return Is_Null for all local objects like
    --  variables.
 
+   procedure Get_Call_Expr_Name
+     (Node            : Libadalang.Analysis.Ada_Node'Class;
+      Active_Position : out LSP.Types.LSP_Number;
+      Designator      : out Libadalang.Analysis.Ada_Node;
+      Name_Node       : out Libadalang.Analysis.Name);
+   --  If Node is inside a Call_Expr returns the following:
+   --  Active_Position: the index of the parameter in the Call_Expr
+   --  Designator: the designator of the Active_Position
+   --  Name_Node: the name of the Call_Expr
+
+   procedure Get_Parameters
+     (Node : Libadalang.Analysis.Basic_Decl;
+      Parameters : in out LSP.Messages.ParameterInformation_Vector);
+   --  Append all the parameters of Node inside Parameters
+
+   function Get_Active_Parameter
+     (Node       : Libadalang.Analysis.Basic_Decl;
+      Designator : Libadalang.Analysis.Ada_Node;
+      Position   : LSP.Types.LSP_Number)
+      return LSP.Types.LSP_Number;
+   --  Return the position of Designator in the parameters of Node else -1
+   --  If Designator is null try check if Position is a valid parameter index
+
    function To_Call_Hierarchy_Item
      (Name : Libadalang.Analysis.Defining_Name)
       return LSP.Messages.CallHierarchyItem;

--- a/source/client/lsp-clients.adb
+++ b/source/client/lsp-clients.adb
@@ -1167,7 +1167,7 @@ package body LSP.Clients is
    procedure Text_Document_Signature_Help_Request
      (Self    : in out Client'Class;
       Request : out LSP.Types.LSP_Number_Or_String;
-      Value   : LSP.Messages.TextDocumentPositionParams)
+      Value   : LSP.Messages.SignatureHelpParams)
    is
       Message : Signature_Help_Request := (params => Value, others => <>);
    begin

--- a/source/client/lsp-clients.ads
+++ b/source/client/lsp-clients.ads
@@ -149,7 +149,7 @@ package LSP.Clients is
    procedure Text_Document_Signature_Help_Request
      (Self     : in out Client'Class;
       Request  : out LSP.Types.LSP_Number_Or_String;
-      Value    : LSP.Messages.TextDocumentPositionParams);
+      Value    : LSP.Messages.SignatureHelpParams);
 
    procedure Text_Document_Symbol_Request
      (Self     : in out Client'Class;

--- a/source/protocol/generated/lsp-messages-server_requests.ads
+++ b/source/protocol/generated/lsp-messages-server_requests.ads
@@ -179,7 +179,7 @@ package LSP.Messages.Server_Requests is
    package Signature_Help_Requests is
      new LSP.Generic_Requests
        (Server_Request,
-        TextDocumentPositionParams,
+        SignatureHelpParams,
         Server_Request_Receiver'Class);
 
    type Signature_Help_Request is

--- a/testsuite/ada_lsp/T723-027.signatureHelp.nested/default.gpr
+++ b/testsuite/ada_lsp/T723-027.signatureHelp.nested/default.gpr
@@ -1,0 +1,3 @@
+project Default is
+
+end Default;

--- a/testsuite/ada_lsp/T723-027.signatureHelp.nested/foo.adb
+++ b/testsuite/ada_lsp/T723-027.signatureHelp.nested/foo.adb
@@ -1,0 +1,25 @@
+procedure Foo 
+is
+   procedure Bar (A : Integer; B, C : Integer);
+   function FooBar (A : Integer) return Integer;
+
+   ---------
+   -- Bar --
+   ---------
+
+   procedure Bar (A : Integer; B, C : Integer) is
+   begin
+      null;
+   end Bar;
+
+   ------------
+   -- FooBar --
+   ------------
+
+   function FooBar (A : Integer) return Integer is
+   begin
+      return A;
+   end FooBar;
+begin
+   Bar (1, FooBar (2), 3);
+end Foo;

--- a/testsuite/ada_lsp/T723-027.signatureHelp.nested/test.json
+++ b/testsuite/ada_lsp/T723-027.signatureHelp.nested/test.json
@@ -1,0 +1,1484 @@
+[
+   {
+      "comment": [
+         "Test signatureHelp when having a nested call inside the initial ",
+         "call. The signature should switch to the nested call and then go ",
+         "back to the initial one."
+      ]
+   }, 
+   {
+      "start": {
+         "cmd": [
+            "${ALS}"
+         ]
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "processId": 13950,
+               "capabilities": {
+                  "workspace": {
+                     "applyEdit": false
+                  }
+               },
+               "rootUri": "$URI{.}"
+            },
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize"
+         },
+         "wait": [{
+               "id": 1,
+               "result": {
+                  "capabilities": {
+                     "hoverProvider": true,
+                     "referencesProvider": true,
+                     "textDocumentSync": 2,
+                     "completionProvider": {
+                        "triggerCharacters": [
+                            ".",
+                            "("
+                        ],
+                        "resolveProvider": false
+                     },
+                     "signatureHelpProvider": {
+                        "triggerCharacters": [
+                           ",",
+                           "("
+                        ],
+                        "retriggerCharacters": [
+                           " "
+                        ]
+                     },
+                     "definitionProvider": true,
+                     "alsCalledByProvider": true
+                  }
+               }
+            }]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0", 
+            "method": "initialized"
+         }, 
+         "wait": []
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "settings": {
+                  "ada": {
+                     "projectFile": "$URI{test.gpr}", 
+                     "scenarioVariables": {},
+                     "defaultCharset": "ISO-8859-1"
+                  }
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "method": "workspace/didChangeConfiguration"
+         }, 
+         "wait": []
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}",
+                  "languageId": "Ada",
+                  "version": 0,
+                  "text": "procedure Foo \nis\n   procedure Bar (A : Integer; B, C : Integer);\n   function FooBar (A : Integer) return Integer;\n\n   ---------\n   -- Bar --\n   ---------\n\n   procedure Bar (A : Integer; B, C : Integer) is\n   begin\n      null;\n   end Bar;\n\n   ------------\n   -- FooBar --\n   ------------\n\n   function FooBar (A : Integer) return Integer is\n   begin\n      return A;\n   end FooBar;\nbegin\n   Bar \nend Foo;\n"
+               }
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "result": null
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}",
+                  "version": 1
+               },
+               "contentChanges": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 23,
+                           "character": 7
+                        },
+                        "end": {
+                           "line": 23,
+                           "character": 7
+                        }
+                     },
+                     "text": "("
+                  }
+               ]
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": "ada-5",
+            "method": "textDocument/signatureHelp",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}"
+               },
+               "position": {
+                  "line": 23,
+                  "character": 8
+               }
+            }
+         },
+         "wait": [
+            {
+               "id": "ada-5",
+               "result": {
+                  "signatures": [
+                     {
+                        "label": "procedure Bar (A : Integer; B, C : Integer)",
+                        "documentation": "",
+                        "parameters": [
+                           {
+                              "label": "A"
+                           },
+                           {
+                              "label": "B"
+                           },
+                           {
+                              "label": "C"
+                           }
+                        ],
+                        "activeParameter": 0
+                     }
+                  ],
+                  "activeSignature": 0,
+                  "activeParameter": 0
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}",
+                  "version": 2
+               },
+               "contentChanges": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 23,
+                           "character": 8
+                        },
+                        "end": {
+                           "line": 23,
+                           "character": 8
+                        }
+                     },
+                     "text": "1"
+                  }
+               ]
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": "ada-9",
+            "method": "textDocument/signatureHelp",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}"
+               },
+               "position": {
+                  "line": 23,
+                  "character": 9
+               }
+            }
+         },
+         "wait": [
+            {
+               "id": "ada-9",
+               "result": {
+                  "signatures": [
+                     {
+                        "label": "procedure Bar (A : Integer; B, C : Integer)",
+                        "documentation": "",
+                        "parameters": [
+                           {
+                              "label": "A"
+                           },
+                           {
+                              "label": "B"
+                           },
+                           {
+                              "label": "C"
+                           }
+                        ],
+                        "activeParameter": 0
+                     }
+                  ],
+                  "activeSignature": 0,
+                  "activeParameter": 0
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}",
+                  "version": 3
+               },
+               "contentChanges": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 23,
+                           "character": 9
+                        },
+                        "end": {
+                           "line": 23,
+                           "character": 9
+                        }
+                     },
+                     "text": ","
+                  }
+               ]
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": "ada-12",
+            "method": "textDocument/signatureHelp",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}"
+               },
+               "position": {
+                  "line": 23,
+                  "character": 10
+               }
+            }
+         },
+         "wait": [
+            {
+               "id": "ada-12",
+               "result": {
+                  "signatures": [
+                     {
+                        "label": "procedure Bar (A : Integer; B, C : Integer)",
+                        "documentation": "",
+                        "parameters": [
+                           {
+                              "label": "A"
+                           },
+                           {
+                              "label": "B"
+                           },
+                           {
+                              "label": "C"
+                           }
+                        ],
+                        "activeParameter": 0
+                     }
+                  ],
+                  "activeSignature": 0,
+                  "activeParameter": 0
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}",
+                  "version": 4
+               },
+               "contentChanges": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 23,
+                           "character": 10
+                        },
+                        "end": {
+                           "line": 23,
+                           "character": 10
+                        }
+                     },
+                     "text": " "
+                  }
+               ]
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": "ada-14",
+            "method": "textDocument/signatureHelp",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}"
+               },
+               "position": {
+                  "line": 23,
+                  "character": 11
+               }
+            }
+         },
+         "wait": [
+            {
+               "id": "ada-14",
+               "result": {
+                  "signatures": [
+                     {
+                        "label": "procedure Bar (A : Integer; B, C : Integer)",
+                        "documentation": "",
+                        "parameters": [
+                           {
+                              "label": "A"
+                           },
+                           {
+                              "label": "B"
+                           },
+                           {
+                              "label": "C"
+                           }
+                        ],
+                        "activeParameter": 0
+                     }
+                  ],
+                  "activeSignature": 0,
+                  "activeParameter": 0
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}",
+                  "version": 5
+               },
+               "contentChanges": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 23,
+                           "character": 11
+                        },
+                        "end": {
+                           "line": 23,
+                           "character": 11
+                        }
+                     },
+                     "text": "F"
+                  }
+               ]
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": "ada-16",
+            "method": "textDocument/signatureHelp",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}"
+               },
+               "position": {
+                  "line": 23,
+                  "character": 12
+               }
+            }
+         },
+         "wait": [
+            {
+               "id": "ada-16",
+               "result": {
+                  "signatures": [
+                     {
+                        "label": "procedure Bar (A : Integer; B, C : Integer)",
+                        "documentation": "",
+                        "parameters": [
+                           {
+                              "label": "A"
+                           },
+                           {
+                              "label": "B"
+                           },
+                           {
+                              "label": "C"
+                           }
+                        ],
+                        "activeParameter": 1
+                     }
+                  ],
+                  "activeSignature": 0,
+                  "activeParameter": 0
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}",
+                  "version": 6
+               },
+               "contentChanges": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 23,
+                           "character": 12
+                        },
+                        "end": {
+                           "line": 23,
+                           "character": 12
+                        }
+                     },
+                     "text": "o"
+                  }
+               ]
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": "ada-19",
+            "method": "textDocument/signatureHelp",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}"
+               },
+               "position": {
+                  "line": 23,
+                  "character": 13
+               }
+            }
+         },
+         "wait": [
+            {
+               "id": "ada-19",
+               "result": {
+                  "signatures": [
+                     {
+                        "label": "procedure Bar (A : Integer; B, C : Integer)",
+                        "documentation": "",
+                        "parameters": [
+                           {
+                              "label": "A"
+                           },
+                           {
+                              "label": "B"
+                           },
+                           {
+                              "label": "C"
+                           }
+                        ],
+                        "activeParameter": 1
+                     }
+                  ],
+                  "activeSignature": 0,
+                  "activeParameter": 0
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}",
+                  "version": 7
+               },
+               "contentChanges": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 23,
+                           "character": 13
+                        },
+                        "end": {
+                           "line": 23,
+                           "character": 13
+                        }
+                     },
+                     "text": "o"
+                  }
+               ]
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": "ada-22",
+            "method": "textDocument/signatureHelp",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}"
+               },
+               "position": {
+                  "line": 23,
+                  "character": 14
+               }
+            }
+         },
+         "wait": [
+            {
+               "id": "ada-22",
+               "result": {
+                  "signatures": [
+                     {
+                        "label": "procedure Bar (A : Integer; B, C : Integer)",
+                        "documentation": "",
+                        "parameters": [
+                           {
+                              "label": "A"
+                           },
+                           {
+                              "label": "B"
+                           },
+                           {
+                              "label": "C"
+                           }
+                        ],
+                        "activeParameter": 1
+                     }
+                  ],
+                  "activeSignature": 0,
+                  "activeParameter": 0
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}",
+                  "version": 8
+               },
+               "contentChanges": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 23,
+                           "character": 14
+                        },
+                        "end": {
+                           "line": 23,
+                           "character": 14
+                        }
+                     },
+                     "text": "B"
+                  }
+               ]
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": "ada-25",
+            "method": "textDocument/signatureHelp",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}"
+               },
+               "position": {
+                  "line": 23,
+                  "character": 15
+               }
+            }
+         },
+         "wait": [
+            {
+               "id": "ada-25",
+               "result": {
+                  "signatures": [
+                     {
+                        "label": "procedure Bar (A : Integer; B, C : Integer)",
+                        "documentation": "",
+                        "parameters": [
+                           {
+                              "label": "A"
+                           },
+                           {
+                              "label": "B"
+                           },
+                           {
+                              "label": "C"
+                           }
+                        ],
+                        "activeParameter": 1
+                     }
+                  ],
+                  "activeSignature": 0,
+                  "activeParameter": 0
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}",
+                  "version": 9
+               },
+               "contentChanges": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 23,
+                           "character": 15
+                        },
+                        "end": {
+                           "line": 23,
+                           "character": 15
+                        }
+                     },
+                     "text": "a"
+                  }
+               ]
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": "ada-28",
+            "method": "textDocument/signatureHelp",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}"
+               },
+               "position": {
+                  "line": 23,
+                  "character": 16
+               }
+            }
+         },
+         "wait": [
+            {
+               "id": "ada-28",
+               "result": {
+                  "signatures": [
+                     {
+                        "label": "procedure Bar (A : Integer; B, C : Integer)",
+                        "documentation": "",
+                        "parameters": [
+                           {
+                              "label": "A"
+                           },
+                           {
+                              "label": "B"
+                           },
+                           {
+                              "label": "C"
+                           }
+                        ],
+                        "activeParameter": 1
+                     }
+                  ],
+                  "activeSignature": 0,
+                  "activeParameter": 0
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}",
+                  "version": 10
+               },
+               "contentChanges": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 23,
+                           "character": 16
+                        },
+                        "end": {
+                           "line": 23,
+                           "character": 16
+                        }
+                     },
+                     "text": "r"
+                  }
+               ]
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": "ada-31",
+            "method": "textDocument/signatureHelp",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}"
+               },
+               "position": {
+                  "line": 23,
+                  "character": 17
+               }
+            }
+         },
+         "wait": [
+            {
+               "id": "ada-31",
+               "result": {
+                  "signatures": [
+                     {
+                        "label": "procedure Bar (A : Integer; B, C : Integer)",
+                        "documentation": "",
+                        "parameters": [
+                           {
+                              "label": "A"
+                           },
+                           {
+                              "label": "B"
+                           },
+                           {
+                              "label": "C"
+                           }
+                        ],
+                        "activeParameter": 1
+                     }
+                  ],
+                  "activeSignature": 0,
+                  "activeParameter": 0
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}",
+                  "version": 11
+               },
+               "contentChanges": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 23,
+                           "character": 17
+                        },
+                        "end": {
+                           "line": 23,
+                           "character": 17
+                        }
+                     },
+                     "text": " "
+                  }
+               ]
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": "ada-34",
+            "method": "textDocument/signatureHelp",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}"
+               },
+               "position": {
+                  "line": 23,
+                  "character": 18
+               }
+            }
+         },
+         "wait": [
+            {
+               "id": "ada-34",
+               "result": {
+                  "signatures": [
+                     {
+                        "label": "procedure Bar (A : Integer; B, C : Integer)",
+                        "documentation": "",
+                        "parameters": [
+                           {
+                              "label": "A"
+                           },
+                           {
+                              "label": "B"
+                           },
+                           {
+                              "label": "C"
+                           }
+                        ],
+                        "activeParameter": 1
+                     }
+                  ],
+                  "activeSignature": 0,
+                  "activeParameter": 0
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}",
+                  "version": 12
+               },
+               "contentChanges": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 23,
+                           "character": 18
+                        },
+                        "end": {
+                           "line": 23,
+                           "character": 18
+                        }
+                     },
+                     "text": "("
+                  }
+               ]
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": "ada-36",
+            "method": "textDocument/signatureHelp",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}"
+               },
+               "position": {
+                  "line": 23,
+                  "character": 19
+               }
+            }
+         },
+         "wait": [
+            {
+               "id": "ada-36",
+               "result": {
+                  "signatures": [
+                     {
+                        "label": "function FooBar (A : Integer) return Integer",
+                        "documentation": "",
+                        "parameters": [
+                           {
+                              "label": "A"
+                           }
+                        ],
+                        "activeParameter": 0
+                     }
+                  ],
+                  "activeSignature": 0,
+                  "activeParameter": 0
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}",
+                  "version": 13
+               },
+               "contentChanges": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 23,
+                           "character": 19
+                        },
+                        "end": {
+                           "line": 23,
+                           "character": 19
+                        }
+                     },
+                     "text": "2"
+                  }
+               ]
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": "ada-40",
+            "method": "textDocument/signatureHelp",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}"
+               },
+               "position": {
+                  "line": 23,
+                  "character": 20
+               }
+            }
+         },
+         "wait": [
+            {
+               "id": "ada-40",
+               "result": {
+                  "signatures": [
+                     {
+                        "label": "function FooBar (A : Integer) return Integer",
+                        "documentation": "",
+                        "parameters": [
+                           {
+                              "label": "A"
+                           }
+                        ],
+                        "activeParameter": 0
+                     }
+                  ],
+                  "activeSignature": 0,
+                  "activeParameter": 0
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}",
+                  "version": 14
+               },
+               "contentChanges": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 23,
+                           "character": 20
+                        },
+                        "end": {
+                           "line": 23,
+                           "character": 20
+                        }
+                     },
+                     "text": ")"
+                  }
+               ]
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": "ada-43",
+            "method": "textDocument/signatureHelp",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}"
+               },
+               "position": {
+                  "line": 23,
+                  "character": 21
+               }
+            }
+         },
+         "wait": [
+            {
+               "id": "ada-43",
+               "result": {
+                  "signatures": [
+                     {
+                        "label": "procedure Bar (A : Integer; B, C : Integer)",
+                        "documentation": "",
+                        "parameters": [
+                           {
+                              "label": "A"
+                           },
+                           {
+                              "label": "B"
+                           },
+                           {
+                              "label": "C"
+                           }
+                        ],
+                        "activeParameter": 1
+                     }
+                  ],
+                  "activeSignature": 0,
+                  "activeParameter": 0
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}",
+                  "version": 15
+               },
+               "contentChanges": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 23,
+                           "character": 21
+                        },
+                        "end": {
+                           "line": 23,
+                           "character": 21
+                        }
+                     },
+                     "text": ","
+                  }
+               ]
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": "ada-45",
+            "method": "textDocument/signatureHelp",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}"
+               },
+               "position": {
+                  "line": 23,
+                  "character": 22
+               }
+            }
+         },
+         "wait": [
+            {
+               "id": "ada-45",
+               "result": {
+                  "signatures": [
+                     {
+                        "label": "procedure Bar (A : Integer; B, C : Integer)",
+                        "documentation": "",
+                        "parameters": [
+                           {
+                              "label": "A"
+                           },
+                           {
+                              "label": "B"
+                           },
+                           {
+                              "label": "C"
+                           }
+                        ],
+                        "activeParameter": 1
+                     }
+                  ],
+                  "activeSignature": 0,
+                  "activeParameter": 0
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}",
+                  "version": 16
+               },
+               "contentChanges": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 23,
+                           "character": 22
+                        },
+                        "end": {
+                           "line": 23,
+                           "character": 22
+                        }
+                     },
+                     "text": " "
+                  }
+               ]
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": "ada-47",
+            "method": "textDocument/signatureHelp",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}"
+               },
+               "position": {
+                  "line": 23,
+                  "character": 23
+               }
+            }
+         },
+         "wait": [
+            {
+               "id": "ada-47",
+               "result": {
+                  "signatures": [
+                     {
+                        "label": "procedure Bar (A : Integer; B, C : Integer)",
+                        "documentation": "",
+                        "parameters": [
+                           {
+                              "label": "A"
+                           },
+                           {
+                              "label": "B"
+                           },
+                           {
+                              "label": "C"
+                           }
+                        ],
+                        "activeParameter": 1
+                     }
+                  ],
+                  "activeSignature": 0,
+                  "activeParameter": 0
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}",
+                  "version": 17
+               },
+               "contentChanges": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 23,
+                           "character": 23
+                        },
+                        "end": {
+                           "line": 23,
+                           "character": 23
+                        }
+                     },
+                     "text": "3"
+                  }
+               ]
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": "ada-51",
+            "method": "textDocument/signatureHelp",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}"
+               },
+               "position": {
+                  "line": 23,
+                  "character": 24
+               }
+            }
+         },
+         "wait": [
+            {
+               "id": "ada-51",
+               "result": {
+                  "signatures": [
+                     {
+                        "label": "procedure Bar (A : Integer; B, C : Integer)",
+                        "documentation": "",
+                        "parameters": [
+                           {
+                              "label": "A"
+                           },
+                           {
+                              "label": "B"
+                           },
+                           {
+                              "label": "C"
+                           }
+                        ],
+                        "activeParameter": 2
+                     }
+                  ],
+                  "activeSignature": 0,
+                  "activeParameter": 0
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}",
+                  "version": 18
+               },
+               "contentChanges": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 23,
+                           "character": 24
+                        },
+                        "end": {
+                           "line": 23,
+                           "character": 24
+                        }
+                     },
+                     "text": ")"
+                  }
+               ]
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": "ada-54",
+            "method": "textDocument/signatureHelp",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}"
+               },
+               "position": {
+                  "line": 23,
+                  "character": 25
+               }
+            }
+         },
+         "wait": [
+            {
+               "id": "ada-54",
+               "result": {
+                  "signatures": []
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}",
+                  "version": 19
+               },
+               "contentChanges": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 23,
+                           "character": 25
+                        },
+                        "end": {
+                           "line": 23,
+                           "character": 25
+                        }
+                     },
+                     "text": ";"
+                  }
+               ]
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didClose",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}"
+               }
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "stop": {
+         "exit_code": 0
+      }
+   }
+]

--- a/testsuite/ada_lsp/T723-027.signatureHelp.nested/test.yaml
+++ b/testsuite/ada_lsp/T723-027.signatureHelp.nested/test.yaml
@@ -1,0 +1,1 @@
+title: 'T723-027.signatureHelp.nested'

--- a/testsuite/ada_lsp/T723-027.signatureHelp.overloaded/default.gpr
+++ b/testsuite/ada_lsp/T723-027.signatureHelp.overloaded/default.gpr
@@ -1,0 +1,3 @@
+project Default is
+
+end Default;

--- a/testsuite/ada_lsp/T723-027.signatureHelp.overloaded/foo.adb
+++ b/testsuite/ada_lsp/T723-027.signatureHelp.overloaded/foo.adb
@@ -1,0 +1,25 @@
+procedure Foo 
+is
+   procedure Bar (A : Integer; B, C : Integer);
+   procedure Bar (A : Integer; B : Integer);
+
+   ---------
+   -- Bar --
+   ---------
+
+   procedure Bar (A : Integer; B, C : Integer) is
+   begin
+      null;
+   end Bar;
+
+   ---------
+   -- Bar --
+   ---------
+
+   procedure Bar (A : Integer; B : Integer) is
+   begin
+      null;
+   end Bar;
+begin
+   Bar 
+end Foo;

--- a/testsuite/ada_lsp/T723-027.signatureHelp.overloaded/test.json
+++ b/testsuite/ada_lsp/T723-027.signatureHelp.overloaded/test.json
@@ -1,0 +1,825 @@
+[
+   {
+      "comment": [
+         "Test signatureHelp for an overloaded name at the end of the test ",
+         "one signature should be filtered out"
+      ]
+   }, 
+   {
+      "start": {
+         "cmd": [
+            "${ALS}"
+         ]
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "processId": 13950,
+               "capabilities": {
+                  "workspace": {
+                     "applyEdit": false
+                  }
+               },
+               "rootUri": "$URI{.}"
+            },
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize"
+         },
+         "wait": [{
+               "id": 1,
+               "result": {
+                  "capabilities": {
+                     "hoverProvider": true,
+                     "referencesProvider": true,
+                     "textDocumentSync": 2,
+                     "completionProvider": {
+                        "triggerCharacters": [
+                            ".",
+                            "("
+                        ],
+                        "resolveProvider": false
+                     },
+                     "signatureHelpProvider": {
+                        "triggerCharacters": [
+                           ",",
+                           "("
+                        ],
+                        "retriggerCharacters": [
+                           " "
+                        ]
+                     },
+                     "definitionProvider": true,
+                     "alsCalledByProvider": true
+                  }
+               }
+            }]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0", 
+            "method": "initialized"
+         }, 
+         "wait": []
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "settings": {
+                  "ada": {
+                     "projectFile": "$URI{test.gpr}", 
+                     "scenarioVariables": {},
+                     "defaultCharset": "ISO-8859-1"
+                  }
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "method": "workspace/didChangeConfiguration"
+         }, 
+         "wait": []
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}",
+                  "languageId": "Ada",
+                  "version": 0,
+                  "text": "procedure Foo \nis\n   procedure Bar (A : Integer; B, C : Integer);\n   procedure Bar (A : Integer; B : Integer);\n\n   ---------\n   -- Bar --\n   ---------\n\n   procedure Bar (A : Integer; B, C : Integer) is\n   begin\n      null;\n   end Bar;\n\n   ---------\n   -- Bar --\n   ---------\n\n   procedure Bar (A : Integer; B : Integer) is\n   begin\n      null;\n   end Bar;\nbegin\n   Bar \nend Foo;\n"
+               }
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "result": null
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}",
+                  "version": 1
+               },
+               "contentChanges": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 23,
+                           "character": 7
+                        },
+                        "end": {
+                           "line": 23,
+                           "character": 7
+                        }
+                     },
+                     "text": "("
+                  }
+               ]
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": "ada-5",
+            "method": "textDocument/signatureHelp",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}"
+               },
+               "position": {
+                  "line": 23,
+                  "character": 8
+               }
+            }
+         },
+         "wait": [
+            {
+               "id": "ada-5",
+               "result": {
+                  "signatures": [
+                     {
+                        "label": "procedure Bar (A : Integer; B : Integer)",
+                        "documentation": "",
+                        "parameters": [
+                           {
+                              "label": "A"
+                           },
+                           {
+                              "label": "B"
+                           }
+                        ],
+                        "activeParameter": 0
+                     },
+                     {
+                        "label": "procedure Bar (A : Integer; B, C : Integer)",
+                        "documentation": "",
+                        "parameters": [
+                           {
+                              "label": "A"
+                           },
+                           {
+                              "label": "B"
+                           },
+                           {
+                              "label": "C"
+                           }
+                        ],
+                        "activeParameter": 0
+                     }
+                  ],
+                  "activeSignature": 0,
+                  "activeParameter": 0
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}",
+                  "version": 2
+               },
+               "contentChanges": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 23,
+                           "character": 8
+                        },
+                        "end": {
+                           "line": 23,
+                           "character": 8
+                        }
+                     },
+                     "text": "1"
+                  }
+               ]
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": "ada-9",
+            "method": "textDocument/signatureHelp",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}"
+               },
+               "position": {
+                  "line": 23,
+                  "character": 9
+               }
+            }
+         },
+         "wait": [
+            {
+               "id": "ada-9",
+               "result": {
+                  "signatures": [
+                     {
+                        "label": "procedure Bar (A : Integer; B : Integer)",
+                        "documentation": "",
+                        "parameters": [
+                           {
+                              "label": "A"
+                           },
+                           {
+                              "label": "B"
+                           }
+                        ],
+                        "activeParameter": 0
+                     },
+                     {
+                        "label": "procedure Bar (A : Integer; B, C : Integer)",
+                        "documentation": "",
+                        "parameters": [
+                           {
+                              "label": "A"
+                           },
+                           {
+                              "label": "B"
+                           },
+                           {
+                              "label": "C"
+                           }
+                        ],
+                        "activeParameter": 0
+                     }
+                  ],
+                  "activeSignature": 0,
+                  "activeParameter": 0
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}",
+                  "version": 3
+               },
+               "contentChanges": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 23,
+                           "character": 9
+                        },
+                        "end": {
+                           "line": 23,
+                           "character": 9
+                        }
+                     },
+                     "text": ","
+                  }
+               ]
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": "ada-14",
+            "method": "textDocument/signatureHelp",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}"
+               },
+               "position": {
+                  "line": 23,
+                  "character": 10
+               }
+            }
+         },
+         "wait": [
+            {
+               "id": "ada-14",
+               "result": {
+                  "signatures": [
+                     {
+                        "label": "procedure Bar (A : Integer; B : Integer)",
+                        "documentation": "",
+                        "parameters": [
+                           {
+                              "label": "A"
+                           },
+                           {
+                              "label": "B"
+                           }
+                        ],
+                        "activeParameter": 0
+                     },
+                     {
+                        "label": "procedure Bar (A : Integer; B, C : Integer)",
+                        "documentation": "",
+                        "parameters": [
+                           {
+                              "label": "A"
+                           },
+                           {
+                              "label": "B"
+                           },
+                           {
+                              "label": "C"
+                           }
+                        ],
+                        "activeParameter": 0
+                     }
+                  ],
+                  "activeSignature": 0,
+                  "activeParameter": 0
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}",
+                  "version": 4
+               },
+               "contentChanges": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 23,
+                           "character": 10
+                        },
+                        "end": {
+                           "line": 23,
+                           "character": 10
+                        }
+                     },
+                     "text": " "
+                  }
+               ]
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": "ada-16",
+            "method": "textDocument/signatureHelp",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}"
+               },
+               "position": {
+                  "line": 23,
+                  "character": 11
+               }
+            }
+         },
+         "wait": [
+            {
+               "id": "ada-16",
+               "result": {
+                  "signatures": [
+                     {
+                        "label": "procedure Bar (A : Integer; B : Integer)",
+                        "documentation": "",
+                        "parameters": [
+                           {
+                              "label": "A"
+                           },
+                           {
+                              "label": "B"
+                           }
+                        ],
+                        "activeParameter": 0
+                     },
+                     {
+                        "label": "procedure Bar (A : Integer; B, C : Integer)",
+                        "documentation": "",
+                        "parameters": [
+                           {
+                              "label": "A"
+                           },
+                           {
+                              "label": "B"
+                           },
+                           {
+                              "label": "C"
+                           }
+                        ],
+                        "activeParameter": 0
+                     }
+                  ],
+                  "activeSignature": 0,
+                  "activeParameter": 0
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}",
+                  "version": 5
+               },
+               "contentChanges": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 23,
+                           "character": 11
+                        },
+                        "end": {
+                           "line": 23,
+                           "character": 11
+                        }
+                     },
+                     "text": "2"
+                  }
+               ]
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": "ada-18",
+            "method": "textDocument/signatureHelp",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}"
+               },
+               "position": {
+                  "line": 23,
+                  "character": 12
+               }
+            }
+         },
+         "wait": [
+            {
+               "id": "ada-18",
+               "result": {
+                  "signatures": [
+                     {
+                        "label": "procedure Bar (A : Integer; B : Integer)",
+                        "documentation": "",
+                        "parameters": [
+                           {
+                              "label": "A"
+                           },
+                           {
+                              "label": "B"
+                           }
+                        ],
+                        "activeParameter": 1
+                     },
+                     {
+                        "label": "procedure Bar (A : Integer; B, C : Integer)",
+                        "documentation": "",
+                        "parameters": [
+                           {
+                              "label": "A"
+                           },
+                           {
+                              "label": "B"
+                           },
+                           {
+                              "label": "C"
+                           }
+                        ],
+                        "activeParameter": 1
+                     }
+                  ],
+                  "activeSignature": 0,
+                  "activeParameter": 0
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}",
+                  "version": 6
+               },
+               "contentChanges": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 23,
+                           "character": 12
+                        },
+                        "end": {
+                           "line": 23,
+                           "character": 12
+                        }
+                     },
+                     "text": ","
+                  }
+               ]
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": "ada-23",
+            "method": "textDocument/signatureHelp",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}"
+               },
+               "position": {
+                  "line": 23,
+                  "character": 13
+               }
+            }
+         },
+         "wait": [
+            {
+               "id": "ada-23",
+               "result": {
+                  "signatures": [
+                     {
+                        "label": "procedure Bar (A : Integer; B : Integer)",
+                        "documentation": "",
+                        "parameters": [
+                           {
+                              "label": "A"
+                           },
+                           {
+                              "label": "B"
+                           }
+                        ],
+                        "activeParameter": 1
+                     },
+                     {
+                        "label": "procedure Bar (A : Integer; B, C : Integer)",
+                        "documentation": "",
+                        "parameters": [
+                           {
+                              "label": "A"
+                           },
+                           {
+                              "label": "B"
+                           },
+                           {
+                              "label": "C"
+                           }
+                        ],
+                        "activeParameter": 1
+                     }
+                  ],
+                  "activeSignature": 0,
+                  "activeParameter": 0
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}",
+                  "version": 7
+               },
+               "contentChanges": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 23,
+                           "character": 13
+                        },
+                        "end": {
+                           "line": 23,
+                           "character": 13
+                        }
+                     },
+                     "text": " "
+                  }
+               ]
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": "ada-25",
+            "method": "textDocument/signatureHelp",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}"
+               },
+               "position": {
+                  "line": 23,
+                  "character": 14
+               }
+            }
+         },
+         "wait": [
+            {
+               "id": "ada-25",
+               "result": {
+                  "signatures": [
+                     {
+                        "label": "procedure Bar (A : Integer; B : Integer)",
+                        "documentation": "",
+                        "parameters": [
+                           {
+                              "label": "A"
+                           },
+                           {
+                              "label": "B"
+                           }
+                        ],
+                        "activeParameter": 1
+                     },
+                     {
+                        "label": "procedure Bar (A : Integer; B, C : Integer)",
+                        "documentation": "",
+                        "parameters": [
+                           {
+                              "label": "A"
+                           },
+                           {
+                              "label": "B"
+                           },
+                           {
+                              "label": "C"
+                           }
+                        ],
+                        "activeParameter": 1
+                     }
+                  ],
+                  "activeSignature": 0,
+                  "activeParameter": 0
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}",
+                  "version": 8
+               },
+               "contentChanges": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 23,
+                           "character": 14
+                        },
+                        "end": {
+                           "line": 23,
+                           "character": 14
+                        }
+                     },
+                     "text": "3"
+                  }
+               ]
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": "ada-27",
+            "method": "textDocument/signatureHelp",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}"
+               },
+               "position": {
+                  "line": 23,
+                  "character": 15
+               }
+            }
+         },
+         "wait": [
+            {
+               "id": "ada-27",
+               "result": {
+                  "signatures": [
+                     {
+                        "label": "procedure Bar (A : Integer; B, C : Integer)",
+                        "documentation": "",
+                        "parameters": [
+                           {
+                              "label": "A"
+                           },
+                           {
+                              "label": "B"
+                           },
+                           {
+                              "label": "C"
+                           }
+                        ],
+                        "activeParameter": 2
+                     }
+                  ],
+                  "activeSignature": 0,
+                  "activeParameter": 0
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didClose",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}"
+               }
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "stop": {
+         "exit_code": 0
+      }
+   }
+]

--- a/testsuite/ada_lsp/T723-027.signatureHelp.overloaded/test.yaml
+++ b/testsuite/ada_lsp/T723-027.signatureHelp.overloaded/test.yaml
@@ -1,0 +1,1 @@
+title: 'T723-027.signatureHelp.overloaded'

--- a/testsuite/ada_lsp/T723-027.signatureHelp.simple/default.gpr
+++ b/testsuite/ada_lsp/T723-027.signatureHelp.simple/default.gpr
@@ -1,0 +1,3 @@
+project Default is
+
+end Default;

--- a/testsuite/ada_lsp/T723-027.signatureHelp.simple/foo.adb
+++ b/testsuite/ada_lsp/T723-027.signatureHelp.simple/foo.adb
@@ -1,0 +1,15 @@
+procedure Foo 
+is
+   procedure Bar (A : Integer; B, C : Integer);
+
+   ---------
+   -- Bar --
+   ---------
+
+   procedure Bar (A : Integer; B, C : Integer) is
+   begin
+      null;
+   end Bar;
+begin
+   Bar (1, 2, 3);
+end Foo;

--- a/testsuite/ada_lsp/T723-027.signatureHelp.simple/test.json
+++ b/testsuite/ada_lsp/T723-027.signatureHelp.simple/test.json
@@ -1,0 +1,960 @@
+[
+   {
+      "comment": [
+         "Test signatureHelp for a simple case and verify that the active ",
+         "parameter is properly changed while editing"
+      ]
+   }, 
+   {
+      "start": {
+         "cmd": [
+            "${ALS}"
+         ]
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "processId": 13950,
+               "capabilities": {
+                  "workspace": {
+                     "applyEdit": false
+                  }
+               },
+               "rootUri": "$URI{.}"
+            },
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize"
+         },
+         "wait": [{
+               "id": 1,
+               "result": {
+                  "capabilities": {
+                     "hoverProvider": true,
+                     "referencesProvider": true,
+                     "textDocumentSync": 2,
+                     "completionProvider": {
+                        "triggerCharacters": [
+                            ".",
+                            "("
+                        ],
+                        "resolveProvider": false
+                     },
+                     "signatureHelpProvider": {
+                        "triggerCharacters": [
+                           ",",
+                           "("
+                        ],
+                        "retriggerCharacters": [
+                           " "
+                        ]
+                     },
+                     "definitionProvider": true,
+                     "alsCalledByProvider": true
+                  }
+               }
+            }]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0", 
+            "method": "initialized"
+         }, 
+         "wait": []
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "settings": {
+                  "ada": {
+                     "projectFile": "$URI{test.gpr}", 
+                     "scenarioVariables": {},
+                     "defaultCharset": "ISO-8859-1"
+                  }
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "method": "workspace/didChangeConfiguration"
+         }, 
+         "wait": []
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}",
+                  "languageId": "Ada",
+                  "version": 0,
+                  "text": "procedure Foo \nis\n   procedure Bar (A : Integer; B, C : Integer);\n\n   ---------\n   -- Bar --\n   ---------\n\n   procedure Bar (A : Integer; B, C : Integer) is\n   begin\n      null;\n   end Bar;\nbegin\n\nend Foo;\n"
+               }
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}",
+                  "version": 1
+               },
+               "contentChanges": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 13,
+                           "character": 0
+                        },
+                        "end": {
+                           "line": 13,
+                           "character": 0
+                        }
+                     },
+                     "text": "   "
+                  }
+               ]
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}",
+                  "version": 2
+               },
+               "contentChanges": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 13,
+                           "character": 3
+                        },
+                        "end": {
+                           "line": 13,
+                           "character": 3
+                        }
+                     },
+                     "text": "B"
+                  }
+               ]
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}",
+                  "version": 3
+               },
+               "contentChanges": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 13,
+                           "character": 4
+                        },
+                        "end": {
+                           "line": 13,
+                           "character": 4
+                        }
+                     },
+                     "text": "a"
+                  }
+               ]
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}",
+                  "version": 4
+               },
+               "contentChanges": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 13,
+                           "character": 5
+                        },
+                        "end": {
+                           "line": 13,
+                           "character": 5
+                        }
+                     },
+                     "text": "r"
+                  }
+               ]
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}",
+                  "version": 5
+               },
+               "contentChanges": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 13,
+                           "character": 6
+                        },
+                        "end": {
+                           "line": 13,
+                           "character": 6
+                        }
+                     },
+                     "text": " "
+                  }
+               ]
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}",
+                  "version": 6
+               },
+               "contentChanges": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 13,
+                           "character": 7
+                        },
+                        "end": {
+                           "line": 13,
+                           "character": 7
+                        }
+                     },
+                     "text": "("
+                  }
+               ]
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": "ada-12",
+            "method": "textDocument/signatureHelp",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}"
+               },
+               "position": {
+                  "line": 13,
+                  "character": 8
+               }
+            }
+         },
+         "wait": [
+            {
+               "id": "ada-12",
+               "result": {
+                  "signatures": [
+                     {
+                        "label": "procedure Bar (A : Integer; B, C : Integer)",
+                        "documentation": "",
+                        "parameters": [
+                           {
+                              "label": "A"
+                           },
+                           {
+                              "label": "B"
+                           },
+                           {
+                              "label": "C"
+                           }
+                        ],
+                        "activeParameter": 0
+                     }
+                  ],
+                  "activeSignature": 0,
+                  "activeParameter": 0
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}",
+                  "version": 7
+               },
+               "contentChanges": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 13,
+                           "character": 8
+                        },
+                        "end": {
+                           "line": 13,
+                           "character": 8
+                        }
+                     },
+                     "text": "1"
+                  }
+               ]
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": "ada-16",
+            "method": "textDocument/signatureHelp",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}"
+               },
+               "position": {
+                  "line": 13,
+                  "character": 9
+               }
+            }
+         },
+         "wait": [
+            {
+               "id": "ada-16",
+               "result": {
+                  "signatures": [
+                     {
+                        "label": "procedure Bar (A : Integer; B, C : Integer)",
+                        "documentation": "",
+                        "parameters": [
+                           {
+                              "label": "A"
+                           },
+                           {
+                              "label": "B"
+                           },
+                           {
+                              "label": "C"
+                           }
+                        ],
+                        "activeParameter": 0
+                     }
+                  ],
+                  "activeSignature": 0,
+                  "activeParameter": 0
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}",
+                  "version": 8
+               },
+               "contentChanges": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 13,
+                           "character": 9
+                        },
+                        "end": {
+                           "line": 13,
+                           "character": 9
+                        }
+                     },
+                     "text": ","
+                  }
+               ]
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": "ada-19",
+            "method": "textDocument/signatureHelp",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}"
+               },
+               "position": {
+                  "line": 13,
+                  "character": 10
+               }
+            }
+         },
+         "wait": [
+            {
+               "id": "ada-19",
+               "result": {
+                  "signatures": [
+                     {
+                        "label": "procedure Bar (A : Integer; B, C : Integer)",
+                        "documentation": "",
+                        "parameters": [
+                           {
+                              "label": "A"
+                           },
+                           {
+                              "label": "B"
+                           },
+                           {
+                              "label": "C"
+                           }
+                        ],
+                        "activeParameter": 0
+                     }
+                  ],
+                  "activeSignature": 0,
+                  "activeParameter": 0
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}",
+                  "version": 9
+               },
+               "contentChanges": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 13,
+                           "character": 10
+                        },
+                        "end": {
+                           "line": 13,
+                           "character": 10
+                        }
+                     },
+                     "text": " "
+                  }
+               ]
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": "ada-20",
+            "method": "textDocument/signatureHelp",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}"
+               },
+               "position": {
+                  "line": 13,
+                  "character": 11
+               }
+            }
+         },
+         "wait": [
+            {
+               "id": "ada-20",
+               "result": {
+                  "signatures": [
+                     {
+                        "label": "procedure Bar (A : Integer; B, C : Integer)",
+                        "documentation": "",
+                        "parameters": [
+                           {
+                              "label": "A"
+                           },
+                           {
+                              "label": "B"
+                           },
+                           {
+                              "label": "C"
+                           }
+                        ],
+                        "activeParameter": 0
+                     }
+                  ],
+                  "activeSignature": 0,
+                  "activeParameter": 0
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}",
+                  "version": 10
+               },
+               "contentChanges": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 13,
+                           "character": 11
+                        },
+                        "end": {
+                           "line": 13,
+                           "character": 11
+                        }
+                     },
+                     "text": "2"
+                  }
+               ]
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": "ada-22",
+            "method": "textDocument/signatureHelp",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}"
+               },
+               "position": {
+                  "line": 13,
+                  "character": 12
+               }
+            }
+         },
+         "wait": [
+            {
+               "id": "ada-22",
+               "result": {
+                  "signatures": [
+                     {
+                        "label": "procedure Bar (A : Integer; B, C : Integer)",
+                        "documentation": "",
+                        "parameters": [
+                           {
+                              "label": "A"
+                           },
+                           {
+                              "label": "B"
+                           },
+                           {
+                              "label": "C"
+                           }
+                        ],
+                        "activeParameter": 1
+                     }
+                  ],
+                  "activeSignature": 0,
+                  "activeParameter": 0
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}",
+                  "version": 11
+               },
+               "contentChanges": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 13,
+                           "character": 12
+                        },
+                        "end": {
+                           "line": 13,
+                           "character": 12
+                        }
+                     },
+                     "text": ","
+                  }
+               ]
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": "ada-27",
+            "method": "textDocument/signatureHelp",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}"
+               },
+               "position": {
+                  "line": 13,
+                  "character": 13
+               }
+            }
+         },
+         "wait": [
+            {
+               "id": "ada-27",
+               "result": {
+                  "signatures": [
+                     {
+                        "label": "procedure Bar (A : Integer; B, C : Integer)",
+                        "documentation": "",
+                        "parameters": [
+                           {
+                              "label": "A"
+                           },
+                           {
+                              "label": "B"
+                           },
+                           {
+                              "label": "C"
+                           }
+                        ],
+                        "activeParameter": 1
+                     }
+                  ],
+                  "activeSignature": 0,
+                  "activeParameter": 0
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}",
+                  "version": 12
+               },
+               "contentChanges": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 13,
+                           "character": 13
+                        },
+                        "end": {
+                           "line": 13,
+                           "character": 13
+                        }
+                     },
+                     "text": " "
+                  }
+               ]
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": "ada-28",
+            "method": "textDocument/signatureHelp",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}"
+               },
+               "position": {
+                  "line": 13,
+                  "character": 14
+               }
+            }
+         },
+         "wait": [
+            {
+               "id": "ada-28",
+               "result": {
+                  "signatures": [
+                     {
+                        "label": "procedure Bar (A : Integer; B, C : Integer)",
+                        "documentation": "",
+                        "parameters": [
+                           {
+                              "label": "A"
+                           },
+                           {
+                              "label": "B"
+                           },
+                           {
+                              "label": "C"
+                           }
+                        ],
+                        "activeParameter": 1
+                     }
+                  ],
+                  "activeSignature": 0,
+                  "activeParameter": 0
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}",
+                  "version": 13
+               },
+               "contentChanges": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 13,
+                           "character": 14
+                        },
+                        "end": {
+                           "line": 13,
+                           "character": 14
+                        }
+                     },
+                     "text": "3"
+                  }
+               ]
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": "ada-30",
+            "method": "textDocument/signatureHelp",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}"
+               },
+               "position": {
+                  "line": 13,
+                  "character": 15
+               }
+            }
+         },
+         "wait": [
+            {
+               "id": "ada-30",
+               "result": {
+                  "signatures": [
+                     {
+                        "label": "procedure Bar (A : Integer; B, C : Integer)",
+                        "documentation": "",
+                        "parameters": [
+                           {
+                              "label": "A"
+                           },
+                           {
+                              "label": "B"
+                           },
+                           {
+                              "label": "C"
+                           }
+                        ],
+                        "activeParameter": 2
+                     }
+                  ],
+                  "activeSignature": 0,
+                  "activeParameter": 0
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}",
+                  "version": 14
+               },
+               "contentChanges": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 13,
+                           "character": 15
+                        },
+                        "end": {
+                           "line": 13,
+                           "character": 15
+                        }
+                     },
+                     "text": ")"
+                  }
+               ]
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": "ada-35",
+            "method": "textDocument/signatureHelp",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}"
+               },
+               "position": {
+                  "line": 13,
+                  "character": 16
+               }
+            }
+         },
+         "wait": [
+            {
+               "id": "ada-35",
+               "result": {
+                  "signatures": []
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}",
+                  "version": 15
+               },
+               "contentChanges": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 13,
+                           "character": 16
+                        },
+                        "end": {
+                           "line": 13,
+                           "character": 16
+                        }
+                     },
+                     "text": ";"
+                  }
+               ]
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didClose",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}"
+               }
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "stop": {
+         "exit_code": 0
+      }
+   }
+]

--- a/testsuite/ada_lsp/T723-027.signatureHelp.simple/test.yaml
+++ b/testsuite/ada_lsp/T723-027.signatureHelp.simple/test.yaml
@@ -1,0 +1,1 @@
+title: 'T723-027.signatureHelp.simple'


### PR DESCRIPTION
Use P_All_Env_Elements and filter the returned node
to find all the function declaration with the same name.
Fix param type in the generated spec.

Add tests.