### PR TITLE
U416-030 Fix Change Subp Signatures refactorings

### DIFF
--- a/source/ada/lsp-ada_handlers-refactor_change_parameter_mode.adb
+++ b/source/ada/lsp-ada_handlers-refactor_change_parameter_mode.adb
@@ -165,7 +165,7 @@ package body LSP.Ada_Handlers.Refactor_Change_Parameter_Mode is
         (Context           => Context.all,
          Where             => ((uri => Where.uri), Where.span.first),
          First_Param_Index => LSP.Types.LSP_Number (Parameters_Indices.First),
-         Last_Param_Index  => LSP.Types.LSP_Number (Parameters_Indices.First),
+         Last_Param_Index  => LSP.Types.LSP_Number (Parameters_Indices.Last),
          New_Mode          => Image (New_Mode));
 
       Pointer.Set (Self);

--- a/source/ada/lsp-ada_handlers-refactor_remove_parameter.adb
+++ b/source/ada/lsp-ada_handlers-refactor_remove_parameter.adb
@@ -103,7 +103,7 @@ package body LSP.Ada_Handlers.Refactor_Remove_Parameter is
         (Context           => Context.all,
          Where             => ((uri => Where.uri), Where.span.first),
          First_Parameter => LSP.Types.LSP_Number (Parameters_Indices.First),
-         Last_Parameter  => LSP.Types.LSP_Number (Parameters_Indices.First));
+         Last_Parameter  => LSP.Types.LSP_Number (Parameters_Indices.Last));
 
       Pointer.Set (Self);
 

--- a/testsuite/ada_lsp/U416-030.refactor_change_parameter_mode_0/default.gpr
+++ b/testsuite/ada_lsp/U416-030.refactor_change_parameter_mode_0/default.gpr
@@ -1,0 +1,3 @@
+project Default is
+   for Main use ("main.adb");
+end Default;

--- a/testsuite/ada_lsp/U416-030.refactor_change_parameter_mode_0/main.adb
+++ b/testsuite/ada_lsp/U416-030.refactor_change_parameter_mode_0/main.adb
@@ -1,0 +1,10 @@
+procedure Main is
+    procedure Foo (A, B: Integer; C: Float);
+
+    procedure Foo (A, B: Integer; C: Float) is
+    begin
+        null;
+    end Foo;
+begin
+    Foo (1, 2, 3.0);
+end Main;

