### PR TITLE
U301-023 Use Virtual_File as a key in Open_Documnets

### DIFF
--- a/source/ada/lsp-ada_handlers.ads
+++ b/source/ada/lsp-ada_handlers.ads
@@ -90,10 +90,10 @@ private
 
    --  Container for documents indexed by URI
    package Document_Maps is new Ada.Containers.Hashed_Maps
-     (Key_Type        => LSP.Messages.DocumentUri,
+     (Key_Type        => GNATCOLL.VFS.Virtual_File,
       Element_Type    => Internal_Document_Access,
-      Hash            => LSP.Types.Hash,
-      Equivalent_Keys => LSP.Types."=");
+      Hash            => GNATCOLL.VFS.Full_Name_Hash,
+      Equivalent_Keys => GNATCOLL.VFS."=");
 
    --  Container for the predefined source files
    package File_Sets is new Ada.Containers.Hashed_Sets


### PR DESCRIPTION
map instead of Document_URI type. This way we fix
errors on case-insensitive file systems, where the
same file can be pointed by distinct URIs, like
`file:///z:/a.adb` and `file:///Z:/a.adb`.