### PR TITLE
U614-038 Improve support for files detached from context

### DIFF
--- a/source/ada/lsp-ada_contexts.adb
+++ b/source/ada/lsp-ada_contexts.adb
@@ -546,9 +546,10 @@ package body LSP.Ada_Contexts is
    ----------------
 
    procedure Initialize
-     (Self            : in out Context;
-      File_Reader     : File_Reader_Interface'Class;
-      Follow_Symlinks : Boolean) is
+     (Self                : in out Context;
+      File_Reader         : File_Reader_Interface'Class;
+      Follow_Symlinks     : Boolean;
+      As_Fallback_Context : Boolean := False) is
    begin
       Self.Follow_Symlinks := Follow_Symlinks;
       Self.Charset := Ada.Strings.Unbounded.To_Unbounded_String
@@ -559,6 +560,7 @@ package body LSP.Ada_Contexts is
          File_Reader   => Self.Reader_Reference,
          With_Trivia   => True,
          Charset       => Self.Get_Charset);
+      Self.Is_Fallback_Context := As_Fallback_Context;
    end Initialize;
 
    ------------------------
@@ -569,7 +571,8 @@ package body LSP.Ada_Contexts is
      (Self : Context;
       File : Virtual_File) return Boolean is
    begin
-      return Self.Source_Files.Contains (File);
+      return Self.Is_Fallback_Context
+        or else Self.Source_Files.Contains (File);
    end Is_Part_Of_Project;
 
    ------------------

--- a/source/ada/lsp-ada_contexts.ads
+++ b/source/ada/lsp-ada_contexts.ads
@@ -47,10 +47,13 @@ package LSP.Ada_Contexts is
    --  libadalang context.
 
    procedure Initialize
-     (Self            : in out Context;
-      File_Reader     : File_Reader_Interface'Class;
-      Follow_Symlinks : Boolean);
+     (Self                : in out Context;
+      File_Reader         : File_Reader_Interface'Class;
+      Follow_Symlinks     : Boolean;
+      As_Fallback_Context : Boolean := False);
    --  Initialize the context, set Follow_Symlinks flag.
