### PR TITLE
T903-007: incoming/outgoing calls spec modification

### DIFF
--- a/source/ada/lsp-ada_handlers.adb
+++ b/source/ada/lsp-ada_handlers.adb
@@ -4267,7 +4267,8 @@ package body LSP.Ada_Handlers is
                     (Node  => Node,
                      Refs  => Refs,
                      Item  => New_Call.from,
-                     Spans => New_Call.fromRanges);
+                     Spans => New_Call.fromRanges,
+                     Kinds => New_Call.kinds);
 
                   Add_Incoming_Call (New_Call);
                   References_By_Subprogram.Next (C);
@@ -4386,7 +4387,8 @@ package body LSP.Ada_Handlers is
                     (Node  => Node,
                      Refs  => Refs,
                      Item  => New_Call.to,
-                     Spans => New_Call.fromRanges);
+                     Spans => New_Call.fromRanges,
+                     Kinds => New_Call.kinds);
 
                   Add_Outgoing_Call (New_Call);
                   References_By_Subprogram.Next (C);

--- a/source/ada/lsp-lal_utils.adb
+++ b/source/ada/lsp-lal_utils.adb
@@ -1003,7 +1003,7 @@ package body LSP.Lal_Utils is
       return LSP.Messages.CallHierarchyItem'
         (name           => To_LSP_String (Name.Text),
          kind           => LSP.Lal_Utils.Get_Decl_Kind (Main_Item),
-         tags           => LSP.Messages.Empty,
+         tags           => (Is_Set => False),
          detail         => (True, LSP.Lal_Utils.Node_Location_Image (Name)),
          uri            => Where.uri,
          span           => Where.span,
@@ -1018,7 +1018,8 @@ package body LSP.Lal_Utils is
      (Node  : Libadalang.Analysis.Defining_Name;
       Refs  : Laltools.Common.References_Sets.Set;
       Item  : out LSP.Messages.CallHierarchyItem;
-      Spans : out LSP.Messages.Span_Vector)
+      Spans : out LSP.Messages.Span_Vector;
+      Kinds : out LSP.Messages.AlsReferenceKind_Vector)
    is
       Decl     : constant Libadalang.Analysis.Basic_Decl :=
         Node.P_Basic_Decl;
@@ -1035,6 +1036,7 @@ package body LSP.Lal_Utils is
          selectionRange => LSP.Lal_Utils.To_Span (Node.Sloc_Range));
 
       Spans.Clear;
+      Kinds.Clear;
 
       for Ref of Refs loop
          declare
@@ -1042,6 +1044,11 @@ package body LSP.Lal_Utils is
               Get_Node_Location (Ada_Node (Ref));
          begin
             Spans.Append (Ref_Location.span);
+            if Ref.P_Is_Dispatching_Call then
+               Kinds.Append (LSP.Messages.Dispatching_Call);
+            else
+               Kinds.Append (LSP.Messages.Simple);
+            end if;
          end;
       end loop;
    end To_Call_Hierarchy_Result;

--- a/source/ada/lsp-lal_utils.ads
+++ b/source/ada/lsp-lal_utils.ads
@@ -204,7 +204,8 @@ package LSP.Lal_Utils is
      (Node  : Libadalang.Analysis.Defining_Name;
       Refs  : Laltools.Common.References_Sets.Set;
       Item  : out LSP.Messages.CallHierarchyItem;
-      Spans : out LSP.Messages.Span_Vector);
+      Spans : out LSP.Messages.Span_Vector;
+      Kinds : out LSP.Messages.AlsReferenceKind_Vector);
    --  Convert the given Node and the given references to it to the
    --  corresponding CallHierarchyItem and its associated spans, which contains
    --  the references. This should be used for the callHierarchy requests.

--- a/source/protocol/generated/lsp-message_io.adb
+++ b/source/protocol/generated/lsp-message_io.adb
@@ -9288,7 +9288,7 @@ package body LSP.Message_IO is
             elsif Key = "kind" then
                SymbolKind'Read (S, V.kind);
             elsif Key = "tags" then
-               SymbolTagSet'Read (S, V.tags);
+               Optional_SymbolTagSet'Read (S, V.tags);
             elsif Key = "detail" then
                Optional_String'Read (S, V.detail);
             elsif Key = "uri" then
@@ -9318,7 +9318,7 @@ package body LSP.Message_IO is
       JS.Key ("kind");
       SymbolKind'Write (S, V.kind);
       JS.Key ("tags");
-      SymbolTagSet'Write (S, V.tags);
+      Optional_SymbolTagSet'Write (S, V.tags);
       JS.Key ("detail");
       Optional_String'Write (S, V.detail);
       JS.Key ("uri");
