### PR TITLE
T903-007: Return enclosing subp body decl for incomingCalls

### DIFF
--- a/source/ada/lsp-ada_handlers.adb
+++ b/source/ada/lsp-ada_handlers.adb
@@ -4174,7 +4174,8 @@ package body LSP.Ada_Handlers is
             Cancel : in out Boolean)
          is
             From : constant Libadalang.Analysis.Defining_Name :=
-              LSP.Lal_Utils.Containing_Entity (Ref.As_Ada_Node);
+              LSP.Lal_Utils.Containing_Entity
+                (Ref.As_Ada_Node, Canonical => False);
             --  Defining name of the enclosing entity.
 
             Call : constant LSP.Messages.Location :=

--- a/source/ada/lsp-lal_utils.adb
+++ b/source/ada/lsp-lal_utils.adb
@@ -516,7 +516,10 @@ package body LSP.Lal_Utils is
    -- Containing_Entity --
    -----------------------
 
-   function Containing_Entity (Ref : Ada_Node) return Defining_Name is
+   function Containing_Entity
+     (Ref       : Ada_Node;
+      Canonical : Boolean := True) return Defining_Name
+   is
       Parents : constant Ada_Node_Array := Ref.Parents;
    begin
       for Parent of Parents loop
@@ -527,7 +530,11 @@ package body LSP.Lal_Utils is
                          | Ada_Package_Body
                          | Ada_Package_Decl
          then
-            return Parent.As_Basic_Decl.P_Canonical_Part.P_Defining_Name;
+            if Canonical then
+               return Parent.As_Basic_Decl.P_Canonical_Part.P_Defining_Name;
+            else
+               return Parent.As_Basic_Decl.P_Defining_Name;
+            end if;
          end if;
       end loop;
 

--- a/source/ada/lsp-lal_utils.ads
+++ b/source/ada/lsp-lal_utils.ads
@@ -150,9 +150,14 @@ package LSP.Lal_Utils is
      (Node : Libadalang.Analysis.Ada_Node'Class) return LSP.Types.LSP_String;
    --  Return "file.adb:line:col" as a string
 
-   function Containing_Entity (Ref : Ada_Node) return Defining_Name;
+   function Containing_Entity
+     (Ref       : Ada_Node;
+      Canonical : Boolean := True) return Defining_Name;
    --  Return the declaration of the subprogram or task that contains Ref.
    --  Return No_Defining_Name if this fails.
+   --  If Canonical is True, the first part of the enclosing entity will be
+   --  returned (i.e: if the enclosing entity is a subprgram body, the function
+   --  will return the spec declaration node).
 
    function To_Unbounded_String
      (Input : Utils.Char_Vectors.Char_Vector)


### PR DESCRIPTION
Instead of returning the subprogram spec decl. This is needed
since VS Code has a different way of showing calls than GS: it
highlights all the calls in the editor isteld instead of showing
them in the tree.