### PR TITLE
Make ALS generate `"documentSymbolProvider":true`

### DIFF
--- a/source/protocol/lsp-generic_optional.adb
+++ b/source/protocol/lsp-generic_optional.adb
@@ -67,7 +67,13 @@ package body LSP.Generic_Optional is
         LSP.JSON_Streams.JSON_Stream'Class (S.all);
    begin
       if V.Is_Set then
-         Element_Type'Write (S, V.Value);
+         if Write_Default_As_True
+           and then V = (Is_Set => True, Value => <>)
+         then
+            JS.Write_Boolean (True);
+         else
+            Element_Type'Write (S, V.Value);
+         end if;
       elsif Write_Unset_As_Null then
          JS.Write_Null;
       end if;

--- a/source/protocol/lsp-generic_optional.ads
+++ b/source/protocol/lsp-generic_optional.ads
@@ -26,6 +26,10 @@ generic
    --  Some TypeScript types are expressed as  `TypeX | null`. Set this to
    --  True to represent such types as an optional type. The `Write` procedure
    --  will encode unset value as `null` JSON value.
+   Write_Default_As_True : Boolean := False;
+   --  Some TypeScript optional properties are expressed as `TypeX | boolean`.
+   --  Set this to True to represent such types as an optional type. The
+   --  `Write` procedure will encode default value as `true` JSON value.
 package LSP.Generic_Optional is
 
    type Optional_Type (Is_Set : Boolean := False) is record

--- a/source/protocol/lsp-messages.ads
+++ b/source/protocol/lsp-messages.ads
@@ -5265,7 +5265,10 @@ package LSP.Messages is
    for DocumentSymbolOptions'Write use Write_DocumentSymbolOptions;
 
    package Optional_DocumentSymbolOptions_Package is
-     new LSP.Generic_Optional (DocumentSymbolOptions);
+     new LSP.Generic_Optional
+       (Element_Type          => DocumentSymbolOptions,
+        Write_Default_As_True => True);
+   --  LSP4J 0.10 expects documentSymbolProvider to be boolean.
 
    type Optional_DocumentSymbolOptions is
      new Optional_DocumentSymbolOptions_Package.Optional_Type;

--- a/testsuite/ada_lsp/0003-get_symbols/0003-get_symbols.json
+++ b/testsuite/ada_lsp/0003-get_symbols/0003-get_symbols.json
@@ -14,7 +14,7 @@
                       "result":{
                           "capabilities":{
                               "textDocumentSync": 2,
-                              "documentSymbolProvider":{}
+                              "documentSymbolProvider":true
                           }
                       }
             }]

--- a/testsuite/ada_lsp/C825-005.xrefs.extending/test.json
+++ b/testsuite/ada_lsp/C825-005.xrefs.extending/test.json
@@ -45,7 +45,7 @@
                         ],
                         "resolveProvider": false
                      },
-                     "documentSymbolProvider": {}
+                     "documentSymbolProvider": true
                   }
                }
             }

--- a/testsuite/ada_lsp/D301-004.xrefs.generics/test.json
+++ b/testsuite/ada_lsp/D301-004.xrefs.generics/test.json
@@ -45,7 +45,7 @@
                         ],
                         "resolveProvider": false
                      },
-                     "documentSymbolProvider": {}
+                     "documentSymbolProvider": true
                   }
                }
             }

--- a/testsuite/ada_lsp/D803-003.xrefs.generics_go_to_body/test.json
+++ b/testsuite/ada_lsp/D803-003.xrefs.generics_go_to_body/test.json
@@ -45,7 +45,7 @@
                         ],
                         "resolveProvider": false
                      },
-                     "documentSymbolProvider": {}
+                     "documentSymbolProvider": true
                   }
                }
             }

--- a/testsuite/ada_lsp/F131-024.xrefs.separate_body/test.json
+++ b/testsuite/ada_lsp/F131-024.xrefs.separate_body/test.json
@@ -52,7 +52,7 @@
                         ],
                         "resolveProvider": false
                      },
