### PR TITLE
U622-019 Fix invisible symbol completion in open files

### DIFF
--- a/source/ada/lsp-ada_contexts.adb
+++ b/source/ada/lsp-ada_contexts.adb
@@ -486,13 +486,10 @@ package body LSP.Ada_Contexts is
          end;
    end Find_All_Env_Elements;
 
-   -------------------------------
-   -- Get_Any_Symbol_Completion --
-   -------------------------------
-
-   procedure Get_Any_Symbol_Completion
-     (Self   : Context;
-      Prefix : VSS.Strings.Virtual_String;
+   procedure Get_Any_Symbol
+     (Self        : Context;
+      Prefix      : VSS.Strings.Virtual_String;
+      Only_Public : Boolean;
       Callback : not null access procedure
         (File : GNATCOLL.VFS.Virtual_File;
          Name : Libadalang.Analysis.Defining_Name;
@@ -531,8 +528,8 @@ package body LSP.Ada_Contexts is
       end Adapter;
 
    begin
-      Self.Source_Files.Get_Any_Symbol_Completion (Prefix, Adapter'Access);
-   end Get_Any_Symbol_Completion;
+      Self.Source_Files.Get_Any_Symbol (Prefix, Only_Public, Adapter'Access);
+   end Get_Any_Symbol;
 
    -----------------
    -- Get_Charset --

--- a/source/ada/lsp-ada_contexts.ads
+++ b/source/ada/lsp-ada_contexts.ads
@@ -222,16 +222,18 @@ package LSP.Ada_Contexts is
      (Self : Context) return Libadalang.Analysis.Analysis_Context;
    --  Return the LAL context corresponding to Self
 
-   procedure Get_Any_Symbol_Completion
-     (Self   : Context;
-      Prefix : VSS.Strings.Virtual_String;
+   procedure Get_Any_Symbol
+     (Self        : Context;
+      Prefix      : VSS.Strings.Virtual_String;
+      Only_Public : Boolean;
       Callback : not null access procedure
         (File : GNATCOLL.VFS.Virtual_File;
          Name : Libadalang.Analysis.Defining_Name;
          Stop : in out Boolean));
    --  Find symbols starting with given Prefix in all files of the context and
    --  call Callback for each. Name could contain a stale reference if the File
-   --  was updated since last indexing operation.
+   --  was updated since last indexing operation. If Only_Public is True it
+   --  will skip any "private" symbols (like symbols in private part or body).
 
    function Charset (Self : Context) return String;
    --  Return the charset for this context

--- a/source/ada/lsp-ada_documents.ads
+++ b/source/ada/lsp-ada_documents.ads
@@ -134,13 +134,14 @@ package LSP.Ada_Documents is
    --  document. Names works for defining name completions to create snippets
    --  and to avoid duplicates.
 
-   procedure Get_Any_Symbol_Completion
-     (Self    : in out Document;
-      Context : LSP.Ada_Contexts.Context;
-      Prefix  : VSS.Strings.Virtual_String;
-      Limit   : Ada.Containers.Count_Type;
+   procedure Get_Any_Symbol
+     (Self        : in out Document;
+      Context     : LSP.Ada_Contexts.Context;
+      Prefix      : VSS.Strings.Virtual_String;
+      Limit       : Ada.Containers.Count_Type;
+      Only_Public : Boolean;
       Result  : in out LSP.Ada_Completions.Completion_Maps.Map);
-   --  See Contexts.Get_Any_Symbol_Completion
+   --  See Contexts.Get_Any_Symbol
 
    procedure Get_Folding_Blocks
      (Self       : Document;
@@ -254,8 +255,13 @@ private
       Element_Type => VSS.Strings.Markers.Character_Marker,
       "="          => VSS.Strings.Markers."=");
 
+   type Name_Information is record
+      Name      : Libadalang.Analysis.Defining_Name;
+      Is_Public : Boolean;
+   end record;
+
    package Name_Vectors is new Ada.Containers.Vectors
-     (Positive, Libadalang.Analysis.Defining_Name, Libadalang.Analysis."=");
+     (Positive, Name_Information);
 
    package Symbol_Maps is new Ada.Containers.Ordered_Maps
      (Key_Type     => VSS.Strings.Virtual_String,

--- a/source/ada/lsp-ada_file_sets.ads
+++ b/source/ada/lsp-ada_file_sets.ads
@@ -61,21 +61,24 @@ package LSP.Ada_File_Sets is
    --  index. After that names could be fetched using Get_Any_Symbol_Completion
    --  function.
 
-   procedure Get_Any_Symbol_Completion
-     (Self     : Indexed_File_Set'Class;
-      Prefix   : VSS.Strings.Virtual_String;
+   procedure Get_Any_Symbol
+     (Self        : Indexed_File_Set'Class;
+      Prefix      : VSS.Strings.Virtual_String;
+      Only_Public : Boolean;
       Callback : not null access procedure
         (File : GNATCOLL.VFS.Virtual_File;
          Loc  : Langkit_Support.Slocs.Source_Location;
          Stop : in out Boolean));
    --  Find symbols starting with given Prefix in all files of the set and
    --  call Callback for each. Name could contain a stale reference if the File
-   --  was updated since last indexing operation.
+   --  was updated since last indexing operation. If Only_Public is True it
+   --  will skip any "private" symbols (like symbols in private part or body).
 
 private
    type Name_Information is record
-      File : GNATCOLL.VFS.Virtual_File;
-      Loc  : Langkit_Support.Slocs.Source_Location;
+      File      : GNATCOLL.VFS.Virtual_File;
+      Loc       : Langkit_Support.Slocs.Source_Location;
+      Is_Public : Boolean;
    end record;
 
    package Name_Vectors is new Ada.Containers.Vectors

--- a/source/ada/lsp-ada_handlers-invisibles.adb
+++ b/source/ada/lsp-ada_handlers-invisibles.adb
@@ -123,13 +123,18 @@ package body LSP.Ada_Handlers.Invisibles is
 
       begin
          if not Word.Is_Empty then
-            Self.Context.Get_Any_Symbol_Completion
-              (Prefix   => Canonical_Prefix,
-               Callback => On_Inaccessible_Name'Access);
+            Self.Context.Get_Any_Symbol
+              (Prefix      => Canonical_Prefix,
+               Only_Public => True,
+               Callback    => On_Inaccessible_Name'Access);
 
             for Doc of Self.Handler.Open_Documents loop
-               Doc.Get_Any_Symbol_Completion
-                 (Self.Context.all, Canonical_Prefix, Limit, Names);
+               Doc.Get_Any_Symbol
+                 (Self.Context.all,
+                  Canonical_Prefix,
+                  Limit,
+                  True,
+                  Names);
             end loop;
          end if;
       end;

--- a/source/ada/lsp-ada_handlers.adb
+++ b/source/ada/lsp-ada_handlers.adb
@@ -3617,9 +3617,10 @@ package body LSP.Ada_Handlers is
 
    begin
       for Context of Self.Contexts.Each_Context loop
-         Context.Get_Any_Symbol_Completion
-           (Prefix   => Query,
-            Callback => On_Inaccessible_Name'Access);
+         Context.Get_Any_Symbol
+           (Prefix      => Query,
+            Only_Public => False,
+            Callback    => On_Inaccessible_Name'Access);
 
          exit when Request.Canceled;
       end loop;
@@ -3629,8 +3630,12 @@ package body LSP.Ada_Handlers is
             Context : constant Context_Access :=
               Self.Contexts.Get_Best_Context (Doc.URI);
          begin
-            Doc.Get_Any_Symbol_Completion
-              (Context.all, Query, Ada.Containers.Count_Type'Last, Names);
+            Doc.Get_Any_Symbol
+              (Context.all,
+               Query,
+               Ada.Containers.Count_Type'Last,
+               False,
+               Names);
          end;
       end loop;
 

--- a/source/ada/lsp-lal_utils.adb
+++ b/source/ada/lsp-lal_utils.adb
@@ -50,6 +50,28 @@ package body LSP.Lal_Utils is
        return Ada.Strings.Unbounded.Unbounded_String;
    --  Convert Input to unbounded string.
 
+   type Restricted_Kind_Predicate is
+     new Libadalang.Iterators.Ada_Node_Predicate_Interface with null record;
+   --  A custom node predicate to filter some declaration kinds.
+   --  See Is_Restricted_Kind for details.
+
+   overriding function Evaluate
+     (Ignore : in out Restricted_Kind_Predicate;
+      Node   : Libadalang.Analysis.Ada_Node) return Boolean;
+   --  Evaluate the Restricted_Kind_Predicate filter
+   --  See Is_Restricted_Kind for details.
+
+   type Is_Global_Visible_Predicate is
+     new Libadalang.Iterators.Ada_Node_Predicate_Interface with null record;
+   --  A custom node predicate to filter some declaration kinds.
+   --  See Is_Restricted_Kind for details.
+
+   overriding function Evaluate
+     (Ignore : in out Is_Global_Visible_Predicate;
+      Node   : Libadalang.Analysis.Ada_Node) return Boolean;
+   --  Evaluate the Restricted_Kind_Predicate filter
+   --  See Is_Restricted_Kind for details.
+
    ---------------------
    -- Append_Location --
    ---------------------
@@ -1386,5 +1408,102 @@ package body LSP.Lal_Utils is
       Langkit_Support.Token_Data_Handlers.Free (TDH);
       Langkit_Support.Symbols.Destroy (Symbols);
    end Format_Vector;
+
+   --------------
+   -- Evaluate --
+   --------------
+
+   overriding function Evaluate
+     (Ignore : in out Restricted_Kind_Predicate;
+      Node   : Libadalang.Analysis.Ada_Node) return Boolean
+   is
+      Decl : constant Libadalang.Analysis.Basic_Decl :=
+        Node.As_Defining_Name.P_Basic_Decl;
+      Next : Libadalang.Analysis.Ada_Node := Decl.Parent;
+   begin
+      if not Decl.Is_Null and then
+        Decl.Kind in Libadalang.Common.Ada_For_Loop_Var_Decl
+          | Libadalang.Common.Ada_Base_Formal_Param_Decl
+          | Libadalang.Common.Ada_Extended_Return_Stmt_Object_Decl
+          | Libadalang.Common.Ada_Anonymous_Expr_Decl
+          | Libadalang.Common.Ada_Exception_Handler
+          | Libadalang.Common.Ada_Label_Decl
+          | Libadalang.Common.Ada_Named_Stmt_Decl
+          | Libadalang.Common.Ada_Entry_Index_Spec
+          | Libadalang.Common.Ada_Entry_Decl
+      then
+         return True;
+      elsif not Decl.Is_Null and then
+        Decl.Kind in Libadalang.Common.Ada_Object_Decl and then
+        Decl.Parent.Kind = Libadalang.Common.Ada_Generic_Formal_Obj_Decl
+      then
+         --  This is a special case for the formal_object_declaration
+         return True;
+      end if;
+
+      while not Next.Is_Null loop
+         if Next.Kind in Libadalang.Common.Ada_Body_Node and then
+           not (Next.Parent.Kind in Libadalang.Common.Ada_Package_Body and then
+                Next.Parent.Parent.Kind in Libadalang.Common.Ada_Library_Item)
+         then
+            return True;
+         end if;
+
+         Next := Next.Parent;
+      end loop;
+
+      return False;
+   end Evaluate;
+
+   --------------
+   -- Evaluate --
+   --------------
+
+   overriding function Evaluate
+     (Ignore : in out Is_Global_Visible_Predicate;
+      Node   : Libadalang.Analysis.Ada_Node) return Boolean
+   is
+      Decl : constant Libadalang.Analysis.Basic_Decl :=
+        Node.As_Defining_Name.P_Basic_Decl;
+      Next : Libadalang.Analysis.Ada_Node := Decl.Parent;
+   begin
+      while not Next.Is_Null loop
+         if Next.Kind in
+           Libadalang.Common.Ada_Body_Node
+           | Libadalang.Common.Ada_Private_Part
+           | Libadalang.Common.Ada_Protected_Type_Decl
+           | Libadalang.Common.Ada_Single_Protected_Decl
+         then
+            return False;
+         end if;
+
+         Next := Next.Parent;
+      end loop;
+
+      return True;
+   end Evaluate;
+
+   ------------------------
+   -- Is_Restricted_Kind --
+   ------------------------
+
+   function Is_Restricted_Kind
+     return Libadalang.Iterators.Ada_Node_Predicate is
+   begin
+      return Result : Libadalang.Iterators.Ada_Node_Predicate do
+         Result.Set (Restricted_Kind_Predicate'(null record));
+      end return;
+   end Is_Restricted_Kind;
+
+   -----------------------
+   -- Is_Global_Visible --
+   -----------------------
+
+   function Is_Global_Visible return Libadalang.Iterators.Ada_Node_Predicate is
+   begin
+      return Result : Libadalang.Iterators.Ada_Node_Predicate do
+         Result.Set (Is_Global_Visible_Predicate'(null record));
+      end return;
+   end Is_Global_Visible;
 
 end LSP.Lal_Utils;

--- a/source/ada/lsp-lal_utils.ads
+++ b/source/ada/lsp-lal_utils.ads
@@ -28,6 +28,7 @@ with Laltools.Refactor;
 
 with Libadalang.Analysis;  use Libadalang.Analysis;
 with Libadalang.Common;
+with Libadalang.Iterators;
 
 with Langkit_Support.Slocs;
 with Langkit_Support.Text;
@@ -253,5 +254,25 @@ package LSP.Lal_Utils is
      (Item : Langkit_Support.Text.Unbounded_Text_Type)
       return VSS.Strings.Virtual_String;
    --  Do string type conversion.
+
+   --  Global symbol index predicates.
+
+   function Is_Restricted_Kind return Libadalang.Iterators.Ada_Node_Predicate;
+   --  A node under query doesn't participate in global symbol index. It's a
+   --  defining name of a declaration such as
+   --  * a loop parameter specification
+   --  * parameter declaration
+   --  * discriminant/component declaration
+   --  * return object declaration
+   --  * entry/entry-index declaration
+   --  * formal parameter declaration
+   --  * etc
+   --  It also includes any symbols local to some non-package body.
+   --  These symbols isn't very useful in "invisible symbol completion" and
+   --  in "Go to workspace symbol" requests.
+
+   function Is_Global_Visible return Libadalang.Iterators.Ada_Node_Predicate;
+   --  A node under query is a defined name visible at a library level, such
+   --  as declaration in a public part of a library level project.
 
 end LSP.Lal_Utils;

--- a/testsuite/ada_lsp/completion.subp_parameters/test.json
+++ b/testsuite/ada_lsp/completion.subp_parameters/test.json
@@ -397,36 +397,6 @@
                            "documentation": "at main.adb (10:4)",
                            "additionalTextEdits": []
                         },
-                          {
-                              "label": "A (invisible)",
-                              "insertText": "A",
-                              "kind": 5,
-                              "detail": "A : Integer;",
-                              "documentation": "at bar.ads (4:7)",
-                              "sortText": "~A",
-                              "additionalTextEdits": [
-                            ]
-                          },
-                          {
-                              "label": "A (invisible)",
-                              "insertText": "A",
-                              "kind": 6,
-                              "detail": "A :Integer",
-                              "documentation": "at bar.ads (7:40)",
-                              "sortText": "~A",
-                              "additionalTextEdits": [
-                              ]
-                          },
-                          {
-                              "label": "A (invisible)",
-                              "insertText": "A",
-                              "kind": 6,
-                              "detail": "A, B : Integer",
-                              "documentation": "at main.adb (6:18)",
-                              "sortText": "~A",
-                              "additionalTextEdits": [
-                              ]
-                          },
                         {
                            "label": "ASCII",
                            "kind": 9,


### PR DESCRIPTION
Make completion return the same symbols as for non-open
files. To do this move Ada_Node predicates (filters) to
LSP.LAL_Utils and reuse them in lsp-ada_handlers-invisibles.adb
and in lsp-ada_file_sets.adb.

Return more symbols in "workspace symbols" request:
return symbols from package body and package private part
also. It could help navigation in some situations.

Fix the testcase.