### PR TITLE
U301-023 Use Virtual_File as a key in symbol index

### DIFF
--- a/source/ada/lsp-ada_contexts.adb
+++ b/source/ada/lsp-ada_contexts.adb
@@ -501,12 +501,12 @@ package body LSP.Ada_Contexts is
      (Self   : Context;
       Prefix : VSS.Strings.Virtual_String;
       Callback : not null access procedure
-        (URI  : LSP.Messages.DocumentUri;
+        (File : GNATCOLL.VFS.Virtual_File;
          Name : Libadalang.Analysis.Defining_Name;
          Stop : in out Boolean))
    is
       procedure Adapter
-        (URI  : LSP.Messages.DocumentUri;
+        (File : GNATCOLL.VFS.Virtual_File;
          Loc  : Langkit_Support.Slocs.Source_Location;
          Stop : in out Boolean);
       --  Find a Defining_Name at the given location Loc in a unit of URI and
@@ -517,13 +517,13 @@ package body LSP.Ada_Contexts is
       -------------
 
       procedure Adapter
-        (URI  : LSP.Messages.DocumentUri;
+        (File : GNATCOLL.VFS.Virtual_File;
          Loc  : Langkit_Support.Slocs.Source_Location;
          Stop : in out Boolean)
       is
          Unit : constant Libadalang.Analysis.Analysis_Unit :=
              Self.LAL_Context.Get_From_File
-               (LSP.Types.To_UTF_8_String (Self.URI_To_File (URI)),
+               (File.Display_Full_Name,
                 Charset => Self.Get_Charset);
 
          Name : constant Libadalang.Analysis.Name :=
@@ -533,7 +533,7 @@ package body LSP.Ada_Contexts is
            Laltools.Common.Get_Name_As_Defining (Name);
       begin
          if not Def_Name.Is_Null then
-            Callback (URI, Def_Name, Stop);
+            Callback (File, Def_Name, Stop);
          end if;
       end Adapter;
 
@@ -847,11 +847,8 @@ package body LSP.Ada_Contexts is
           (File.Display_Full_Name,
            Charset => Self.Get_Charset,
            Reparse => Reparse);
-      Name : constant LSP.Types.LSP_String :=
-        LSP.Types.To_LSP_String (Unit.Get_Filename);
-      URI  : constant LSP.Messages.DocumentUri := File_To_URI (Name);
    begin
-      Self.Source_Files.Index_File (URI, Unit);
+      Self.Source_Files.Index_File (File, Unit);
    end Index_File;
 
    --------------------

--- a/source/ada/lsp-ada_contexts.ads
+++ b/source/ada/lsp-ada_contexts.ads
@@ -231,7 +231,7 @@ package LSP.Ada_Contexts is
      (Self   : Context;
       Prefix : VSS.Strings.Virtual_String;
       Callback : not null access procedure
-        (URI  : LSP.Messages.DocumentUri;
+        (File : GNATCOLL.VFS.Virtual_File;
          Name : Libadalang.Analysis.Defining_Name;
          Stop : in out Boolean));
    --  Find symbols starting with given Prefix in all files of the context and

--- a/source/ada/lsp-ada_file_sets.ads
+++ b/source/ada/lsp-ada_file_sets.ads
@@ -29,9 +29,6 @@ with Langkit_Support.Slocs;
 
 with VSS.Strings;
 
-with LSP.Messages;
-with LSP.Types;
-
 package LSP.Ada_File_Sets is
 
    package File_Sets is new Ada.Containers.Ordered_Sets
@@ -58,7 +55,7 @@ package LSP.Ada_File_Sets is
 
    procedure Index_File
      (Self : in out Indexed_File_Set'Class;
-      URI  : LSP.Messages.DocumentUri;
+      File : GNATCOLL.VFS.Virtual_File;
       Unit : Libadalang.Analysis.Analysis_Unit);
    --  Append names defined in the Unit (identified by URI) to internal symbol
    --  index. After that names could be fetched using Get_Any_Symbol_Completion
@@ -68,7 +65,7 @@ package LSP.Ada_File_Sets is
      (Self     : Indexed_File_Set'Class;
       Prefix   : VSS.Strings.Virtual_String;
       Callback : not null access procedure
-        (URI  : LSP.Messages.DocumentUri;
+        (File : GNATCOLL.VFS.Virtual_File;
          Loc  : Langkit_Support.Slocs.Source_Location;
          Stop : in out Boolean));
    --  Find symbols starting with given Prefix in all files of the set and
@@ -77,7 +74,7 @@ package LSP.Ada_File_Sets is
 
 private
    type Name_Information is record
-      URI  : LSP.Messages.DocumentUri;
+      File : GNATCOLL.VFS.Virtual_File;
       Loc  : Langkit_Support.Slocs.Source_Location;
    end record;
 
@@ -91,17 +88,17 @@ private
       Name_Vectors."=");
    --  A map from cannonical writting to vector of name information
 
-   package String_Sets is new Ada.Containers.Hashed_Sets
-     (LSP.Types.LSP_String,
-      LSP.Types.Hash,
-      LSP.Types."=",
-      LSP.Types."=");
+   package Hashed_File_Sets is new Ada.Containers.Hashed_Sets
+     (GNATCOLL.VFS.Virtual_File,
+      GNATCOLL.VFS.Full_Name_Hash,
+      GNATCOLL.VFS."=",
+      GNATCOLL.VFS."=");
 
    type Indexed_File_Set is tagged limited record
       Files       : File_Sets.Set;
       All_Symbols : Symbol_Maps.Map;
       --  Index of all symbols defined in Files
-      Indexed     : String_Sets.Set;
+      Indexed     : Hashed_File_Sets.Set;
       --  Set of document URIs presented in All_Symbols
    end record;
 

--- a/source/ada/lsp-ada_handlers.adb
+++ b/source/ada/lsp-ada_handlers.adb
@@ -3844,7 +3844,7 @@ package body LSP.Ada_Handlers is
       return LSP.Messages.Server_Responses.Symbol_Response
    is
       procedure On_Inaccessible_Name
-        (URI  : LSP.Messages.DocumentUri;
+        (File : GNATCOLL.VFS.Virtual_File;
          Name : Libadalang.Analysis.Defining_Name;
          Stop : in out Boolean);
 
@@ -3871,11 +3871,9 @@ package body LSP.Ada_Handlers is
       --------------------------
 
       procedure On_Inaccessible_Name
-        (URI  : LSP.Messages.DocumentUri;
+        (File : GNATCOLL.VFS.Virtual_File;
          Name : Libadalang.Analysis.Defining_Name;
-         Stop : in out Boolean)
-      is
-         File : constant GNATCOLL.VFS.Virtual_File := Self.To_File (URI);
+         Stop : in out Boolean) is
       begin
          --  Skip all names in open documents, because they could have
          --  stale references. Then skip already provided results.
@@ -3937,7 +3935,7 @@ package body LSP.Ada_Handlers is
       --  project contexts.
 
       procedure On_Inaccessible_Name
-        (URI  : LSP.Messages.DocumentUri;
+        (File : GNATCOLL.VFS.Virtual_File;
          Name : Libadalang.Analysis.Defining_Name;
          Stop : in out Boolean);
 
@@ -3959,11 +3957,9 @@ package body LSP.Ada_Handlers is
       --------------------------
 
       procedure On_Inaccessible_Name
-        (URI  : LSP.Messages.DocumentUri;
+        (File : GNATCOLL.VFS.Virtual_File;
          Name : Libadalang.Analysis.Defining_Name;
-         Stop : in out Boolean)
-      is
-         File : constant GNATCOLL.VFS.Virtual_File := Self.To_File (URI);
+         Stop : in out Boolean) is
       begin
          --  Skip all names in open documents, because they could have
          --  stale references. Then skip already provided results.


### PR DESCRIPTION
So we can look for a symbol with a distinct URI
(like `file:///z:/a.adb` instead of `file:///Z:/a.adb`).