--- a/testsuite/ada_lsp/U416-030.refactor_change_parameter_mode_0/test.json
+++ b/testsuite/ada_lsp/U416-030.refactor_change_parameter_mode_0/test.json
@@ -1,0 +1,592 @@
+[
+   {
+      "comment": [
+         "test automatically generated"
+      ]
+   },
+   {
+      "start": {
+         "cmd": [
+            "${ALS}"
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": 0,
+            "method": "initialize",
+            "params": {
+               "processId": 269432,
+               "rootUri": "$URI{.}",
+               "capabilities": {
+                  "workspace": {
+                     "applyEdit": true,
+                     "workspaceEdit": {
+                        "documentChanges": true,
+                        "resourceOperations": [
+                           "create",
+                           "rename",
+                           "delete"
+                        ],
+                        "failureHandling": "textOnlyTransactional",
+                        "normalizesLineEndings": true,
+                        "changeAnnotationSupport": {
+                           "groupsOnLabel": true
+                        }
+                     },
+                     "didChangeConfiguration": {
+                        "dynamicRegistration": true
+                     },
+                     "didChangeWatchedFiles": {
+                        "dynamicRegistration": true
+                     },
+                     "symbol": {},
+                     "codeLens": {
+                        "refreshSupport": true
+                     },
+                     "executeCommand": {
+                        "dynamicRegistration": true
+                     },
+                     "configuration": true,
+                     "workspaceFolders": true,
+                     "semanticTokens": {
+                        "refreshSupport": true
+                     },
+                     "fileOperations": {}
+                  },
+                  "textDocument": {
+                     "publishDiagnostics": {},
+                     "synchronization": {
+                        "dynamicRegistration": true,
+                        "willSave": true,
+                        "willSaveWaitUntil": true,
+                        "didSave": true
+                     },
+                     "completion": {
+                        "dynamicRegistration": true,
+                        "contextSupport": true,
+                        "completionItem": {
+                           "snippetSupport": true,
+                           "commitCharactersSupport": true,
+                           "documentationFormat": [
+                              "markdown",
+                              "plaintext"
+                           ],
+                           "deprecatedSupport": true,
+                           "preselectSupport": true,
+                           "tagSupport": {
+                              "valueSet": [
+                                 1
+                              ]
+                           },
+                           "insertReplaceSupport": true,
+                           "resolveSupport": {
+                              "properties": [
+                                 "documentation",
+                                 "detail",
+                                 "additionalTextEdits"
+                              ]
+                           },
+                           "insertTextModeSupport": {
+                              "valueSet": [
+                                 1,
+                                 2
+                              ]
+                           }
+                        },
+                        "completionItemKind": {}
+                     },
+                     "hover": {
+                        "dynamicRegistration": true,
+                        "contentFormat": [
+                           "markdown",
+                           "plaintext"
+                        ]
+                     },
+                     "signatureHelp": {
+                        "dynamicRegistration": true,
+                        "signatureInformation": {
+                           "documentationFormat": [
+                              "markdown",
+                              "plaintext"
+                           ],
+                           "parameterInformation": {
+                              "labelOffsetSupport": true
+                           },
+                           "activeParameterSupport": true
+                        },
+                        "contextSupport": true
+                     },
+                     "definition": {
+                        "dynamicRegistration": true,
+                        "linkSupport": true
+                     },
+                     "references": {
+                        "dynamicRegistration": true
+                     },
+                     "documentHighlight": {
+                        "dynamicRegistration": true
+                     },
+                     "documentSymbol": {},
+                     "codeAction": {
+                        "dynamicRegistration": true,
+                        "isPreferredSupport": true,
+                        "disabledSupport": true,
+                        "dataSupport": true,
+                        "resolveSupport": {
+                           "properties": [
+                              "edit"
+                           ]
+                        },
+                        "codeActionLiteralSupport": {
+                           "codeActionKind": {
+                              "valueSet": [
+                                 "",
+                                 "quickfix",
+                                 "refactor",
+                                 "refactor.extract",
+                                 "refactor.inline",
+                                 "refactor.rewrite",
+                                 "source",
+                                 "source.organizeImports"
+                              ]
+                           }
+                        },
+                        "honorsChangeAnnotations": false
+                     },
+                     "rename": {
+                        "dynamicRegistration": true,
+                        "prepareSupport": true,
+                        "prepareSupportDefaultBehavior": 1,
+                        "honorsChangeAnnotations": true
+                     }
+                  }
+               },
+               "workspaceFolders": [
+                  {
+                     "uri": "$URI{.}",
+                     "name": "S314-015.refactor_remove_parameter_0"
+                  }
+               ]
+            }
+         },
+         "wait": [
+            {
+               "id": 0,
+               "result": {
+                  "capabilities": {
+                     "textDocumentSync": 2,
+                     "completionProvider": {
+                        "triggerCharacters": [
+                           ".",
+                           "("
+                        ],
+                        "resolveProvider": false
+                     },
+                     "hoverProvider": true,
+                     "declarationProvider": true,
+                     "definitionProvider": true,
+                     "typeDefinitionProvider": true,
+                     "implementationProvider": true,
+                     "referencesProvider": true,
+                     "documentHighlightProvider": true,
+                     "codeActionProvider": {
+                        "codeActionKinds": [
+                           "refactor.rewrite"
+                        ]
+                     },
+                     "documentFormattingProvider": true,
+                     "renameProvider": {
+                        "prepareProvider": true
+                     },
+                     "foldingRangeProvider": true,
+                     "executeCommandProvider": {
+                        "commands": [
+                           "<HAS>",
+                           "als-refactor-change-parameter-mode"
+                        ]
+                     },
+                     "workspaceSymbolProvider": true,
+                     "callHierarchyProvider": {},
+                     "alsCalledByProvider": true,
+                     "alsCallsProvider": true,
+                     "alsShowDepsProvider": true,
+                     "alsReferenceKinds": [
+                        "reference",
+                        "access",
+                        "write",
+                        "call",
+                        "dispatching call",
+                        "parent",
+                        "child"
+                     ]
+                  }
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "initialized",
+            "params": {}
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "workspace/didChangeConfiguration",
+            "params": {
+               "settings": {
+                  "ada": {
+                     "trace": {
+                        "server": "verbose"
+                     },
+                     "projectFile": "",
+                     "scenarioVariables": {},
+                     "defaultCharset": "iso-8859-1",
+                     "displayMethodAncestryOnNavigation": "usage_and_abstract_only",
+                     "enableDiagnostics": true,
+                     "renameInComments": false
+                  }
+               }
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{main.adb}",
+                  "languageId": "ada",
+                  "version": 1,
+                  "text": "procedure Main is\n    procedure Foo (A, B: Integer; C: Float);\n\n    procedure Foo (A, B: Integer; C: Float) is\n    begin\n        null;\n    end Foo;\nbegin\n    Foo (1, 2, 3.0);\nend Main;\n"
+               }
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "textDocument/codeAction",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{main.adb}"
+               },
+               "range": {
+                  "start": {
+                     "line": 1,
+                     "character": 25
+                  },
+                  "end": {
+                     "line": 1,
+                     "character": 25
+                  }
+               },
+               "context": {
+                  "diagnostics": []
+               }
+            }
+         },
+         "wait": [
+            {
+               "jsonrpc": "2.0",
+               "id": 3,
+               "result": [
+                  {
+                     "title": "Remove parameters A and B",
+                     "kind": "refactor.rewrite",
+                     "command": {
+                        "title": "",
+                        "command": "als-refactor-remove-parameters",
+                        "arguments": [
+                           {
+                              "context": "Default",
+                              "where": {
+                                 "textDocument": {
+                                    "uri": "$URI{main.adb}"
+                                 },
+                                 "position": {
+                                    "line": 1,
+                                    "character": 14
+                                 }
+                              },
+                              "first_parameter": 1,
+                              "last_parameter": 2
+                           }
+                        ]
+                     }
+                  },
+                  {
+                     "title": "Change parameters A and B mode to in",
+                     "kind": "refactor.rewrite",
+                     "command": {
+                        "title": "",
+                        "command": "als-refactor-change-parameter-mode",
+                        "arguments": [
+                           {
+                              "context": "Default",
+                              "where": {
+                                 "textDocument": {
+                                    "uri": "$URI{main.adb}"
+                                 },
+                                 "position": {
+                                    "line": 1,
+                                    "character": 14
+                                 }
+                              },
+                              "first_parameter": 1,
+                              "last_parameter": 2,
+                              "new_mode": "in"
+                           }
+                        ]
+                     }
+                  },
+                  {
+                     "title": "Change parameters A and B mode to out",
+                     "kind": "refactor.rewrite",
+                     "command": {
+                        "title": "",
+                        "command": "als-refactor-change-parameter-mode",
+                        "arguments": [
+                           {
+                              "context": "Default",
+                              "where": {
+                                 "textDocument": {
+                                    "uri": "$URI{main.adb}"
+                                 },
+                                 "position": {
+                                    "line": 1,
+                                    "character": 14
+                                 }
+                              },
+                              "first_parameter": 1,
+                              "last_parameter": 2,
+                              "new_mode": "out"
+                           }
+                        ]
+                     }
+                  },
+                  {
+                     "title": "Change parameters A and B mode to in out",
+                     "kind": "refactor.rewrite",
+                     "command": {
+                        "title": "",
+                        "command": "als-refactor-change-parameter-mode",
+                        "arguments": [
+                           {
+                              "context": "Default",
+                              "where": {
+                                 "textDocument": {
+                                    "uri": "$URI{main.adb}"
+                                 },
+                                 "position": {
+                                    "line": 1,
+                                    "character": 14
+                                 }
+                              },
+                              "first_parameter": 1,
+                              "last_parameter": 2,
+                              "new_mode": "in out"
+                           }
+                        ]
+                     }
+                  }
+               ]
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": 4,
+            "method": "workspace/executeCommand",
+            "params": {
+               "command": "als-refactor-remove-parameters",
+               "arguments": [
+                  {
+                     "context": "Default",
+                     "where": {
+                        "textDocument": {
+                           "uri": "$URI{main.adb}"
+                        },
+                        "position": {
+                           "line": 1,
+                           "character": 14
+                        }
+                     },
+                     "first_parameter": 1,
+                     "last_parameter": 2
+                  }
+               ]
+            }
+         },
+         "wait": [
+            {
+               "jsonrpc": "2.0",
+               "id": 4,
+               "method": "workspace/applyEdit",
+               "params": {
+                  "edit": {
+                     "documentChanges": [
+                        {
+                           "textDocument": {
+                              "uri": "$URI{main.adb}",
+                              "version": 1
+                           },
+                           "edits": [
+                              {
+                                 "range": {
+                                    "start": {
+                                       "line": 1,
+                                       "character": 19
+                                    },
+                                    "end": {
+                                       "line": 1,
+                                       "character": 34
+                                    }
+                                 },
+                                 "newText": ""
+                              },
+                              {
+                                 "range": {
+                                    "start": {
+                                       "line": 3,
+                                       "character": 19
+                                    },
+                                    "end": {
+                                       "line": 3,
+                                       "character": 34
+                                    }
+                                 },
+                                 "newText": ""
+                              },
+                              {
+                                 "range": {
+                                    "start": {
+                                       "line": 8,
+                                       "character": 9
+                                    },
+                                    "end": {
+                                       "line": 8,
+                                       "character": 15
+                                    }
+                                 },
+                                 "newText": ""
+                              }
+                           ]
+                        }
+                     ]
+                  }
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{main.adb}",
+                  "version": 2
+               },
+               "contentChanges": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 8,
+                           "character": 9
+                        },
+                        "end": {
+                           "line": 8,
+                           "character": 15
+                        }
+                     },
+                     "rangeLength": 6,
+                     "text": ""
+                  },
+                  {
+                     "range": {
+                        "start": {
+                           "line": 3,
+                           "character": 19
+                        },
+                        "end": {
+                           "line": 3,
+                           "character": 34
+                        }
+                     },
+                     "rangeLength": 15,
+                     "text": ""
+                  },
+                  {
+                     "range": {
+                        "start": {
+                           "line": 1,
+                           "character": 19
+                        },
+                        "end": {
+                           "line": 1,
+                           "character": 34
+                        }
+                     },
+                     "rangeLength": 15,
+                     "text": ""
+                  }
+               ]
+            }
+         },
+         "wait": [
+            {
+               "jsonrpc": "2.0",
+               "method": "textDocument/publishDiagnostics",
+               "params": {
+                  "uri": "$URI{main.adb}",
+                  "diagnostics": []
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": 5,
+            "method": "shutdown"
+         },
+         "wait": [
+            {
+               "id": 5,
+               "result": null
+            }
+         ]
+      }
+   },
+   {
+      "stop": {
+         "exit_code": 0
+      }
+   }
+]

