### PR TITLE
[VS Code] Grammar: add `body` patterns to declare section

### DIFF
--- a/integration/vscode/ada/advanced/ada.tmLanguage.json
+++ b/integration/vscode/ada/advanced/ada.tmLanguage.json
@@ -395,6 +395,7 @@
 						"0": { "name": "keyword.ada" }
 					},
 					"patterns": [
+						{ "include": "#body" },
 						{ "include": "#basic_declarative_item" }
 					]
 				},
@@ -1423,7 +1424,7 @@
 					},
 					"end": "(?i)(?=(\\bbegin\\b|\\bend\\b))",
 					"patterns": [
-						{ 
+						{
 							"match": "(?i)\\bprivate\\b",
 							"name": "keyword.ada"
 						},
@@ -1476,7 +1477,7 @@
 								{ "include": "#actual_parameter_part" }
 							]
 						},
-						{ 
+						{
 							"match": "(?i)\\bprivate\\b",
 							"name": "keyword.ada"
 						},
@@ -1890,7 +1891,7 @@
 						"0": { "name": "keyword.ada" }
 					},
 					"patterns": [
-						
+
 						{ "include": "#type_definition" }
 					]
 				},


### PR DESCRIPTION
Syntax highlighting currently fails on the following program due to the task body being inside of the `declare` section
```
with Ada.Text_IO;

procedure Example is
begin
   declare
      task My_Task;
      task body My_Task is
      begin
         for i in 1 .. 5 loop
            Ada.Text_IO.Put_Line(i'Image);
         end loop;
      end My_Task;
   begin
      null;
   end;
end Example;
```

![image](https://user-images.githubusercontent.com/22167388/128629418-029ee9bb-9bdb-4810-b47b-8d9092417be0.png)


Fortunately, the TextMate grammar follows the [Ada grammar](https://www.adaic.org/resources/add_content/standards/05rm/html/RM-P.html) closely, so a fix is straightforward: insert the [`#body`](https://github.com/AdaCore/ada_language_server/blob/cab0a492ce38a907847f559cda1b43435d7e4187/integration/vscode/ada/advanced/ada.tmLanguage.json#L410) rule inside of the declare section of the [`#block_statement`](https://github.com/AdaCore/ada_language_server/blob/cab0a492ce38a907847f559cda1b43435d7e4187/integration/vscode/ada/advanced/ada.tmLanguage.json#L391-L400) rule.

The original `#basic_declarative_item` rule matches the following general constructs:
- 'task' 'type'
- 'task'
- 'subtype'
- \* ':' 'exception'
- \* ':'
- 'protected'
- 'task'
- 'procedure'
- 'function'
- 'package'
- 'pragma'
- 'for'
- 'use' 'type'
- 'use'
- (comment patterns)
- (keyword catch-all)

The added `#body` rule matches
- 'procedure'
- 'function'
- 'package' 'body'
- 'task' 'body'
- 'protected' 'body'

With the exception of 'procedure' and 'function', the `#body` rules are more specific (require `body` as the next word) and so won't conflict with any valid uses of the `#basic_declarative_item` rules.

For 'procedure' and 'function', the rules for these are shared by both `#body` and `#basic_declarative_item`, the latter indirectly through [`#subprogram_specification`](https://github.com/AdaCore/ada_language_server/blob/cab0a492ce38a907847f559cda1b43435d7e4187/integration/vscode/ada/advanced/ada.tmLanguage.json#L2231-L2237). This middle rule tries to add a `meta.declaration.subprogram.specification.ada` scope to the chain, but VS Code doesn't appear to do this (see below image). If `body` is added before `basic_declarative_item` (which it needs to be to avoid other rules grabbing `task` without checking for `body`) then this will never match in this context. However, as 
- TextMate struggles with scopes that depend on content potentially on later lines (needed to see if specification / body),
- it's not doing it's job anyway, and
- the current behaviour is catastrophically incorrect for a valid program (everything that follows is broken)
I would suggest the change is fine.

(current version: scope of `procedure Foo;` is missing `meta.declaration.subprogram.specification.ada`)
![image](https://user-images.githubusercontent.com/22167388/128628881-d444509f-b342-4739-b971-43296ab18b21.png)

(with fix)
![image](https://user-images.githubusercontent.com/22167388/128629527-1d785671-54c7-487e-92ee-213ac14c2ffe.png)
