### PR TITLE
T903-007: Remove dead link

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -40,8 +40,6 @@ This section includes related feature description documents and links to others
 related resources.
 
 ## List of features
- * [Called by](called_by.md)
- * [Calls](calls.md)
  * [Debug](debug.md)
  * [Other File](other_file.md)
  * [Reference kinds](reference_kinds.md)


### PR DESCRIPTION
Calls and Called_By are now implemented using the incomingCalls
and outgoingCalls request, the related documentation was removed
but not these links