### PR TITLE
U526-026 Silence notification for imprecise navigation

### DIFF
--- a/testsuite/.als/traces.cfg
+++ b/testsuite/.als/traces.cfg
@@ -9,3 +9,6 @@ ALS.OUT=yes  > inout.txt:buffer_size=0
 
 # Testing should include incremental text changes
 ALS.ALLOW_INCREMENTAL_TEXT_CHANGES=yes > inout.txt:buffer_size=0
+
+# Activate navigation warnings in test mode
+ALS.NOTIFICATIONS_FOR_IMPRECISE_NAVIGATION=yes


### PR DESCRIPTION
These messages are noisy and most often uninteresting.

Add a trace to allow printing them, and checking for them
in tests.

Closes #691