### PR TITLE
T608-018 Deactivate timeout in the driver

### DIFF
--- a/testsuite/drivers/basic.py
+++ b/testsuite/drivers/basic.py
@@ -30,7 +30,7 @@ class JsonTestDriver(ALSTestDriver):
             process = self.run_and_log(
                 [self.env.tester_run, json],
                 cwd=wd,
-                timeout=min(780, 120 * self.env.wait_factor),
+                timeout=0,
                 env={'ALS': self.env.als,
                      'ALS_HOME': self.env.als_home,
                      'ALS_WAIT_FACTOR': str(self.env.wait_factor)},


### PR DESCRIPTION
e3-testsuite-driver relies on rlimit to implement timeouts,
and this does not seem to work on GitHub Action machines.

Deactivate this timeout, and rely instead on the fine-grained
timeout mechanism implemented by the test runner.