### PR TITLE
U729-020 Don't send invisible name in completion if

### DIFF
--- a/source/ada/lsp-ada_completions.adb
+++ b/source/ada/lsp-ada_completions.adb
@@ -15,6 +15,10 @@
 -- of the license.                                                          --
 ------------------------------------------------------------------------------
 
+with Ada.Containers.Hashed_Sets;
+
+with VSS.Strings;
+
 with LSP.Ada_Contexts;
 with LSP.Ada_Documents;
 with LSP.Lal_Utils;
@@ -41,26 +45,60 @@ package body LSP.Ada_Completions is
       Named_Notation_Threshold : Natural;
       Result                   : in out LSP.Messages.CompletionItem_Vector)
    is
+      function Hash (Value : VSS.Strings.Virtual_String)
+        return Ada.Containers.Hash_Type
+          is (Ada.Containers.Hash_Type'Mod (Value.Hash));
+
+      package String_Sets is new Ada.Containers.Hashed_Sets
+        (VSS.Strings.Virtual_String, Hash, VSS.Strings."=", VSS.Strings."=");
+
+      Seen   : String_Sets.Set;
+      --  Set of found visible names in canonical form
       Length : constant Natural := Natural (Names.Length);
    begin
-      for Cursor in Names.Iterate loop
-         declare
-            Name : constant Libadalang.Analysis.Defining_Name :=
-              Completion_Maps.Key (Cursor);
-            Info : constant Name_Information := Names (Cursor);
-         begin
-            Result.Append
-              (LSP.Ada_Documents.Compute_Completion_Item
-                 (Context                  => Context,
-                  BD                       => Name.P_Basic_Decl,
-                  DN                       => Name,
-                  Use_Snippets             => Info.Use_Snippets,
-                  Named_Notation_Threshold => Named_Notation_Threshold,
-                  Is_Dot_Call              => Info.Is_Dot_Call,
-                  Is_Visible               => Info.Is_Visible,
-                  Pos                      => Info.Pos,
-                  Completions_Count                   => Length));
-         end;
+
+      --  Write Result in two pases. Firstly append all visible names and
+      --  populate Seen set. Then append invisible names not in Seen.
+
+      for Visible in reverse Boolean loop  --  Phase: True then False
+         for Cursor in Names.Iterate loop
+            declare
+               Append    : Boolean := False;
+               Info      : constant Name_Information := Names (Cursor);
+               Name      : constant Libadalang.Analysis.Defining_Name :=
+                 Completion_Maps.Key (Cursor);
+               Selector  : constant Libadalang.Analysis.Single_Tok_Node :=
+                 Name.P_Relative_Name;
+               Label     : VSS.Strings.Virtual_String;
+               Canonical : VSS.Strings.Virtual_String;
+            begin
+               if Visible and Info.Is_Visible then
+                  Label := LSP.Lal_Utils.To_Virtual_String (Selector.Text);
+                  Canonical := LSP.Lal_Utils.Canonicalize (Label);
+                  Seen.Include (Canonical);
+                  Append := True;
+               elsif not Visible and not Info.Is_Visible then
+                  --  Append invisible name on if no such visible name found
+                  Label := LSP.Lal_Utils.To_Virtual_String (Selector.Text);
+                  Canonical := LSP.Lal_Utils.Canonicalize (Label);
+                  Append := not Seen.Contains (Canonical);
+               end if;
+
+               if Append then
+                  Result.Append
+                    (LSP.Ada_Documents.Compute_Completion_Item
+                       (Context                  => Context,
+                        BD                       => Name.P_Basic_Decl,
+                        Label                    => Label,
+                        Use_Snippets             => Info.Use_Snippets,
+                        Named_Notation_Threshold => Named_Notation_Threshold,
+                        Is_Dot_Call              => Info.Is_Dot_Call,
+                        Is_Visible               => Info.Is_Visible,
+                        Pos                      => Info.Pos,
+                        Completions_Count        => Length));
+               end if;
+            end;
+         end loop;
       end loop;
    end Write_Completions;
 

--- a/source/ada/lsp-ada_documents.adb
+++ b/source/ada/lsp-ada_documents.adb
@@ -1742,7 +1742,7 @@ package body LSP.Ada_Documents is
    function Compute_Completion_Item
      (Context                  : LSP.Ada_Contexts.Context;
       BD                       : Libadalang.Analysis.Basic_Decl;
-      DN                       : Libadalang.Analysis.Defining_Name;
+      Label                    : VSS.Strings.Virtual_String;
       Use_Snippets             : Boolean;
       Named_Notation_Threshold : Natural;
       Is_Dot_Call              : Boolean;
@@ -1792,7 +1792,7 @@ package body LSP.Ada_Documents is
       end Get_Sort_text;
 
    begin
-      Item.label := LSP.Lal_Utils.To_Virtual_String (DN.P_Relative_Name.Text);
+      Item.label := Label;
       Item.kind := (True, To_Completion_Kind
                             (LSP.Lal_Utils.Get_Decl_Kind (BD)));
       Item.detail := (True,
@@ -1802,8 +1802,7 @@ package body LSP.Ada_Documents is
       declare
          Base_Label : constant LSP_String := LSP.Types.To_LSP_String
            (Item.label);
-         Sort_Text  : constant LSP_String :=
-           Get_Sort_text (Base_Label);
+         Sort_Text  : constant LSP_String := Get_Sort_text (Base_Label);
       begin
          if not Is_Visible then
             Item.insertText := (True, Base_Label);

--- a/source/ada/lsp-ada_documents.ads
+++ b/source/ada/lsp-ada_documents.ads
@@ -232,7 +232,7 @@ package LSP.Ada_Documents is
    function Compute_Completion_Item
      (Context                  : LSP.Ada_Contexts.Context;
       BD                       : Libadalang.Analysis.Basic_Decl;
-      DN                       : Libadalang.Analysis.Defining_Name;
+      Label                    : VSS.Strings.Virtual_String;
       Use_Snippets             : Boolean;
       Named_Notation_Threshold : Natural;
       Is_Dot_Call              : Boolean;
@@ -242,7 +242,7 @@ package LSP.Ada_Documents is
       return LSP.Messages.CompletionItem;
    --  Compute a completion item.
    --  Node is the node from which the completion starts (e.g: 'A' in 'A.').
-   --  BD and DN are respectively the basic declaration and the defining name
+   --  BD is the basic declaration and Label is the defining name text
    --  that should be used to compute the completion item.
    --  When Use_Snippets is True, subprogram completion items are computed
    --  as snippets that list all the subprogram's formal parameters.

--- a/testsuite/ada_lsp/completion.invisible5/default.gpr
+++ b/testsuite/ada_lsp/completion.invisible5/default.gpr
@@ -1,0 +1,2 @@
+project Default is
+end Default;

--- a/testsuite/ada_lsp/completion.invisible5/main.adb
+++ b/testsuite/ada_lsp/completion.invisible5/main.adb
@@ -1,0 +1,6 @@
+with Ada.Text_IO;
+
+procedure Main is
+begin
+   Ada;
+end;

--- a/testsuite/ada_lsp/completion.invisible5/pkg-ada.ads
+++ b/testsuite/ada_lsp/completion.invisible5/pkg-ada.ads
@@ -1,0 +1,1 @@
+package Pkg.Ada is end;

--- a/testsuite/ada_lsp/completion.invisible5/pkg.ads
+++ b/testsuite/ada_lsp/completion.invisible5/pkg.ads
@@ -1,0 +1,1 @@
+package Pkg is end;

--- a/testsuite/ada_lsp/completion.invisible5/test.json
+++ b/testsuite/ada_lsp/completion.invisible5/test.json
@@ -1,0 +1,178 @@
+[
+   {
+      "comment": [
+          "Check no invisible completion if there is some visible",
+          "with the same name"
+      ]
+   },
+   {
+      "start": {
+         "cmd": [
+            "${ALS}"
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+               "rootUri": "$URI{.}",
+               "capabilities": {
+                  "workspace": {
+                     "applyEdit": true
+                  },
+                  "textDocument": {
+                     "completion": {
+                        "completionItem": {
+                           "snippetSupport": true,
+                           "documentationFormat": [
+                              "markdown",
+                              "plaintext"
+                           ]
+                        }
+                     }
+                  },
+                  "window": {
+                     "workDoneProgress": true
+                  }
+               }
+            }
+         },
+         "wait": [
+             {
+                 "jsonrpc": "2.0",
+                 "id": 1,
+                 "result": {
+                     "capabilities": {
+                         "textDocumentSync": 2,
+                         "completionProvider": {
+                             "triggerCharacters": [
+                                 ".",
+                                 "("
+                             ],
+                             "resolveProvider": false
+                         }
+                     }
+                 }
+             }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "initialized"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "workspace/didChangeConfiguration",
+            "params": {
+               "settings": {
+                  "ada": {
+                     "projectFile":"default.gpr"
+                  }
+               }
+            }
+         },
+         "wait": [
+            {
+                "jsonrpc": "2.0",
+                "method": "$/progress",
+                "params": {
+                  "token": "<ANY>",
+                  "value": {
+                    "kind": "end"
+                  }
+                }
+            }
+        ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen",
+            "params": {
+               "textDocument": {
+                  "text": "with Ada.Text_IO;\n\nprocedure Main is\nbegin\n   Ada;\nend;",
+                  "version": 1,
+                  "uri": "$URI{main.adb}",
+                  "languageId": "ada"
+               }
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": 7,
+            "method": "textDocument/completion",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{main.adb}"
+               },
+               "position": {
+                  "line": 4,
+                  "character": 6
+               },
+               "context": {
+                  "triggerKind": 1
+               }
+            }
+         },
+         "sortReply": { "result": {"items": ["label", "documentation"]} },
+         "wait": [
+            {
+               "jsonrpc": "2.0",
+               "id": 7,
+               "result": {
+                  "isIncomplete": false,
+                     "items": [
+                        {
+                           "label": "Ada",
+                           "kind": 9,
+                           "detail": "package Ada ",
+                           "documentation": "<ANY>",
+                           "sortText": "1Ada",
+                           "additionalTextEdits": []
+                        }
+                     ]
+                  }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": 44,
+            "method": "shutdown"
+         },
+         "wait": [
+            {
+               "id": 44,
+               "result": null
+            }
+         ]
+      }
+   },
+   {
+      "stop": {
+         "exit_code": 0
+      }
+   }
+]

--- a/testsuite/ada_lsp/completion.invisible5/test.yaml
+++ b/testsuite/ada_lsp/completion.invisible5/test.yaml
@@ -1,0 +1,1 @@
+title: 'completion.invisible5'


### PR DESCRIPTION
there is some visible name with the same label in result.

For instance, if we have `Pkg.Ada` in the project and
`with Ada;` in unit clauses, we shouldn't propose `Pkg.Ada`
as invisible completion for `Ada` identifier, because it
won't work any way. `Ada` is already visible and the
second package can't become visible even if we append
`with Pkg.Ada; use Pkg;` clauses.