### PR TITLE
T608-018 Deactivate timeout in the driver

### DIFF
--- a/testsuite/drivers/basic.py
+++ b/testsuite/drivers/basic.py
@@ -20,21 +20,23 @@ class JsonTestDriver(ALSTestDriver):
             return False
 
         # The working directory
-        wd = self.test_env['working_dir']
+        wd = self.test_env["working_dir"]
 
         output = ""
 
         status = TestStatus.PASS
 
-        for json in glob.glob(os.path.join(wd, '*.json')):
+        for json in glob.glob(os.path.join(wd, "*.json")):
             process = self.run_and_log(
                 [self.env.tester_run, json],
                 cwd=wd,
-                timeout=min(780, 120 * self.env.wait_factor),
-                env={'ALS': self.env.als,
-                     'ALS_HOME': self.env.als_home,
-                     'ALS_WAIT_FACTOR': str(self.env.wait_factor)},
-                ignore_environ=False)
+                env={
+                    "ALS": self.env.als,
+                    "ALS_HOME": self.env.als_home,
+                    "ALS_WAIT_FACTOR": str(self.env.wait_factor),
+                },
+                ignore_environ=False,
+            )
             output += process.out
 
             if process.status:

--- a/testsuite/drivers/codecs.py
+++ b/testsuite/drivers/codecs.py
@@ -18,12 +18,9 @@ class CodecsTestDriver(ALSTestDriver):
         if self.should_skip():
             return False
 
-        index = os.path.abspath(
-            os.path.join(self.test_env['test_dir'], 'index.txt'))
-        p = self.run_and_log([self.env.codec_test], cwd=self.env.repo_base,
-                             timeout=120, input=index)
+        index = os.path.abspath(os.path.join(self.test_env["test_dir"], "index.txt"))
+        p = self.run_and_log([self.env.codec_test], cwd=self.env.repo_base, input=index)
         self.result.out += p.out
 
-        self.result.set_status(
-            TestStatus.PASS if p.status == 0 else TestStatus.FAIL)
+        self.result.set_status(TestStatus.PASS if p.status == 0 else TestStatus.FAIL)
         self.push_result()


### PR DESCRIPTION
e3-testsuite-driver relies on rlimit to implement timeouts,
and this does not seem to work on GitHub Action machines.

Deactivate this timeout, and rely instead on the fine-grained
timeout mechanism implemented by the test runner.