### PR TITLE
U720-009: improve sorting for completionItems

### DIFF
--- a/source/ada/lsp-ada_completions-names.adb
+++ b/source/ada/lsp-ada_completions-names.adb
@@ -136,11 +136,9 @@ package body LSP.Ada_Completions.Names is
          BD                  : Basic_Decl;
          Completion_Count    : Natural := 0;
          Name                : VSS.Strings.Virtual_String;
-
       begin
          while Next (Raw_Completions, Item) loop
             BD := Decl (Item).As_Basic_Decl;
-            Completion_Count := Completion_Count + 1;
 
             if not BD.Is_Null then
                for DN of BD.P_Defining_Names loop
@@ -157,11 +155,14 @@ package body LSP.Ada_Completions.Names is
                        Prefix         => Prefix,
                        Case_Sensitive => False)
                   then
+                     Completion_Count := Completion_Count + 1;
+
                      Names.Include
                        (DN,
                         (Is_Dot_Call (Item),
                          Is_Visible (Item),
-                         Use_Snippets));
+                         Use_Snippets,
+                         Completion_Count));
                   end if;
                end loop;
             end if;

--- a/source/ada/lsp-ada_completions.adb
+++ b/source/ada/lsp-ada_completions.adb
@@ -39,7 +39,9 @@ package body LSP.Ada_Completions is
      (Context                  : LSP.Ada_Contexts.Context;
       Names                    : Completion_Maps.Map;
       Named_Notation_Threshold : Natural;
-      Result                   : in out LSP.Messages.CompletionItem_Vector) is
+      Result                   : in out LSP.Messages.CompletionItem_Vector)
+   is
+      Length : constant Natural := Natural (Names.Length);
    begin
       for Cursor in Names.Iterate loop
          declare
@@ -55,7 +57,9 @@ package body LSP.Ada_Completions is
                   Use_Snippets             => Info.Use_Snippets,
                   Named_Notation_Threshold => Named_Notation_Threshold,
                   Is_Dot_Call              => Info.Is_Dot_Call,
-                  Is_Visible               => Info.Is_Visible));
+                  Is_Visible               => Info.Is_Visible,
+                  Pos                      => Info.Pos,
+                  Completions_Count                   => Length));
          end;
       end loop;
    end Write_Completions;

--- a/source/ada/lsp-ada_completions.ads
+++ b/source/ada/lsp-ada_completions.ads
@@ -39,8 +39,18 @@ package LSP.Ada_Completions is
 
    type Name_Information is record
       Is_Dot_Call  : Boolean;
+      --  True if we are dealing with a dotted call.
+
       Is_Visible   : Boolean;
+      --  True if the item is visible from the withed/used packages, False
+      --  otherwise.
+
       Use_Snippets : Boolean;
+      --  True if it's a snippet completion item.
+
+      Pos          : Integer := -1;
+      --  The position of the item in the fully computed completion list. Used
+      --  for sorting properly the items on client-side.
    end record;
 
    package Completion_Maps is new Ada.Containers.Hashed_Maps

--- a/source/ada/lsp-ada_documents.ads
+++ b/source/ada/lsp-ada_documents.ads
@@ -229,7 +229,9 @@ package LSP.Ada_Documents is
       Use_Snippets             : Boolean;
       Named_Notation_Threshold : Natural;
       Is_Dot_Call              : Boolean;
-      Is_Visible               : Boolean)
+      Is_Visible               : Boolean;
+      Pos                      : Integer;
+      Completions_Count        : Natural)
       return LSP.Messages.CompletionItem;
    --  Compute a completion item.
    --  Node is the node from which the completion starts (e.g: 'A' in 'A.').
@@ -241,6 +243,7 @@ package LSP.Ada_Documents is
    --  named notation is used for subprogram completion snippets.
    --  Is_Dot_Call is used to know if we should omit the first parameter
    --  when computing subprogram snippets.
+   --  Completions_Count is the total number of completion items.
 
    function Get_Source_Location
      (Self     : Document'Class;

--- a/source/ada/lsp-ada_handlers-invisibles.adb
+++ b/source/ada/lsp-ada_handlers-invisibles.adb
@@ -45,6 +45,7 @@ package body LSP.Ada_Handlers.Invisibles is
          Stop : in out Boolean);
 
       Limit : constant := 10;
+      Pos   : Integer := 0;
 
       --------------------------
       -- On_Inaccessible_Name --
@@ -64,7 +65,10 @@ package body LSP.Ada_Handlers.Invisibles is
               (Name,
                (Is_Dot_Call  => False,
                 Is_Visible   => False,
-                Use_Snippets => False));
+                Use_Snippets => False,
+                Pos          => Pos));
+
+            Pos := Pos + 1;
 
             Stop := Names.Length >= Limit;
          end if;

--- a/source/ada/lsp-ada_handlers.adb
+++ b/source/ada/lsp-ada_handlers.adb
@@ -3623,8 +3623,8 @@ package body LSP.Ada_Handlers is
               (Name,
                (Is_Dot_Call  => False,
                 Is_Visible   => False,
-                Use_Snippets => False));
-
+                Use_Snippets => False,
+                Pos          => <>));
             Stop := Has_Been_Canceled;
          end if;
       end On_Inaccessible_Name;


### PR DESCRIPTION
... by keeping track of the order returned by LAL itself, and using
it to set the sortText accordingly.

This allows the client to sort results in a better way, in line with
LAL results.