-                     "documentSymbolProvider": {}
+                     "documentSymbolProvider": true
                   }
                }
             }

--- a/testsuite/ada_lsp/F222-029.xrefs.prefixed_notation/test.json
+++ b/testsuite/ada_lsp/F222-029.xrefs.prefixed_notation/test.json
@@ -45,7 +45,7 @@
                         ],
                         "resolveProvider": false
                      },
-                     "documentSymbolProvider": {}
+                     "documentSymbolProvider": true
                   }
                }
             }

--- a/testsuite/ada_lsp/G323-009.tooltips.function_prototype/test.json
+++ b/testsuite/ada_lsp/G323-009.tooltips.function_prototype/test.json
@@ -52,7 +52,7 @@
                         ],
                         "resolveProvider": false
                      },
-                     "documentSymbolProvider": {}
+                     "documentSymbolProvider": true
                   }
                }
             }

--- a/testsuite/ada_lsp/JB24-033.xrefs.no_refs_for_non_loaded_projects/test.json
+++ b/testsuite/ada_lsp/JB24-033.xrefs.no_refs_for_non_loaded_projects/test.json
@@ -45,7 +45,7 @@
                         ],
                         "resolveProvider": false
                      },
-                     "documentSymbolProvider": {}
+                     "documentSymbolProvider": true
                   }
                }
             }

--- a/testsuite/ada_lsp/O208-003.xrefs.aggregate_library_projects/test.json
+++ b/testsuite/ada_lsp/O208-003.xrefs.aggregate_library_projects/test.json
@@ -45,7 +45,7 @@
                         ],
                         "resolveProvider": false
                      },
-                     "documentSymbolProvider": {}
+                     "documentSymbolProvider": true
                   }
                }
             }

--- a/testsuite/ada_lsp/P107-003.refactoring.underscores/test.json
+++ b/testsuite/ada_lsp/P107-003.refactoring.underscores/test.json
@@ -45,7 +45,7 @@
                         ],
                         "resolveProvider": false
                      },
-                     "documentSymbolProvider": {}
+                     "documentSymbolProvider": true
                   }
                }
             }

--- a/testsuite/ada_lsp/P429-023.refactoring.rename_clauses/test.json
+++ b/testsuite/ada_lsp/P429-023.refactoring.rename_clauses/test.json
@@ -45,7 +45,7 @@
                         ],
                         "resolveProvider": false
                      },
-                     "documentSymbolProvider": {}
+                     "documentSymbolProvider": true
                   }
                }
             }

--- a/testsuite/ada_lsp/QB01-002.xrefs.non_ascii_documentation/test.json
+++ b/testsuite/ada_lsp/QB01-002.xrefs.non_ascii_documentation/test.json
@@ -45,7 +45,7 @@
                         ],
                         "resolveProvider": false
                      },
-                     "documentSymbolProvider": {}
+                     "documentSymbolProvider": true
                   }
                }
             }

--- a/testsuite/ada_lsp/S312-063.documentSymbol.constant/test.json
+++ b/testsuite/ada_lsp/S312-063.documentSymbol.constant/test.json
@@ -32,7 +32,7 @@
                     "result":{
                         "capabilities":{
                           "textDocumentSync": 2,
-                           "documentSymbolProvider":{}
+                           "documentSymbolProvider":true
                         }
                     }
           }]

--- a/testsuite/ada_lsp/S820-016.called_by.entry/test.json
+++ b/testsuite/ada_lsp/S820-016.called_by.entry/test.json
@@ -93,7 +93,7 @@
                      "implementationProvider": true,
                      "referencesProvider": true,
                      "documentHighlightProvider": true,
-                     "documentSymbolProvider": {},
+                     "documentSymbolProvider": true,
                      "codeActionProvider": {},
                      "documentFormattingProvider": true,
                      "renameProvider": {},

--- a/testsuite/ada_lsp/SA11-040.definition.fallback/test.json
+++ b/testsuite/ada_lsp/SA11-040.definition.fallback/test.json
@@ -51,7 +51,7 @@
                         ],
                         "resolveProvider": false
                      },