--- a/testsuite/ada_lsp/U416-030.refactor_change_parameter_mode_0/test.yaml
+++ b/testsuite/ada_lsp/U416-030.refactor_change_parameter_mode_0/test.yaml
@@ -1,0 +1,1 @@
+title: 'S314-015.refactor_change_parameter_mode_0'

--- a/testsuite/ada_lsp/U416-030.refactor_remove_parameter_0/default.gpr
+++ b/testsuite/ada_lsp/U416-030.refactor_remove_parameter_0/default.gpr
@@ -1,0 +1,3 @@
+project Default is
+   for Main use ("main.adb");
+end Default;

--- a/testsuite/ada_lsp/U416-030.refactor_remove_parameter_0/main.adb
+++ b/testsuite/ada_lsp/U416-030.refactor_remove_parameter_0/main.adb
@@ -1,0 +1,10 @@
+procedure Main is
+    procedure Foo (A, B: Integer; C: Float);
+
+    procedure Foo (A, B: Integer; C: Float) is
+    begin
+        null;
+    end Foo;
+begin
+    Foo (1, 2, 3.0);
+end Main;

--- a/testsuite/ada_lsp/U416-030.refactor_remove_parameter_0/test.json
+++ b/testsuite/ada_lsp/U416-030.refactor_remove_parameter_0/test.json
@@ -1,0 +1,566 @@
+[
+   {
+      "comment": [
+         "test automatically generated"
+      ]
+   },
+   {
+      "start": {
+         "cmd": [
+            "${ALS}"
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": 0,
+            "method": "initialize",
+            "params": {
+               "processId": 269432,
+               "rootUri": "$URI{.}",
+               "capabilities": {
+                  "workspace": {
+                     "applyEdit": true,
+                     "workspaceEdit": {
+                        "documentChanges": true,
+                        "resourceOperations": [
+                           "create",
+                           "rename",
+                           "delete"
+                        ],
+                        "failureHandling": "textOnlyTransactional",
+                        "normalizesLineEndings": true,
+                        "changeAnnotationSupport": {
+                           "groupsOnLabel": true
+                        }
+                     },
+                     "didChangeConfiguration": {
+                        "dynamicRegistration": true
+                     },
+                     "didChangeWatchedFiles": {
+                        "dynamicRegistration": true
+                     },
+                     "symbol": {},
+                     "codeLens": {
+                        "refreshSupport": true
+                     },
+                     "executeCommand": {
+                        "dynamicRegistration": true
+                     },
+                     "configuration": true,
+                     "workspaceFolders": true,
+                     "semanticTokens": {
+                        "refreshSupport": true
+                     },
+                     "fileOperations": {}
+                  },
+                  "textDocument": {
+                     "publishDiagnostics": {},
+                     "synchronization": {
+                        "dynamicRegistration": true,
+                        "willSave": true,
+                        "willSaveWaitUntil": true,
+                        "didSave": true
+                     },
+                     "completion": {
+                        "dynamicRegistration": true,
+                        "contextSupport": true,
+                        "completionItem": {
+                           "snippetSupport": true,
+                           "commitCharactersSupport": true,
+                           "documentationFormat": [
+                              "markdown",
+                              "plaintext"
+                           ],
+                           "deprecatedSupport": true,
+                           "preselectSupport": true,
+                           "tagSupport": {
+                              "valueSet": [
+                                 1
+                              ]
+                           },
+                           "insertReplaceSupport": true,
+                           "resolveSupport": {
+                              "properties": [
+                                 "documentation",
+                                 "detail",
+                                 "additionalTextEdits"
+                              ]
+                           },
+                           "insertTextModeSupport": {
+                              "valueSet": [
+                                 1,
+                                 2
+                              ]
+                           }
+                        },
+                        "completionItemKind": {}
+                     },
+                     "hover": {
+                        "dynamicRegistration": true,
+                        "contentFormat": [
+                           "markdown",
+                           "plaintext"
+                        ]
+                     },
+                     "signatureHelp": {
+                        "dynamicRegistration": true,
+                        "signatureInformation": {
+                           "documentationFormat": [
+                              "markdown",
+                              "plaintext"
+                           ],
+                           "parameterInformation": {
+                              "labelOffsetSupport": true
+                           },
+                           "activeParameterSupport": true
+                        },
+                        "contextSupport": true
+                     },
+                     "definition": {
+                        "dynamicRegistration": true,
+                        "linkSupport": true
+                     },
+                     "references": {
+                        "dynamicRegistration": true
+                     },
+                     "documentHighlight": {
+                        "dynamicRegistration": true
+                     },
+                     "documentSymbol": {},
+                     "codeAction": {
+                        "dynamicRegistration": true,
+                        "isPreferredSupport": true,
+                        "disabledSupport": true,
+                        "dataSupport": true,
+                        "resolveSupport": {
+                           "properties": [
+                              "edit"
+                           ]
+                        },
+                        "codeActionLiteralSupport": {
+                           "codeActionKind": {
+                              "valueSet": [
+                                 "",
+                                 "quickfix",
+                                 "refactor",
+                                 "refactor.extract",
+                                 "refactor.inline",
+                                 "refactor.rewrite",
+                                 "source",
+                                 "source.organizeImports"
+                              ]
+                           }
+                        },
+                        "honorsChangeAnnotations": false
+                     },
+                     "rename": {
+                        "dynamicRegistration": true,
+                        "prepareSupport": true,
+                        "prepareSupportDefaultBehavior": 1,
+                        "honorsChangeAnnotations": true
+                     }
+                  }
+               },
+               "workspaceFolders": [
+                  {
+                     "uri": "$URI{.}",
+                     "name": "S314-015.refactor_remove_parameter_0"
+                  }
+               ]
+            }
+         },
+         "wait": [
+            {
+               "id": 0,
+               "result": {
+                  "capabilities": {
+                     "textDocumentSync": 2,
+                     "completionProvider": {
+                        "triggerCharacters": [
+                           ".",
+                           "("
+                        ],
+                        "resolveProvider": false
+                     },
+                     "hoverProvider": true,
+                     "declarationProvider": true,
+                     "definitionProvider": true,
+                     "typeDefinitionProvider": true,
+                     "implementationProvider": true,
+                     "referencesProvider": true,
+                     "documentHighlightProvider": true,
+                     "codeActionProvider": {
+                        "codeActionKinds": [
+                           "refactor.rewrite"
+                        ]
+                     },
+                     "documentFormattingProvider": true,
+                     "renameProvider": {
+                        "prepareProvider": true
+                     },
+                     "foldingRangeProvider": true,
+                     "executeCommandProvider": {
+                        "commands": [
+                           "<HAS>",
+                           "als-refactor-remove-parameters"
+                        ]
+                     },
+                     "workspaceSymbolProvider": true,
+                     "callHierarchyProvider": {},
+                     "alsCalledByProvider": true,
+                     "alsCallsProvider": true,
+                     "alsShowDepsProvider": true,
+                     "alsReferenceKinds": [
+                        "reference",
+                        "access",
+                        "write",
+                        "call",
+                        "dispatching call",
+                        "parent",
+                        "child"
+                     ]
+                  }
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "initialized",
+            "params": {}
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "workspace/didChangeConfiguration",
+            "params": {
+               "settings": {
+                  "ada": {
+                     "trace": {
+                        "server": "verbose"
+                     },
+                     "projectFile": "",
+                     "scenarioVariables": {},
+                     "defaultCharset": "iso-8859-1",
+                     "displayMethodAncestryOnNavigation": "usage_and_abstract_only",
+                     "enableDiagnostics": true,
+                     "renameInComments": false
+                  }
+               }
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{main.adb}",
+                  "languageId": "ada",
+                  "version": 1,
+                  "text": "procedure Main is\n    procedure Foo (A, B: Integer; C: Float);\n\n    procedure Foo (A, B: Integer; C: Float) is\n    begin\n        null;\n    end Foo;\nbegin\n    Foo (1, 2, 3.0);\nend Main;\n"
+               }
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "textDocument/codeAction",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{main.adb}"
+               },
+               "range": {
+                  "start": {
+                     "line": 1,
+                     "character": 30
+                  },
+                  "end": {
+                     "line": 1,
+                     "character": 30
+                  }
+               },
+               "context": {
+                  "diagnostics": []
+               }
+            }
+         },
+         "wait": [
+            {
+               "jsonrpc": "2.0",
+               "id": 3,
+               "result": [
+                  {
+                     "title": "Remove parameters A and B",
+                     "kind": "refactor.rewrite",
+                     "command": {
+                        "title": "",
+                        "command": "als-refactor-remove-parameters",
+                        "arguments": [
+                           {
+                              "context": "Default",
+                              "where": {
+                                 "textDocument": {
+                                    "uri": "$URI{main.adb}"
+                                 },
+                                 "position": {
+                                    "line": 1,
+                                    "character": 14
+                                 }
+                              },
+                              "first_parameter": 1,
+                              "last_parameter": 2
+                           }
+                        ]
+                     }
+                  },
+                  {
+                     "title": "Change parameters A and B mode to in",
+                     "kind": "refactor.rewrite",
+                     "command": {
+                        "title": "",
+                        "command": "als-refactor-change-parameter-mode",
+                        "arguments": [
+                           {
+                              "context": "Default",
+                              "where": {
+                                 "textDocument": {
+                                    "uri": "$URI{main.adb}"
+                                 },
+                                 "position": {
+                                    "line": 1,
+                                    "character": 14
+                                 }
+                              },
+                              "first_parameter": 1,
+                              "last_parameter": 2,
+                              "new_mode": "in"
+                           }
+                        ]
+                     }
+                  },
+                  {
+                     "title": "Change parameters A and B mode to out",
+                     "kind": "refactor.rewrite",
+                     "command": {
+                        "title": "",
+                        "command": "als-refactor-change-parameter-mode",
+                        "arguments": [
+                           {
+                              "context": "Default",
+                              "where": {
+                                 "textDocument": {
+                                    "uri": "$URI{main.adb}"
+                                 },
+                                 "position": {
+                                    "line": 1,
+                                    "character": 14
+                                 }
+                              },
+                              "first_parameter": 1,
+                              "last_parameter": 2,
+                              "new_mode": "out"
+                           }
+                        ]
+                     }
+                  },
+                  {
+                     "title": "Change parameters A and B mode to in out",
+                     "kind": "refactor.rewrite",
+                     "command": {
+                        "title": "",
+                        "command": "als-refactor-change-parameter-mode",
+                        "arguments": [
+                           {
+                              "context": "Default",
+                              "where": {
+                                 "textDocument": {
+                                    "uri": "$URI{main.adb}"
+                                 },
+                                 "position": {
+                                    "line": 1,
+                                    "character": 14
+                                 }
+                              },
+                              "first_parameter": 1,
+                              "last_parameter": 2,
+                              "new_mode": "in out"
+                           }
+                        ]
+                     }
+                  }
+               ]
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": 4,
+            "method": "workspace/executeCommand",
+            "params": {
+               "command": "als-refactor-change-parameter-mode",
+               "arguments": [
+                  {
+                     "context": "Default",
+                     "where": {
+                        "textDocument": {
+                           "uri": "$URI{main.adb}"
+                        },
+                        "position": {
+                           "line": 1,
+                           "character": 14
+                        }
+                     },
+                     "first_parameter": 1,
+                     "last_parameter": 2,
+                     "new_mode": "out"
+                  }
+               ]
+            }
+         },
+         "wait": [
+            {
+               "jsonrpc": "2.0",
+               "id": 4,
+               "method": "workspace/applyEdit",
+               "params": {
+                  "edit": {
+                     "documentChanges": [
+                        {
+                           "textDocument": {
+                              "uri": "$URI{main.adb}",
+                              "version": 1
+                           },
+                           "edits": [
+                              {
+                                 "range": {
+                                    "start": {
+                                       "line": 1,
+                                       "character": 24
+                                    },
+                                    "end": {
+                                       "line": 1,
+                                       "character": 24
+                                    }
+                                 },
+                                 "newText": "out"
+                              },
+                              {
+                                 "range": {
+                                    "start": {
+                                       "line": 3,
+                                       "character": 24
+                                    },
+                                    "end": {
+                                       "line": 3,
+                                       "character": 24
+                                    }
+                                 },
+                                 "newText": "out"
+                              }
+                           ]
+                        }
+                     ]
+                  }
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{main.adb}",
+                  "version": 2
+               },
+               "contentChanges": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 3,
+                           "character": 24
+                        },
+                        "end": {
+                           "line": 3,
+                           "character": 24
+                        }
+                     },
+                     "rangeLength": 0,
+                     "text": "out"
+                  },
+                  {
+                     "range": {
+                        "start": {
+                           "line": 1,
+                           "character": 24
+                        },
+                        "end": {
+                           "line": 1,
+                           "character": 24
+                        }
+                     },
+                     "rangeLength": 0,
+                     "text": "out"
+                  }
+               ]
+            }
+         },
+         "wait": [
+            {
+               "jsonrpc": "2.0",
+               "method": "textDocument/publishDiagnostics",
+               "params": {
+                  "uri": "$URI{main.adb}",
+                  "diagnostics": []
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": 5,
+            "method": "shutdown"
+         },
+         "wait": [
+            {
+               "id": 5,
+               "result": null
+            }
+         ]
+      }
+   },
+   {
+      "stop": {
+         "exit_code": 0
+      }
+   }
+]

--- a/testsuite/ada_lsp/U416-030.refactor_remove_parameter_0/test.yaml
+++ b/testsuite/ada_lsp/U416-030.refactor_remove_parameter_0/test.yaml
@@ -1,0 +1,1 @@
+title: 'S314-015.refactor_change_parameter_mode_0'


### PR DESCRIPTION
Fix the Change Parameter Mode and Remove Parameter refactoring tools when these are applied to a range of parameters instead of an unique parameter.
Without this fix, the refactoring tools are only applied to the first parameter in the range.
Add a test case for each refactoring.