### PR TITLE
U429-018 Pass "g++" as the Linker

### DIFF
--- a/gnat/lsp_server.gpr
+++ b/gnat/lsp_server.gpr
@@ -50,6 +50,7 @@ project LSP_Server is
    end Compiler;
 
    package Linker is
+      for Driver use "g++";
       case Library_Type is
          when "static" | "static-pic" =>
             case OS is


### PR DESCRIPTION
Do this in all cases, rather than letting gprbuild detect it.
Tentative workaround for an issue with gpr2.