-                     "documentSymbolProvider": {}
+                     "documentSymbolProvider": true
                   }
                }
             }

--- a/testsuite/ada_lsp/SA21-029.documentSymbol.function/test.json
+++ b/testsuite/ada_lsp/SA21-029.documentSymbol.function/test.json
@@ -28,7 +28,7 @@
                       "result":{
                           "capabilities":{
                               "textDocumentSync": 2,
-                              "documentSymbolProvider":{}
+                              "documentSymbolProvider":true
                           }
                       }
             }]

--- a/testsuite/ada_lsp/SA21-029.documentSymbol.with/test.json
+++ b/testsuite/ada_lsp/SA21-029.documentSymbol.with/test.json
@@ -29,7 +29,7 @@
                       "result":{
                           "capabilities":{
                               "textDocumentSync": 2,
-                              "documentSymbolProvider":{}
+                              "documentSymbolProvider":true
                           }
                       }
             }]

--- a/testsuite/ada_lsp/SA22-029.rename_in_comments/test.json
+++ b/testsuite/ada_lsp/SA22-029.rename_in_comments/test.json
@@ -51,7 +51,7 @@
                         ],
                         "resolveProvider": false
                      },
-                     "documentSymbolProvider": {}
+                     "documentSymbolProvider": true
                   }
                }
             }

--- a/testsuite/ada_lsp/SA24-055.called_by_on_abstract/test.json
+++ b/testsuite/ada_lsp/SA24-055.called_by_on_abstract/test.json
@@ -93,7 +93,7 @@
                      "implementationProvider": true,
                      "referencesProvider": true,
                      "documentHighlightProvider": true,
-                     "documentSymbolProvider": {},
+                     "documentSymbolProvider": true,
                      "codeActionProvider": {},
                      "documentFormattingProvider": true,
                      "renameProvider": {},

--- a/testsuite/ada_lsp/SB14-027.references.tagged_access_kind/test.json
+++ b/testsuite/ada_lsp/SB14-027.references.tagged_access_kind/test.json
@@ -72,7 +72,7 @@
                         ],
                         "resolveProvider": false
                      },
-                     "documentSymbolProvider": {}
+                     "documentSymbolProvider": true
                   }
                }
             }

--- a/testsuite/ada_lsp/SB14-037.references.access_kind/test.json
+++ b/testsuite/ada_lsp/SB14-037.references.access_kind/test.json
@@ -72,7 +72,7 @@
                         ],
                         "resolveProvider": false
                      },
-                     "documentSymbolProvider": {}
+                     "documentSymbolProvider": true
                   }
                }
             }

--- a/testsuite/ada_lsp/SB21-042.tooltips.aspects/test.json
+++ b/testsuite/ada_lsp/SB21-042.tooltips.aspects/test.json
@@ -51,7 +51,7 @@
                         ],
                         "resolveProvider": false
                      },
-                     "documentSymbolProvider": {}
+                     "documentSymbolProvider": true
                   }
                }
             }

--- a/testsuite/ada_lsp/SC16-095.fallback_when_no_body/test.json
+++ b/testsuite/ada_lsp/SC16-095.fallback_when_no_body/test.json
@@ -70,7 +70,7 @@
                         ],
                         "resolveProvider": false
                      },
-                     "documentSymbolProvider": {}
+                     "documentSymbolProvider": true
                   }
                }
             }

--- a/testsuite/ada_lsp/T123-048.incremental_editing/test.json
+++ b/testsuite/ada_lsp/T123-048.incremental_editing/test.json
@@ -287,7 +287,7 @@
                         ],
                         "resolveProvider": false
                      },
-                     "documentSymbolProvider": {}
+                     "documentSymbolProvider": true
                   }
                }
             }

--- a/testsuite/ada_lsp/T709-018.is_called_by.name_collision/test.json
+++ b/testsuite/ada_lsp/T709-018.is_called_by.name_collision/test.json
@@ -96,7 +96,7 @@
                      "implementationProvider": true,
                      "referencesProvider": true,
                      "documentHighlightProvider": true,