+   --  As_Fallback_Context should be set when we are creating the "fallback"
+   --  context based on the empty project.
 
    procedure Load_Project
      (Self     : in out Context;
@@ -240,6 +243,10 @@ private
       Unit_Provider  : Libadalang.Analysis.Unit_Provider_Reference;
       LAL_Context    : Libadalang.Analysis.Analysis_Context;
       Charset        : Ada.Strings.Unbounded.Unbounded_String;
+
+      Is_Fallback_Context : Boolean := False;
+      --  Indicate that this is a "fallback" context, ie the context
+      --  holding any file, in the case no valid project was loaded.
 
       Source_Files   : LSP.Ada_File_Sets.Indexed_File_Set;
       --  Cache for the list of Ada source files in the loaded project tree.

--- a/source/ada/lsp-ada_handlers.adb
+++ b/source/ada/lsp-ada_handlers.adb
@@ -519,7 +519,8 @@ package body LSP.Ada_Handlers is
       Self.Project_Environment.Set_Trusted_Mode (not Self.Follow_Symlinks);
       Self.Project_Tree := new Project_Tree;
 
-      C.Initialize (Reader, Self.Follow_Symlinks);
+      C.Initialize (Reader, Self.Follow_Symlinks,
+                    As_Fallback_Context => True);
 
       --  Note: we would call Load_Implicit_Project here, but this has
       --  two problems:

--- a/testsuite/ada_lsp/U614-038.edits.no_project/otherdir/a.ads
+++ b/testsuite/ada_lsp/U614-038.edits.no_project/otherdir/a.ads
@@ -1,0 +1,6 @@
+package A is
+   procedure Foo (X : Integer);
+   --  Doc for Foo
+   procedure Bar (X : Integer);
+   --  Doc for Bar;
+end A;

--- a/testsuite/ada_lsp/U614-038.edits.no_project/test.json
+++ b/testsuite/ada_lsp/U614-038.edits.no_project/test.json
@@ -1,0 +1,483 @@
+[
+   {
+      "comment": [
+         "Verify that code edits are applied even if the source belongs to no project"
+      ]
+   },
+   {
+      "start": {
+         "cmd": [
+            "${ALS}"
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": 0,
+            "method": "initialize",
+            "params": {
+               "clientInfo": {
+                  "name": "Visual Studio Code",
+                  "version": "1.57.0"
+               },
+               "locale": "en-gb",
+               "rootPath": null,
+               "rootUri": null,
+               "capabilities": {
+                  "workspace": {
+                     "applyEdit": true,
+                     "workspaceEdit": {
+                        "documentChanges": true,
+                        "resourceOperations": [
+                           "create",
+                           "rename",
+                           "delete"
+                        ],
+                        "failureHandling": "textOnlyTransactional",
+                        "normalizesLineEndings": true,
+                        "changeAnnotationSupport": {
+                           "groupsOnLabel": true
+                        }
+                     },
+                     "didChangeConfiguration": {
+                        "dynamicRegistration": true
+                     },
+                     "didChangeWatchedFiles": {
+                        "dynamicRegistration": true
+                     },
+                     "codeLens": {
+                        "refreshSupport": true
+                     },
+                     "executeCommand": {
+                        "dynamicRegistration": true
+                     },
+                     "configuration": true,
+                     "workspaceFolders": true,
+                     "semanticTokens": {
+                        "refreshSupport": true
+                     },
+                     "fileOperations": {
+                        "dynamicRegistration": true,
+                        "didCreate": true,
+                        "didRename": true,
+                        "didDelete": true,
+                        "willCreate": true,
+                        "willRename": true,
+                        "willDelete": true
+                     }
+                  },
+                  "textDocument": {
+                     "publishDiagnostics": {
+                        "relatedInformation": true,
+                        "versionSupport": false,
+                        "tagSupport": {
+                           "valueSet": [
+                              1,
+                              2
+                           ]
+                        },
+                        "codeDescriptionSupport": true,
+                        "dataSupport": true
+                     },
+                     "synchronization": {
+                        "dynamicRegistration": true,
+                        "willSave": true,
+                        "willSaveWaitUntil": true,
+                        "didSave": true
+                     },
+                     "hover": {
+                        "dynamicRegistration": true,
+                        "contentFormat": [
+                           "markdown",
+                           "plaintext"
+                        ]
+                     },
+                     "signatureHelp": {
+                        "dynamicRegistration": true,
+                        "signatureInformation": {
+                           "documentationFormat": [
+                              "markdown",
+                              "plaintext"
+                           ],
+                           "parameterInformation": {
+                              "labelOffsetSupport": true
+                           },
+                           "activeParameterSupport": true
+                        },
+                        "contextSupport": true
+                     },
+                     "definition": {
+                        "dynamicRegistration": true,
+                        "linkSupport": true
+                     },
+                     "references": {
+                        "dynamicRegistration": true
+                     },
+                     "documentHighlight": {
+                        "dynamicRegistration": true
+                     },
+                     "codeAction": {
+                        "dynamicRegistration": true,
+                        "isPreferredSupport": true,
+                        "disabledSupport": true,
+                        "dataSupport": true,
+                        "resolveSupport": {
+                           "properties": [
+                              "edit"
+                           ]
+                        },
+                        "codeActionLiteralSupport": {
+                           "codeActionKind": {
+                              "valueSet": [
+                                 "",
+                                 "quickfix",
+                                 "refactor",
+                                 "refactor.extract",
+                                 "refactor.inline",
+                                 "refactor.rewrite",
+                                 "source",
+                                 "source.organizeImports"
+                              ]
+                           }
+                        },
+                        "honorsChangeAnnotations": false
+                     },
+                     "codeLens": {
+                        "dynamicRegistration": true
+                     },
+                     "formatting": {
+                        "dynamicRegistration": true
+                     },
+                     "rangeFormatting": {
+                        "dynamicRegistration": true
+                     },
+                     "onTypeFormatting": {
+                        "dynamicRegistration": true
+                     },
+                     "rename": {
+                        "dynamicRegistration": true,
+                        "prepareSupport": true,
+                        "prepareSupportDefaultBehavior": 1,
+                        "honorsChangeAnnotations": true
+                     },
+                     "documentLink": {
+                        "dynamicRegistration": true,
+                        "tooltipSupport": true
+                     },
+                     "typeDefinition": {
+                        "dynamicRegistration": true,
+                        "linkSupport": true
+                     },
+                     "implementation": {
+                        "dynamicRegistration": true,
+                        "linkSupport": true
+                     },
+                     "colorProvider": {
+                        "dynamicRegistration": true
+                     },
+                     "foldingRange": {
+                        "dynamicRegistration": true,
+                        "rangeLimit": 5000,
+                        "lineFoldingOnly": true
+                     },
+                     "declaration": {
+                        "dynamicRegistration": true,
+                        "linkSupport": true
+                     },
+                     "selectionRange": {
+                        "dynamicRegistration": true
+                     },
+                     "callHierarchy": {
+                        "dynamicRegistration": true
+                     },
+                     "linkedEditingRange": {
+                        "dynamicRegistration": true
+                     }
+                  },
+                  "window": {
+                     "showMessage": {
+                        "messageActionItem": {
+                           "additionalPropertiesSupport": true
+                        }
+                     },
+                     "showDocument": {
+                        "support": true
+                     },
+                     "workDoneProgress": true
+                  },
+                  "general": {
+                     "regularExpressions": {
+                        "engine": "ECMAScript",
+                        "version": "ES2020"
+                     },
+                     "markdown": {
+                        "parser": "marked",
+                        "version": "1.1.0"
+                     }
+                  }
+               },
+               "trace": "off",
+               "workspaceFolders": null
+            }
+         },
+         "wait": [
+            {
+               "id": 0,
+               "result": {
+                  "capabilities": {
+                     "textDocumentSync": 2,
+                     "completionProvider": {
+                        "triggerCharacters": [
+                           ".",
+                           "("
+                        ],
+                        "resolveProvider": false
+                     },
+                     "hoverProvider": true,
+                     "signatureHelpProvider": {
+                        "triggerCharacters": [
+                           ",",
+                           "("
+                        ],
+                        "retriggerCharacters": [
+                           " "
+                        ]
+                     },
+                     "declarationProvider": true,
+                     "definitionProvider": true,
+                     "typeDefinitionProvider": true,
+                     "implementationProvider": true,
+                     "referencesProvider": true,
+                     "documentHighlightProvider": true,
+                     "documentSymbolProvider": {},
+                     "codeActionProvider": {
+                        "codeActionKinds": [
+                           "refactor.rewrite"
+                        ]
+                     },
+                     "documentFormattingProvider": true,
+                     "renameProvider": {
+                        "prepareProvider": true
+                     },
+                     "foldingRangeProvider": true,
+                     "executeCommandProvider": {
+                        "commands": [
+                           "als-other-file",
+                           "als-named-parameters",
+                           "als-refactor-imports",
+                           "als-refactor-remove-parameters",
+                           "als-refactor-move-parameter",
+                           "als-refactor-change-parameter-mode",
+                           "als-suppress-separate"
+                        ]
+                     },
+                     "workspaceSymbolProvider": true,
+                     "callHierarchyProvider": {},
+                     "alsCalledByProvider": true,
+                     "alsCallsProvider": true,
+                     "alsShowDepsProvider": true,
+                     "alsReferenceKinds": [
+                        "reference",
+                        "access",
+                        "write",
+                        "call",
+                        "dispatching call",
+                        "parent",
+                        "child"
+                     ]
+                  }
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "initialized",
+            "params": {}
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "workspace/didChangeConfiguration",
+            "params": {
+               "settings": {
+                  "ada": {
+                     "trace": {
+                        "server": "off"
+                     },
+                     "projectFile": "",
+                     "scenarioVariables": {},
+                     "defaultCharset": "iso-8859-1",
+                     "displayMethodAncestryOnNavigation": "usage_and_abstract_only",
+                     "enableDiagnostics": true,
+                     "renameInComments": false
+                  }
+               }
+            }
+         },
+         "wait": [            {
+            "id": 2,
+            "method": "client/registerCapability",
+            "params": {
+               "registrations": [
+                  {
+                     "id": "rf",
+                     "method": "textDocument/rangeFormatting",
+                     "registerOptions": {
+                        "documentSelector": [
+                           "ada"
+                        ]
+                     }
+                  }
+               ]
+            }
+         }
+         ]
+      }
+   },
+   { "comment": "------------------ send text for the file -------------------------------"},
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{otherdir/a.ads}",
+                  "languageId": "ada",
+                  "version": 1,
+                  "text": "package A is\n   procedure Foo (X : Integer);\n   --  Doc for Foo\n   procedure Bar (X : Integer);\n   --  Doc for Bar;\nend A;"
+               }
+            }
+         },
+         "wait": [
+         ]
+      }
+   },
+   { "comment": "------------------ insert two blank lines -------------------------------"},
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{otherdir/a.ads}",
+                  "version": 2
+               },
+               "contentChanges": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 0,
+                           "character": 0
+                        },
+                        "end": {
+                           "line": 0,
+                           "character": 0
+                        }
+                     },
+                     "rangeLength": 0,
+                     "text": "\n"
+                  }
+               ]
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{otherdir/a.ads}",
+                  "version": 3
+               },
+               "contentChanges": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 1,
+                           "character": 0
+                        },
+                        "end": {
+                           "line": 1,
+                           "character": 0
+                        }
+                     },
+                     "rangeLength": 0,
+                     "text": "\n"
+                  }
+               ]
+            }
+         },
+         "wait": []
+      }
+   },
+   { "comment": "------------------ use a hover to verify that changes have been applied -------------------------------"},
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": 7,
+            "method": "textDocument/hover",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{otherdir/a.ads}"
+               },
+               "position": {
+                  "line": 3,
+                  "character": 14
+               }
+            }
+         },
+         "wait": [
+            {
+               "id": 7,
+               "result": {
+                  "contents": [
+                     {
+                        "language": "ada",
+                        "value": "procedure Foo (X : Integer)"
+                     },
+                     "at a.ads (4:4)",
+                     "Doc for Foo"
+                  ]
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": 8,
+            "method": "shutdown"
+         },
+         "wait": [
+            {
+               "id": 8,
+               "result": null
+            }
+         ]
+      }
+   },
+   {
+      "stop": {
+         "exit_code": 0
+      }
+   }
+]

--- a/testsuite/ada_lsp/U614-038.edits.no_project/test.yaml
+++ b/testsuite/ada_lsp/U614-038.edits.no_project/test.yaml
@@ -1,0 +1,1 @@
+title: 'U614-038.edits.no_project'


### PR DESCRIPTION
The modification for files are applied only in the contexts
where the files belong. When there is no project loaded and
the file is in a separate directory, no context accepts this
file, and the modifications are not taken into account.

Fix this by making the "fallback" context accept all
files.