@@ -9399,6 +9399,8 @@ package body LSP.Message_IO is
                CallHierarchyItem'Read (S, V.from);
             elsif Key = "fromRanges" then
                Span_Vector'Read (S, V.fromRanges);
+            elsif Key = "kinds" then
+               AlsReferenceKind_Vector'Read (S, V.kinds);
             else
                JS.Skip_Value;
             end if;
@@ -9419,6 +9421,8 @@ package body LSP.Message_IO is
       CallHierarchyItem'Write (S, V.from);
       JS.Key ("fromRanges");
       Span_Vector'Write (S, V.fromRanges);
+      JS.Key ("kinds");
+      AlsReferenceKind_Vector'Write (S, V.kinds);
       JS.End_Object;
    end Write_CallHierarchyIncomingCall;
 
@@ -9443,6 +9447,8 @@ package body LSP.Message_IO is
                CallHierarchyItem'Read (S, V.to);
             elsif Key = "fromRanges" then
                Span_Vector'Read (S, V.fromRanges);
+            elsif Key = "kinds" then
+               AlsReferenceKind_Vector'Read (S, V.kinds);
             else
                JS.Skip_Value;
             end if;
@@ -9463,6 +9469,8 @@ package body LSP.Message_IO is
       CallHierarchyItem'Write (S, V.to);
       JS.Key ("fromRanges");
       Span_Vector'Write (S, V.fromRanges);
+      JS.Key ("kinds");
+      AlsReferenceKind_Vector'Write (S, V.kinds);
       JS.End_Object;
    end Write_CallHierarchyOutgoingCall;
 

--- a/source/protocol/lsp-messages.ads
+++ b/source/protocol/lsp-messages.ads
@@ -16,7 +16,7 @@
 ------------------------------------------------------------------------------
 --
 --  This package provides LSP messages types, request parameters and results
---  types, corresponding encodein/decoding procedures to/from JSON stream.
+--  types, corresponding encoding/decoding procedures to/from JSON stream.
 --
 --  We keep original LSP specification in the comments as TypeScript snippet.
 --  Some of snippets are out of order, because of forward declaration
@@ -466,6 +466,12 @@ package LSP.Messages is
      new LSP.Generic_Optional (AlsReferenceKind_Set);
    type Optional_AlsReferenceKind_Set is
      new Optional_AlsReferenceKind_Sets.Optional_Type;
+
+   package AlsReferenceKind_Vectors is new LSP.Generic_Vectors
+     (AlsReferenceKind, Write_Empty => LSP.Write_Array);
+
+   type AlsReferenceKind_Vector is new AlsReferenceKind_Vectors.Vector with
+     null record;
 
    --  Display method ancestry on navigation ALS extension:
    --
@@ -1982,6 +1988,12 @@ package LSP.Messages is
 
    package SymbolTagSets is new LSP.Generic_Sets (SymbolTag, LSP.Skip);
    type SymbolTagSet is new SymbolTagSets.Set;
+
+   package Optional_SymbolTagSets is
+     new LSP.Generic_Optional (SymbolTagSet);
+
+   type Optional_SymbolTagSet is
+     new Optional_SymbolTagSets.Optional_Type;
 
    type tagSupportCapability is record
       valueSet: SymbolTagSet;
@@ -9907,7 +9919,7 @@ package LSP.Messages is
    type CallHierarchyItem is record
       name: LSP_String;
       kind: SymbolKind;
-      tags: SymbolTagSet;
+      tags: Optional_SymbolTagSet;
       detail: Optional_String;
       uri: DocumentUri;
       span: LSP.Messages.Span;  --  range: is reserved word
@@ -9967,6 +9979,7 @@ package LSP.Messages is
    type CallHierarchyIncomingCall is record
       from: CallHierarchyItem;
       fromRanges: Span_Vector;
+      kinds: AlsReferenceKind_Vector;
    end record;
 
    procedure Read_CallHierarchyIncomingCall
@@ -10010,6 +10023,7 @@ package LSP.Messages is
    type CallHierarchyOutgoingCall is record
       to: CallHierarchyItem;
       fromRanges: Span_Vector;
+      kinds: AlsReferenceKind_Vector;
    end record;
 
    procedure Read_CallHierarchyOutgoingCall


### PR DESCRIPTION
Make the "tags" field optional.
Add a custom field "kinds" containing nothing or a vector of
AlsReferencesKind with the same length as spans.
(This is intentionally not stored in the spans vectors to not
complicated the data structure).