-                     "documentSymbolProvider": {},
+                     "documentSymbolProvider": true,
                      "codeActionProvider": {},
                      "documentFormattingProvider": true,
                      "renameProvider": {},

--- a/testsuite/ada_lsp/T827-018.documentSymbol.pragma/test.json
+++ b/testsuite/ada_lsp/T827-018.documentSymbol.pragma/test.json
@@ -32,7 +32,7 @@
                     "result":{
                         "capabilities":{
                           "textDocumentSync": 2,
-                           "documentSymbolProvider":{}
+                           "documentSymbolProvider":true
                         }
                     }
           }]

--- a/testsuite/ada_lsp/aggregate.is_called_by/test.json
+++ b/testsuite/ada_lsp/aggregate.is_called_by/test.json
@@ -94,7 +94,7 @@
                      "implementationProvider": true,
                      "referencesProvider": true,
                      "documentHighlightProvider": true,
-                     "documentSymbolProvider": {},
+                     "documentSymbolProvider": true,
                      "codeActionProvider": {},
                      "documentFormattingProvider": true,
                      "renameProvider": {},

--- a/testsuite/ada_lsp/aggregate.references_after_update/test.json
+++ b/testsuite/ada_lsp/aggregate.references_after_update/test.json
@@ -70,7 +70,7 @@
                         ],
                         "resolveProvider": false
                      },
-                     "documentSymbolProvider": {}
+                     "documentSymbolProvider": true
                   }
                }
             }

--- a/testsuite/ada_lsp/aggregate.simple/test.json
+++ b/testsuite/ada_lsp/aggregate.simple/test.json
@@ -51,7 +51,7 @@
                         ],
                         "resolveProvider": false
                      },
-                     "documentSymbolProvider": {}
+                     "documentSymbolProvider": true
                   }
                }
             }]

--- a/testsuite/ada_lsp/callHierarchy.abstract_subps/test.json
+++ b/testsuite/ada_lsp/callHierarchy.abstract_subps/test.json
@@ -93,7 +93,7 @@
                      "implementationProvider": true,
                      "referencesProvider": true,
                      "documentHighlightProvider": true,
-                     "documentSymbolProvider": {},
+                     "documentSymbolProvider": true,
                      "codeActionProvider": {},
                      "documentFormattingProvider": true,
                      "renameProvider": {},

--- a/testsuite/ada_lsp/called_by.null_subp/test.json
+++ b/testsuite/ada_lsp/called_by.null_subp/test.json
@@ -93,7 +93,7 @@
                      "implementationProvider": true,
                      "referencesProvider": true,
                      "documentHighlightProvider": true,
-                     "documentSymbolProvider": {},
+                     "documentSymbolProvider": true,
                      "codeActionProvider": {},
                      "documentFormattingProvider": true,
                      "renameProvider": {},

--- a/testsuite/ada_lsp/called_by.renames/test.json
+++ b/testsuite/ada_lsp/called_by.renames/test.json
@@ -93,7 +93,7 @@
                      "implementationProvider": true,
                      "referencesProvider": true,
                      "documentHighlightProvider": true,
-                     "documentSymbolProvider": {},
+                     "documentSymbolProvider": true,
                      "codeActionProvider": {},
                      "documentFormattingProvider": true,
                      "renameProvider": {},

--- a/testsuite/ada_lsp/called_by/test.json
+++ b/testsuite/ada_lsp/called_by/test.json
@@ -93,7 +93,7 @@
                      "implementationProvider": true,
                      "referencesProvider": true,
                      "documentHighlightProvider": true,
-                     "documentSymbolProvider": {},
+                     "documentSymbolProvider": true,
                      "codeActionProvider": {},
                      "documentFormattingProvider": true,
                      "renameProvider": {},

--- a/testsuite/ada_lsp/called_by_dispatching/test.json
+++ b/testsuite/ada_lsp/called_by_dispatching/test.json
@@ -93,7 +93,7 @@
                      "implementationProvider": true,
                      "referencesProvider": true,
                      "documentHighlightProvider": true,
