### PR TITLE
U831-003: Handle generic package in Get_Decl_Kind

### DIFF
--- a/source/ada/lsp-ada_documents.adb
+++ b/source/ada/lsp-ada_documents.adb
@@ -82,6 +82,7 @@ package body LSP.Ada_Documents is
         when LSP.Messages.A_Package  => LSP.Messages.Module,
         when LSP.Messages.Module     => LSP.Messages.Module,
         when LSP.Messages.Class      => LSP.Messages.Class,
+        when LSP.Messages.Struct     => LSP.Messages.Class,
         when LSP.Messages.Number     => LSP.Messages.Value,
         when LSP.Messages.Enum       => LSP.Messages.Enum,
         when LSP.Messages.String     => LSP.Messages.Value,
@@ -1551,10 +1552,10 @@ package body LSP.Ada_Documents is
       use Libadalang.Common;
    begin
       case Node.Kind is
-         when Ada_Generic_Package_Decl |
+         when Ada_Base_Package_Decl |
+              Ada_Generic_Package_Decl |
               Ada_Generic_Package_Instantiation |
               Ada_Generic_Package_Renaming_Decl |
-              Ada_Package_Decl |
               Ada_Package_Renaming_Decl |
               Ada_Abstract_Subp_Decl |
               Ada_Formal_Subp_Decl |

--- a/source/ada/lsp-ada_handlers-invisibles.adb
+++ b/source/ada/lsp-ada_handlers-invisibles.adb
@@ -102,8 +102,8 @@ package body LSP.Ada_Handlers.Invisibles is
          return;
       end if;
 
-      --  Return without asing Libadalang for completion results we are dealing
-      --  with a syntax error.
+      --  Return without asking Libadalang for completion results we are
+      --  dealing with a syntax error.
       if Node.Kind in Libadalang.Common.Ada_Error_Decl_Range then
          return;
       end if;

--- a/source/ada/lsp-lal_utils.adb
+++ b/source/ada/lsp-lal_utils.adb
@@ -291,21 +291,14 @@ package body LSP.Lal_Utils is
         return LSP.Messages.SymbolKind is
    begin
       case Node.Kind is
-         when Ada_Generic_Formal_Subp_Decl |
-              Ada_Abstract_Subp_Decl |
-              Ada_Abstract_Formal_Subp_Decl |
-              Ada_Concrete_Formal_Subp_Decl |
-              Ada_Null_Subp_Decl |
-              Ada_Subp_Decl |
-              Ada_Subp_Renaming_Decl |
-              Ada_Expr_Function |
-              Ada_Subp_Body |
-              Ada_Subp_Body_Stub |
-              Ada_Entry_Body |
-              Ada_Entry_Decl |
-              Ada_Generic_Subp_Decl |
-              Ada_Generic_Subp_Instantiation |
-              Ada_Generic_Subp_Renaming_Decl =>
+         when Ada_Classic_Subp_Decl |
+              Ada_Base_Subp_Body |
+              Ada_Entry_Body_Range |
+              Ada_Entry_Decl_Range |
+              Ada_Generic_Subp_Decl_Range |
+              Ada_Generic_Subp_Instantiation_Range |
+              Ada_Generic_Subp_Renaming_Decl_Range |
+              Ada_Subp_Body_Stub_Range  =>
             return LSP.Messages.A_Function;
 
          when Ada_Component_Decl |
@@ -326,9 +319,11 @@ package body LSP.Lal_Utils is
                        then LSP.Messages.A_Constant
                        else LSP.Messages.Variable));
 
-         when Ada_Generic_Formal_Package |
-              Ada_Package_Decl |
-              Ada_Generic_Package_Decl |
+         when Ada_Base_Package_Decl |
+              Ada_Generic_Formal_Package |
+              --  Ignore: Ada_Generic_Package_Decl kind, this node always have
+              --  an Ada_Generic_Package_Internal as a child and we will use it
+              --  to create the CompletionItem/DocumentSymbol
               Ada_Generic_Package_Instantiation |
               Ada_Generic_Package_Renaming_Decl |
               Ada_Package_Renaming_Decl =>

--- a/testsuite/ada_lsp/completion.invisible3/test.json
+++ b/testsuite/ada_lsp/completion.invisible3/test.json
@@ -152,7 +152,7 @@
                      },
                      {
                         "label": "ABC14 (invisible)",
-                        "kind": 18,
+                        "kind": 9,
                         "detail": "generic\n      ABC13 : Integer;\npackage ABC14 ",
                         "documentation": "at pkg.ads (19:4)",
                         "sortText": "~ABC14",
@@ -161,7 +161,7 @@
                      },
                      {
                         "label": "ABC4 (invisible)",
-                        "kind": 18,
+                        "kind": 7,
                         "detail": "type ABC4 (ABC5 : Integer) is record\n   ABC6 : Boolean := (for some ABC7 in Boolean => ABC7);\nend record;",
                         "documentation": "at pkg.ads (5:4)",
                         "sortText": "~ABC4",

--- a/testsuite/ada_lsp/completion.subp_params_dotted_names/test.json
+++ b/testsuite/ada_lsp/completion.subp_params_dotted_names/test.json
@@ -206,7 +206,7 @@
                        },
                        {
                            "label": "My_Int",
-                           "kind": 18,
+                           "kind": 7,
                            "detail": "type My_Int is tagged record\n   A : Integer;\nend record;",
                            "documentation": "at bar.ads (3:4)",
                            "additionalTextEdits": [


### PR DESCRIPTION
When parsing a generic package declaration LAL will return
GenericPackageDecl(GenericPackageInternal(...)) at this point
To prevent duplicate we must ignore either the GenericPackageDecl
or the GenericPackageInternal => the completion returns the second.
(Also Ada_Base_Package_Decl contains GenericPackageInternal and not
GenericPackageDecl)

Also fix a missing conversion between SymbolKind and CompletionKind

Adapts tests.