### PR TITLE
U804-021: Handle "," in signatureHelp

### DIFF
--- a/testsuite/ada_lsp/T723-027.signatureHelp.nested/test.json
+++ b/testsuite/ada_lsp/T723-027.signatureHelp.nested/test.json
@@ -327,7 +327,7 @@
                               "label": "C"
                            }
                         ],
-                        "activeParameter": 0
+                        "activeParameter": 1
                      }
                   ],
                   "activeSignature": 0,
@@ -402,7 +402,7 @@
                               "label": "C"
                            }
                         ],
-                        "activeParameter": 0
+                        "activeParameter": 1
                      }
                   ],
                   "activeSignature": 0,
@@ -1215,7 +1215,7 @@
                               "label": "C"
                            }
                         ],
-                        "activeParameter": 1
+                        "activeParameter": 2
                      }
                   ],
                   "activeSignature": 0,
@@ -1290,7 +1290,7 @@
                               "label": "C"
                            }
                         ],
-                        "activeParameter": 1
+                        "activeParameter": 2
                      }
                   ],
                   "activeSignature": 0,

--- a/testsuite/ada_lsp/T723-027.signatureHelp.overloaded/test.json
+++ b/testsuite/ada_lsp/T723-027.signatureHelp.overloaded/test.json
@@ -349,7 +349,7 @@
                               "label": "B"
                            }
                         ],
-                        "activeParameter": 0
+                        "activeParameter": 1
                      },
                      {
                         "label": "procedure Bar (A : Integer; B, C : Integer)",
@@ -365,7 +365,7 @@
                               "label": "C"
                            }
                         ],
-                        "activeParameter": 0
+                        "activeParameter": 1
                      }
                   ],
                   "activeSignature": 0,
@@ -437,7 +437,7 @@
                               "label": "B"
                            }
                         ],
-                        "activeParameter": 0
+                        "activeParameter": 1
                      },
                      {
                         "label": "procedure Bar (A : Integer; B, C : Integer)",
@@ -453,7 +453,7 @@
                               "label": "C"
                            }
                         ],
-                        "activeParameter": 0
+                        "activeParameter": 1
                      }
                   ],
                   "activeSignature": 0,
@@ -603,19 +603,6 @@
                "result": {
                   "signatures": [
                      {
-                        "label": "procedure Bar (A : Integer; B : Integer)",
-                        "documentation": "",
-                        "parameters": [
-                           {
-                              "label": "A"
-                           },
-                           {
-                              "label": "B"
-                           }
-                        ],
-                        "activeParameter": 1
-                     },
-                     {
                         "label": "procedure Bar (A : Integer; B, C : Integer)",
                         "documentation": "",
                         "parameters": [
@@ -629,7 +616,7 @@
                               "label": "C"
                            }
                         ],
-                        "activeParameter": 1
+                        "activeParameter": 2
                      }
                   ],
                   "activeSignature": 0,
@@ -691,19 +678,6 @@
                "result": {
                   "signatures": [
                      {
-                        "label": "procedure Bar (A : Integer; B : Integer)",
-                        "documentation": "",
-                        "parameters": [
-                           {
-                              "label": "A"
-                           },
-                           {
-                              "label": "B"
-                           }
-                        ],
-                        "activeParameter": 1
-                     },
-                     {
                         "label": "procedure Bar (A : Integer; B, C : Integer)",
                         "documentation": "",
                         "parameters": [
@@ -717,7 +691,7 @@
                               "label": "C"
                            }
                         ],
-                        "activeParameter": 1
+                        "activeParameter": 2
                      }
                   ],
                   "activeSignature": 0,

--- a/testsuite/ada_lsp/T723-027.signatureHelp.simple/test.json
+++ b/testsuite/ada_lsp/T723-027.signatureHelp.simple/test.json
@@ -466,7 +466,7 @@
                               "label": "C"
                            }
                         ],
-                        "activeParameter": 0
+                        "activeParameter": 1
                      }
                   ],
                   "activeSignature": 0,
@@ -541,7 +541,7 @@
                               "label": "C"
                            }
                         ],
-                        "activeParameter": 0
+                        "activeParameter": 1
                      }
                   ],
                   "activeSignature": 0,
@@ -691,7 +691,7 @@
                               "label": "C"
                            }
                         ],
-                        "activeParameter": 1
+                        "activeParameter": 2
                      }
                   ],
                   "activeSignature": 0,
@@ -766,7 +766,7 @@
                               "label": "C"
                            }
                         ],
-                        "activeParameter": 1
+                        "activeParameter": 2
                      }
                   ],
                   "activeSignature": 0,

--- a/testsuite/ada_lsp/U429-030.signatureHelp.dot_call/test.json
+++ b/testsuite/ada_lsp/U429-030.signatureHelp.dot_call/test.json
@@ -678,7 +678,7 @@
                               "label": "B"
                            }
                         ],
-                        "activeParameter": 0
+                        "activeParameter": 1
                      },
                      {
                         "label": "procedure Hello (A : Integer; B : Float)",
@@ -691,7 +691,7 @@
                               "label": "B"
                            }
                         ],
-                        "activeParameter": 0
+                        "activeParameter": 1
                      }
                   ],
                   "activeSignature": 0,
@@ -826,20 +826,7 @@
                               "label": "B"
                            }
                         ],
-                        "activeParameter": 1
-                     },
-                     {
-                        "label": "procedure Hello (A : Integer; B : Float)",
-                        "documentation": "",
-                        "parameters": [
-                           {
-                              "label": "A"
-                           },
-                           {
-                              "label": "B"
-                           }
-                        ],
-                        "activeParameter": 1
+                        "activeParameter": 2
                      }
                   ],
                   "activeSignature": 0,
@@ -2225,7 +2212,7 @@
                               "label": "B"
                            }
                         ],
-                        "activeParameter": 0
+                        "activeParameter": 2
                      }
                   ],
                   "activeSignature": 0,


### PR DESCRIPTION
LAL error recovery create a similar tree for "Foo (1|" and "Foo (1,|"
thus we must add token analysis to detect a ",".

Adapts the tests.