-                     "documentSymbolProvider": {},
+                     "documentSymbolProvider": true,
                      "codeActionProvider": {},
                      "documentFormattingProvider": true,
                      "renameProvider": {},

--- a/testsuite/ada_lsp/called_by_not_open/test.json
+++ b/testsuite/ada_lsp/called_by_not_open/test.json
@@ -93,7 +93,7 @@
                      "implementationProvider": true,
                      "referencesProvider": true,
                      "documentHighlightProvider": true,
-                     "documentSymbolProvider": {},
+                     "documentSymbolProvider": true,
                      "codeActionProvider": {},
                      "documentFormattingProvider": true,
                      "renameProvider": {},

--- a/testsuite/ada_lsp/callgraph.named_blocks/test.json
+++ b/testsuite/ada_lsp/callgraph.named_blocks/test.json
@@ -93,7 +93,7 @@
                      "implementationProvider": true,
                      "referencesProvider": true,
                      "documentHighlightProvider": true,
-                     "documentSymbolProvider": {},
+                     "documentSymbolProvider": true,
                      "codeActionProvider": {},
                      "documentFormattingProvider": true,
                      "renameProvider": {},

--- a/testsuite/ada_lsp/calls/test.json
+++ b/testsuite/ada_lsp/calls/test.json
@@ -93,7 +93,7 @@
                      "implementationProvider": true,
                      "referencesProvider": true,
                      "documentHighlightProvider": true,
-                     "documentSymbolProvider": {},
+                     "documentSymbolProvider": true,
                      "codeActionProvider": {},
                      "documentFormattingProvider": true,
                      "renameProvider": {},

--- a/testsuite/ada_lsp/definition_and_overridings/test.json
+++ b/testsuite/ada_lsp/definition_and_overridings/test.json
@@ -70,7 +70,7 @@
                         ],
                         "resolveProvider": false
                      },
-                     "documentSymbolProvider": {}
+                     "documentSymbolProvider": true
                   }
                }
             }

--- a/testsuite/ada_lsp/definition_parents/test.json
+++ b/testsuite/ada_lsp/definition_parents/test.json
@@ -72,7 +72,7 @@
                         ],
                         "resolveProvider": false
                      },
-                     "documentSymbolProvider": {}
+                     "documentSymbolProvider": true
                   }
                }
             }

--- a/testsuite/ada_lsp/editor.incremental/test.json
+++ b/testsuite/ada_lsp/editor.incremental/test.json
@@ -287,7 +287,7 @@
                         ],
                         "resolveProvider": false
                      },
-                     "documentSymbolProvider": {}
+                     "documentSymbolProvider": true
                   }
                }
             }

--- a/testsuite/ada_lsp/find_all_refs_child_package/test.json
+++ b/testsuite/ada_lsp/find_all_refs_child_package/test.json
@@ -72,7 +72,7 @@
                         ],
                         "resolveProvider": false
                      },
-                     "documentSymbolProvider": {}
+                     "documentSymbolProvider": true
                   }
                }
             }

--- a/testsuite/ada_lsp/get_symbol_hier/test.json
+++ b/testsuite/ada_lsp/get_symbol_hier/test.json
@@ -29,7 +29,7 @@
                       "result":{
                           "capabilities":{
                               "textDocumentSync": 2,
-                              "documentSymbolProvider":{}
+                              "documentSymbolProvider":true
                           }
                       }
             }]

--- a/testsuite/ada_lsp/implementation.aggregates/test.json
+++ b/testsuite/ada_lsp/implementation.aggregates/test.json
@@ -73,7 +73,7 @@
                         ],
                         "resolveProvider": false
                      },
-                     "documentSymbolProvider": {}
+                     "documentSymbolProvider": true
                   }
                }
             }

--- a/testsuite/ada_lsp/implementation.overridings/test.json
+++ b/testsuite/ada_lsp/implementation.overridings/test.json
@@ -73,7 +73,7 @@
                         ],
                         "resolveProvider": false
                      },
