### PR TITLE
Fix CHANGELOG.md generation on tag/release

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -101,6 +101,8 @@ jobs:
     steps:
       - name: Get als
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Download all workflow run artifacts
         uses: actions/download-artifact@v2
       - name: Pack vscode extension


### PR DESCRIPTION
To generate CHANGELOG.md we need all tag commits in the
checkouted repositiory, so we should disable --depth=1 on
repository checkout.