-                     "documentSymbolProvider": {}
+                     "documentSymbolProvider": true
                   }
                }
             }

--- a/testsuite/ada_lsp/implementation/test.json
+++ b/testsuite/ada_lsp/implementation/test.json
@@ -73,7 +73,7 @@
                         ],
                         "resolveProvider": false
                      },
-                     "documentSymbolProvider": {}
+                     "documentSymbolProvider": true
                   }
                }
             }

--- a/testsuite/ada_lsp/indexing_progress/test.json
+++ b/testsuite/ada_lsp/indexing_progress/test.json
@@ -51,7 +51,7 @@
                         ],
                         "resolveProvider": false
                      },
-                     "documentSymbolProvider": {}
+                     "documentSymbolProvider": true
                   }
                }
             }

--- a/testsuite/ada_lsp/invalidation.file_contents/test.json
+++ b/testsuite/ada_lsp/invalidation.file_contents/test.json
@@ -45,7 +45,7 @@
                         ],
                         "resolveProvider": false
                      },
-                     "documentSymbolProvider": {}
+                     "documentSymbolProvider": true
                   }
                }
             }

--- a/testsuite/ada_lsp/preprocessor/test.json
+++ b/testsuite/ada_lsp/preprocessor/test.json
@@ -91,7 +91,7 @@
                      "implementationProvider": true,
                      "referencesProvider": true,
                      "documentHighlightProvider": true,
-                     "documentSymbolProvider": {},
+                     "documentSymbolProvider": true,
                      "codeActionProvider": {},
                      "documentFormattingProvider": true,
                      "renameProvider": {},

--- a/testsuite/ada_lsp/references.child/test.json
+++ b/testsuite/ada_lsp/references.child/test.json
@@ -74,7 +74,7 @@
                         ],
                         "resolveProvider": false
                      },
-                     "documentSymbolProvider": {}
+                     "documentSymbolProvider": true
                   }
                }
             }

--- a/testsuite/ada_lsp/rename.not_up_to_date/test.json
+++ b/testsuite/ada_lsp/rename.not_up_to_date/test.json
@@ -45,7 +45,7 @@
                         ],
                         "resolveProvider": false
                      },
-                     "documentSymbolProvider": {}
+                     "documentSymbolProvider": true
                   }
                }
             }

--- a/testsuite/ada_lsp/rename.primitive_parameters/test.json
+++ b/testsuite/ada_lsp/rename.primitive_parameters/test.json
@@ -76,7 +76,7 @@
                         ],
                         "resolveProvider": false
                      },
-                     "documentSymbolProvider": {}
+                     "documentSymbolProvider": true
                   }
                }
             }

--- a/testsuite/ada_lsp/rename.tagged_type_primitives/test.json
+++ b/testsuite/ada_lsp/rename.tagged_type_primitives/test.json
@@ -75,7 +75,7 @@
                         ],
                         "resolveProvider": false
                      },
-                     "documentSymbolProvider": {}
+                     "documentSymbolProvider": true
                   }
                }
             }

--- a/testsuite/ada_lsp/show_dependencies.aggregate/test.json
+++ b/testsuite/ada_lsp/show_dependencies.aggregate/test.json
@@ -86,7 +86,7 @@
                           "typeDefinitionProvider": true,
                           "implementationProvider": true,
                           "referencesProvider": true,
-                          "documentSymbolProvider": {},
+                          "documentSymbolProvider": true,
                           "codeActionProvider": {
                           },
                           "documentFormattingProvider": true,

--- a/testsuite/ada_lsp/type_definition.aggregate/test.json
+++ b/testsuite/ada_lsp/type_definition.aggregate/test.json
@@ -72,7 +72,7 @@
                         ],
                         "resolveProvider": false
                      },
-                     "documentSymbolProvider": {}
+                     "documentSymbolProvider": true
                   }
                }
             }


### PR DESCRIPTION
in `iitialize` response to fix an error in LSP4J 0.10. This
LSP4J expects a boolean value for documentSymbolProvider.