### PR TITLE
U622-021: Compute some completion items properties lazily

### DIFF
--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -257,6 +257,8 @@ REQUESTS = [
      'CodeAction_Response'),
     ('textDocument/completion', 'Completion', 'TextDocumentPositionParams',
      'Completion_Response'),
+    ('completionItem/resolve', 'CompletionItemResolve', 'CompletionItem',
+     'CompletionItemResolve_Response'),
     ('textDocument/definition', 'Definition', 'DefinitionParams',
      'Location_Link_Response'),
     ('textDocument/declaration', 'Declaration', 'DeclarationParams',

--- a/source/ada/lsp-ada_completions.adb
+++ b/source/ada/lsp-ada_completions.adb
@@ -43,6 +43,7 @@ package body LSP.Ada_Completions is
      (Context                  : LSP.Ada_Contexts.Context;
       Names                    : Completion_Maps.Map;
       Named_Notation_Threshold : Natural;
+      Compute_Doc_And_Details  : Boolean;
       Result                   : in out LSP.Messages.CompletionItem_Vector)
    is
       function Hash (Value : VSS.Strings.Virtual_String)
@@ -91,6 +92,7 @@ package body LSP.Ada_Completions is
                         BD                       => Name.P_Basic_Decl,
                         Label                    => Label,
                         Use_Snippets             => Info.Use_Snippets,
+                        Compute_Doc_And_Details  => Compute_Doc_And_Details,
                         Named_Notation_Threshold => Named_Notation_Threshold,
                         Is_Dot_Call              => Info.Is_Dot_Call,
                         Is_Visible               => Info.Is_Visible,

--- a/source/ada/lsp-ada_completions.ads
+++ b/source/ada/lsp-ada_completions.ads
@@ -88,7 +88,15 @@ package LSP.Ada_Completions is
      (Context                  : LSP.Ada_Contexts.Context;
       Names                    : Completion_Maps.Map;
       Named_Notation_Threshold : Natural;
+      Compute_Doc_And_Details  : Boolean;
       Result                   : in out LSP.Messages.CompletionItem_Vector);
+   --  Convert all the completion Names into LSP completion items' results.
+   --  Named_Notation_Threshold defines the number of parameters/components at
+   --  which point named notation is used for subprogram/aggregate completion
+   --  snippets.
+   --  If Compute_Doc_And_Details is True, the 'detail' and 'documentation'
+   --  fields for all the resulting completion items will be computed
+   --  immediately, which might take time.
 
    generic
       with function Has_Been_Canceled return Boolean;

--- a/source/ada/lsp-ada_documents.ads
+++ b/source/ada/lsp-ada_documents.ads
@@ -234,6 +234,7 @@ package LSP.Ada_Documents is
       BD                       : Libadalang.Analysis.Basic_Decl;
       Label                    : VSS.Strings.Virtual_String;
       Use_Snippets             : Boolean;
+      Compute_Doc_And_Details  : Boolean;
       Named_Notation_Threshold : Natural;
       Is_Dot_Call              : Boolean;
       Is_Visible               : Boolean;

--- a/source/ada/lsp-ada_handlers.ads
+++ b/source/ada/lsp-ada_handlers.ads
@@ -20,6 +20,7 @@
 
 with Ada.Containers.Hashed_Maps;
 with Ada.Containers.Hashed_Sets;
+with VSS.String_Vectors;
 
 with GNATCOLL.VFS;    use GNATCOLL.VFS;
 with GNATCOLL.Projects;
@@ -200,6 +201,11 @@ private
       Completion_Snippets_Enabled : Boolean := False;
       --  True if the client supports completion snippets
 
+      Completion_Resolve_Properties : VSS.String_Vectors.Virtual_String_Vector;
+      --  The list of CompletionItem properties that can be resolved
+      --  lazily (i.e: when the item is selected on client-side) via
+      --  the completionItem/resolve request.
+
       Range_Formatting_Enabled : Boolean := False;
       --  True if the handler has registered rangeFormatting provider
 
@@ -271,6 +277,11 @@ private
      (Self    : access Message_Handler;
       Request : LSP.Messages.Server_Requests.Completion_Request)
       return LSP.Messages.Server_Responses.Completion_Response;
+
+   overriding function On_CompletionItemResolve_Request
+     (Self    : access Message_Handler;
+      Request : LSP.Messages.Server_Requests.CompletionItemResolve_Request)
+      return LSP.Messages.Server_Responses.CompletionItemResolve_Response;
 
    overriding function On_Definition_Request
      (Self    : access Message_Handler;

--- a/source/ada/lsp-error_decorators.adb
+++ b/source/ada/lsp-error_decorators.adb
@@ -136,7 +136,27 @@ package body LSP.Error_Decorators is
      (Self    : access Error_Decorator;
       Request : LSP.Messages.Server_Requests.Completion_Request)
       return LSP.Messages.Server_Responses.Completion_Response
-        renames Completion_Request;
+      renames Completion_Request;
+
+   -----------------------------------
+   -- CompletionItemResolve_Request --
+   -----------------------------------
+
+   function CompletionItemResolve_Request is new Generic_Request
+     (Request    =>
+         LSP.Messages.Server_Requests.CompletionItemResolve_Request,
+      Response   =>
+         LSP.Messages.Server_Responses.CompletionItemResolve_Response,
+      Handler    =>
+         LSP.Server_Request_Handlers.Server_Request_Handler,
+      On_Request =>
+         LSP.Server_Request_Handlers.On_CompletionItemResolve_Request);
+
+   overriding function On_CompletionItemResolve_Request
+     (Self    : access Error_Decorator;
+      Request : LSP.Messages.Server_Requests.CompletionItemResolve_Request)
+      return LSP.Messages.Server_Responses.CompletionItemResolve_Response
+        renames CompletionItemResolve_Request;
 
    ---------------------------
    -- On_Declaration_Request --

--- a/source/ada/lsp-error_decorators.ads
+++ b/source/ada/lsp-error_decorators.ads
@@ -58,6 +58,11 @@ package LSP.Error_Decorators is
       Request : LSP.Messages.Server_Requests.Completion_Request)
       return LSP.Messages.Server_Responses.Completion_Response;
 
+   overriding function On_CompletionItemResolve_Request
+     (Self    : access Error_Decorator;
+      Request : LSP.Messages.Server_Requests.CompletionItemResolve_Request)
+      return LSP.Messages.Server_Responses.CompletionItemResolve_Response;
+
    overriding function On_Definition_Request
      (Self    : access Error_Decorator;
       Request : LSP.Messages.Server_Requests.Definition_Request)

--- a/source/ada/lsp-lal_utils.adb
+++ b/source/ada/lsp-lal_utils.adb
@@ -15,6 +15,7 @@
 -- of the license.                                                          --
 ------------------------------------------------------------------------------
 
+with Ada.Characters.Wide_Wide_Latin_1;
 with Ada.Strings.Unbounded;
 with Ada.Strings.Wide_Wide_Unbounded;
 
@@ -25,6 +26,7 @@ with VSS.Strings.Conversions;
 with Langkit_Support;
 with Langkit_Support.Symbols; use Langkit_Support.Symbols;
 with Libadalang.Common;       use Libadalang.Common;
+with Libadalang.Doc_Utils;
 with Libadalang.Sources;
 
 with Laltools.Call_Hierarchy;
@@ -909,6 +911,38 @@ package body LSP.Lal_Utils is
 
       return Result;
    end Compute_Completion_Detail;
+
+   ----------------------------
+   -- Compute_Completion_Doc --
+   ----------------------------
+
+   function Compute_Completion_Doc
+     (BD : Libadalang.Analysis.Basic_Decl) return VSS.Strings.Virtual_String
+   is
+      Doc_Text : VSS.Strings.Virtual_String;
+      Loc_Text : VSS.Strings.Virtual_String;
+   begin
+      Doc_Text :=
+        VSS.Strings.To_Virtual_String
+          (Libadalang.Doc_Utils.Get_Documentation
+             (BD).Doc.To_String);
+
+      --  Append the declaration's location.
+      --  In addition, append the project's name if we are dealing with
+      --  an aggregate project.
+
+      Loc_Text.Append (LSP.Lal_Utils.Node_Location_Image (BD));
+
+      if not Doc_Text.Is_Empty then
+         Loc_Text.Append
+           (VSS.Strings.To_Virtual_String
+              ((1 .. 2 => Ada.Characters.Wide_Wide_Latin_1.LF)));
+
+         Loc_Text.Append (Doc_Text);
+      end if;
+
+      return Loc_Text;
+   end Compute_Completion_Doc;
 
    -----------------------
    -- Containing_Entity --

--- a/source/ada/lsp-lal_utils.ads
+++ b/source/ada/lsp-lal_utils.ads
@@ -262,6 +262,15 @@ package LSP.Lal_Utils is
 
    function Compute_Completion_Detail
      (BD : Libadalang.Analysis.Basic_Decl) return VSS.Strings.Virtual_String;
+   --  Return a suitable string that should be used for the
+   --  CompletionItem.detail field. It currently returns the same text used
+   --  for textDocument/hover requests (tooltips).
+
+   function Compute_Completion_Doc
+     (BD : Libadalang.Analysis.Basic_Decl) return VSS.Strings.Virtual_String;
+   --  Return a suitable string that should be used for the
+   --  CompletionItem.documentation field. It currently returns the comments
+   --  associated with the given basic decl and its location.
 
    function To_Unbounded_Text_Type
      (Item : LSP.Types.LSP_String)

--- a/source/protocol/generated/lsp-message_io.adb
+++ b/source/protocol/generated/lsp-message_io.adb
@@ -7056,6 +7056,8 @@ package body LSP.Message_IO is
                Optional_LSP_String_Vector'Read (S, V.commitCharacters);
             elsif Key = "command" then
                Optional_Command'Read (S, V.command);
+            elsif Key = "data" then
+               Optional_Location'Read (S, V.data);
             else
                JS.Skip_Value;
             end if;
@@ -7104,6 +7106,8 @@ package body LSP.Message_IO is
       Optional_LSP_String_Vector'Write (S, V.commitCharacters);
       JS.Key ("command");
       Optional_Command'Write (S, V.command);
+      JS.Key ("data");
+      Optional_Location'Write (S, V.data);
       JS.End_Object;
    end Write_CompletionItem;
 

--- a/source/protocol/generated/lsp-messages-server_requests.adb
+++ b/source/protocol/generated/lsp-messages-server_requests.adb
@@ -50,6 +50,13 @@ package body LSP.Messages.Server_Requests is
    end Visit;
 
    overriding procedure Visit
+     (Self    : CompletionItemResolve_Request;
+      Handler : access Server_Request_Receiver'Class) is
+   begin
+      Handler.On_CompletionItemResolve_Request (Self);
+   end Visit;
+
+   overriding procedure Visit
      (Self    : Definition_Request;
       Handler : access Server_Request_Receiver'Class) is
    begin
@@ -248,6 +255,10 @@ begin
    Map.Insert
      ("textDocument/completion",
       Completion_Request'Tag);
+
+   Map.Insert
+     ("completionItem/resolve",
+      CompletionItemResolve_Request'Tag);
 
    Map.Insert
      ("textDocument/definition",

--- a/source/protocol/generated/lsp-messages-server_requests.ads
+++ b/source/protocol/generated/lsp-messages-server_requests.ads
@@ -73,6 +73,19 @@ package LSP.Messages.Server_Requests is
      (Self    : Completion_Request;
       Handler : access Server_Request_Receiver'Class);
 
+   package CompletionItemResolve_Requests is
+     new LSP.Generic_Requests
+       (Server_Request,
+        CompletionItem,
+        Server_Request_Receiver'Class);
+
+   type CompletionItemResolve_Request is
+     new CompletionItemResolve_Requests.Request with null record;
+
+   overriding procedure Visit
+     (Self    : CompletionItemResolve_Request;
+      Handler : access Server_Request_Receiver'Class);
+
    package Definition_Requests is
      new LSP.Generic_Requests
        (Server_Request,

--- a/source/protocol/generated/lsp-server_request_receivers.ads
+++ b/source/protocol/generated/lsp-server_request_receivers.ads
@@ -33,6 +33,11 @@ package LSP.Server_Request_Receivers is
       Value : LSP.Messages.Server_Requests.Completion_Request)
         is abstract;
 
+   procedure On_CompletionItemResolve_Request
+     (Self  : access Server_Request_Receiver;
+      Value : LSP.Messages.Server_Requests.CompletionItemResolve_Request)
+        is abstract;
+
    procedure On_Definition_Request
      (Self  : access Server_Request_Receiver;
       Value : LSP.Messages.Server_Requests.Definition_Request)

--- a/source/protocol/lsp-messages-server_responses.adb
+++ b/source/protocol/lsp-messages-server_responses.adb
@@ -46,6 +46,18 @@ package body LSP.Messages.Server_Responses is
    -----------
 
    overriding procedure Visit
+     (Self    : CompletionItemResolve_Response;
+      Handler : access Server_Response_Sender'Class)
+   is
+   begin
+      Handler.On_CompletionItemResolve_Response (Self);
+   end Visit;
+
+   -----------
+   -- Visit --
+   -----------
+
+   overriding procedure Visit
      (Self    : Hover_Response;
       Handler : access Server_Response_Sender'Class)
    is

--- a/source/protocol/lsp-messages-server_responses.ads
+++ b/source/protocol/lsp-messages-server_responses.ads
@@ -48,6 +48,17 @@ package LSP.Messages.Server_Responses is
      (Self    : Completion_Response;
       Handler : access Server_Response_Sender'Class);
 
+   package CompletionItemResolve_Responses is new LSP.Generic_Responses
+     (ResponseMessage => Server_Response,
+      T               => CompletionItem);
+
+   type CompletionItemResolve_Response is
+     new CompletionItemResolve_Responses.Response with null record;
+
+   overriding procedure Visit
+     (Self    : CompletionItemResolve_Response;
+      Handler : access Server_Response_Sender'Class);
+
    package Hover_Responses is new LSP.Generic_Responses
      (ResponseMessage => Server_Response,
       T               => Optional_Hover);

--- a/source/protocol/lsp-messages.ads
+++ b/source/protocol/lsp-messages.ads
@@ -544,6 +544,9 @@ package LSP.Messages is
 
    type Location_Vector is new Location_Vectors.Vector with null record;
 
+   package Optional_Locations is new LSP.Generic_Optional (Location);
+   type Optional_Location is new Optional_Locations.Optional_Type;
+
    --```typescript
    --interface LocationLink {
    --
@@ -7602,7 +7605,7 @@ package LSP.Messages is
       additionalTextEdits: TextEdit_Vector;
       commitCharacters: Optional_LSP_String_Vector;
       command: Optional_Command;
-   --	data?: any
+      data : Optional_Location;
    end record;
 
    procedure Read_CompletionItem

--- a/source/protocol/lsp-server_response_senders.ads
+++ b/source/protocol/lsp-server_response_senders.ads
@@ -33,6 +33,11 @@ package LSP.Server_Response_Senders is
       Response : LSP.Messages.Server_Responses.Completion_Response)
        is abstract;
 
+   procedure On_CompletionItemResolve_Response
+     (Self     : in out Server_Response_Sender;
+      Response : LSP.Messages.Server_Responses.CompletionItemResolve_Response)
+       is abstract;
+
    procedure On_Hover_Response
      (Self     : in out Server_Response_Sender;
       Response : LSP.Messages.Server_Responses.Hover_Response) is abstract;

--- a/source/server/generated/lsp-server_request_handlers.ads
+++ b/source/server/generated/lsp-server_request_handlers.ads
@@ -38,6 +38,12 @@ package LSP.Server_Request_Handlers is
       return LSP.Messages.Server_Responses.Completion_Response
         is abstract;
 
+   function On_CompletionItemResolve_Request
+     (Self    : access Server_Request_Handler;
+      Request : LSP.Messages.Server_Requests.CompletionItemResolve_Request)
+      return LSP.Messages.Server_Responses.CompletionItemResolve_Response
+        is abstract;
+
    function On_Definition_Request
      (Self    : access Server_Request_Handler;
       Request : LSP.Messages.Server_Requests.Definition_Request)

--- a/source/server/generated/lsp-servers-handle_request.adb
+++ b/source/server/generated/lsp-servers-handle_request.adb
@@ -57,6 +57,18 @@ begin
          end;
       end if;
 
+      if Request in CompletionItemResolve_Request'Class then
+         declare
+            R : LSP.Messages.ResponseMessage'Class :=
+               Self.On_CompletionItemResolve_Request
+                  (CompletionItemResolve_Request (Request));
+         begin
+            R.jsonrpc := "2.0";
+            R.id := Request.id;
+            return R;
+         end;
+      end if;
+
       if Request in Definition_Request'Class then
          declare
             R : LSP.Messages.ResponseMessage'Class :=

--- a/source/server/lsp-message_loggers.adb
+++ b/source/server/lsp-message_loggers.adb
@@ -50,6 +50,8 @@ package body LSP.Message_Loggers is
      (Value : LSP.Messages.DocumentFormattingParams) return String;
    function Image
      (Value : LSP.Messages.TextDocumentPositionParams'Class) return String;
+   function Image
+     (Value : LSP.Messages.CompletionItem) return String;
 
    -----------
    -- Image --
@@ -119,6 +121,16 @@ package body LSP.Message_Loggers is
      (Value : LSP.Messages.TextDocumentPositionParams'Class) return String is
    begin
       return (+Value.textDocument.uri) & Image (Value.position);
+   end Image;
+
+   -----------
+   -- Image --
+   -----------
+
+   function Image
+     (Value : LSP.Messages.CompletionItem) return String is
+   begin
+      return VSS.Strings.Conversions.To_UTF_8_String (Value.label);
    end Image;
 
    -----------
@@ -387,6 +399,20 @@ package body LSP.Message_Loggers is
          & Image (Value.params));
    end On_Completion_Request;
 
+   --------------------------------------
+   -- On_CompletionItemResolve_Request --
+   --------------------------------------
+
+   overriding procedure On_CompletionItemResolve_Request
+     (Self   : access Message_Logger;
+      Value  : LSP.Messages.Server_Requests.CompletionItemResolve_Request) is
+   begin
+      Self.Trace.Trace
+        ("CompletionItemResolve_Request: "
+         & Image (Value)
+         & Image (Value.params));
+   end On_CompletionItemResolve_Request;
+
    ----------------------------
    -- On_Completion_Response --
    ----------------------------
@@ -408,6 +434,27 @@ package body LSP.Message_Loggers is
          & Image (Value)
          & Ada.Containers.Count_Type'Image (Value.result.items.Length));
    end On_Completion_Response;
+
+   ---------------------------------------
+   -- On_CompletionItemResolve_Response --
+   ---------------------------------------
+
+   overriding procedure On_CompletionItemResolve_Response
+     (Self   : in out Message_Logger;
+      Value  : LSP.Messages.Server_Responses.CompletionItemResolve_Response) is
+   begin
+      if Value.Is_Error then
+         Self.Trace.Trace
+           ("CompletionItemResolve_Response: "
+            & Image (Value)
+            & " Error");
+         return;
+      end if;
+
+      Self.Trace.Trace
+        ("CompletionItemResolve_Response: "
+         & Image (Value));
+   end On_CompletionItemResolve_Response;
 
    ----------------------------------------
    -- On_Workspace_Configuration_Request --

--- a/source/server/lsp-message_loggers.ads
+++ b/source/server/lsp-message_loggers.ads
@@ -142,6 +142,10 @@ private
      (Self   : access Message_Logger;
       Value  : LSP.Messages.Server_Requests.Completion_Request);
 
+   overriding procedure On_CompletionItemResolve_Request
+     (Self   : access Message_Logger;
+      Value  : LSP.Messages.Server_Requests.CompletionItemResolve_Request);
+
    overriding procedure On_Definition_Request
      (Self   : access Message_Logger;
       Value  : LSP.Messages.Server_Requests.Definition_Request);
@@ -245,6 +249,10 @@ private
    overriding procedure On_Completion_Response
      (Self   : in out Message_Logger;
       Value  : LSP.Messages.Server_Responses.Completion_Response);
+
+   overriding procedure On_CompletionItemResolve_Response
+     (Self   : in out Message_Logger;
+      Value  : LSP.Messages.Server_Responses.CompletionItemResolve_Response);
 
    overriding procedure On_Hover_Response
      (Self   : in out Message_Logger;

--- a/testsuite/ada_lsp/C825-005.xrefs.extending/test.json
+++ b/testsuite/ada_lsp/C825-005.xrefs.extending/test.json
@@ -43,7 +43,7 @@
                             ".",
                             "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      },
                      "documentSymbolProvider": true
                   }

--- a/testsuite/ada_lsp/D301-004.xrefs.generics/test.json
+++ b/testsuite/ada_lsp/D301-004.xrefs.generics/test.json
@@ -43,7 +43,7 @@
                             ".",
                             "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      },
                      "documentSymbolProvider": true
                   }

--- a/testsuite/ada_lsp/D803-003.xrefs.generics_go_to_body/test.json
+++ b/testsuite/ada_lsp/D803-003.xrefs.generics_go_to_body/test.json
@@ -43,7 +43,7 @@
                             ".",
                             "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      },
                      "documentSymbolProvider": true
                   }

--- a/testsuite/ada_lsp/F131-024.xrefs.separate_body/test.json
+++ b/testsuite/ada_lsp/F131-024.xrefs.separate_body/test.json
@@ -50,7 +50,7 @@
                             ".",
                             "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      },
                      "documentSymbolProvider": true
                   }

--- a/testsuite/ada_lsp/F222-029.xrefs.prefixed_notation/test.json
+++ b/testsuite/ada_lsp/F222-029.xrefs.prefixed_notation/test.json
@@ -43,7 +43,7 @@
                             ".",
                             "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      },
                      "documentSymbolProvider": true
                   }

--- a/testsuite/ada_lsp/G323-009.tooltips.function_prototype/test.json
+++ b/testsuite/ada_lsp/G323-009.tooltips.function_prototype/test.json
@@ -50,7 +50,7 @@
                             ".",
                             "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      },
                      "documentSymbolProvider": true
                   }

--- a/testsuite/ada_lsp/JB24-033.xrefs.no_refs_for_non_loaded_projects/test.json
+++ b/testsuite/ada_lsp/JB24-033.xrefs.no_refs_for_non_loaded_projects/test.json
@@ -43,7 +43,7 @@
                             ".",
                             "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      },
                      "documentSymbolProvider": true
                   }

--- a/testsuite/ada_lsp/O208-003.xrefs.aggregate_library_projects/test.json
+++ b/testsuite/ada_lsp/O208-003.xrefs.aggregate_library_projects/test.json
@@ -43,7 +43,7 @@
                             ".",
                             "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      },
                      "documentSymbolProvider": true
                   }

--- a/testsuite/ada_lsp/P107-003.refactoring.underscores/test.json
+++ b/testsuite/ada_lsp/P107-003.refactoring.underscores/test.json
@@ -43,7 +43,7 @@
                             ".",
                             "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      },
                      "documentSymbolProvider": true
                   }

--- a/testsuite/ada_lsp/P429-023.refactoring.rename_clauses/test.json
+++ b/testsuite/ada_lsp/P429-023.refactoring.rename_clauses/test.json
@@ -43,7 +43,7 @@
                             ".",
                             "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      },
                      "documentSymbolProvider": true
                   }

--- a/testsuite/ada_lsp/QB01-002.xrefs.non_ascii_documentation/test.json
+++ b/testsuite/ada_lsp/QB01-002.xrefs.non_ascii_documentation/test.json
@@ -43,7 +43,7 @@
                             ".",
                             "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      },
                      "documentSymbolProvider": true
                   }

--- a/testsuite/ada_lsp/S314-015.refactor_change_parameter_mode_0/test.json
+++ b/testsuite/ada_lsp/S314-015.refactor_change_parameter_mode_0/test.json
@@ -183,7 +183,7 @@
                            ".",
                            "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      },
                      "hoverProvider": true,
                      "declarationProvider": true,

--- a/testsuite/ada_lsp/S314-015.refactor_move_parameter_0/test.json
+++ b/testsuite/ada_lsp/S314-015.refactor_move_parameter_0/test.json
@@ -183,7 +183,7 @@
                            ".",
                            "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      },
                      "hoverProvider": true,
                      "declarationProvider": true,

--- a/testsuite/ada_lsp/S314-015.refactor_remove_parameter_0/test.json
+++ b/testsuite/ada_lsp/S314-015.refactor_remove_parameter_0/test.json
@@ -183,7 +183,7 @@
                            ".",
                            "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      },
                      "hoverProvider": true,
                      "declarationProvider": true,

--- a/testsuite/ada_lsp/S820-016.called_by.entry/test.json
+++ b/testsuite/ada_lsp/S820-016.called_by.entry/test.json
@@ -84,7 +84,7 @@
                            ".",
                            "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      },
                      "hoverProvider": true,
                      "declarationProvider": true,

--- a/testsuite/ada_lsp/SA11-040.definition.fallback/test.json
+++ b/testsuite/ada_lsp/SA11-040.definition.fallback/test.json
@@ -49,7 +49,7 @@
                             ".",
                             "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      },
                      "documentSymbolProvider": true
                   }

--- a/testsuite/ada_lsp/SA22-029.rename_in_comments/test.json
+++ b/testsuite/ada_lsp/SA22-029.rename_in_comments/test.json
@@ -49,7 +49,7 @@
                             ".",
                             "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      },
                      "documentSymbolProvider": true
                   }

--- a/testsuite/ada_lsp/SA22-032.folding/test.json
+++ b/testsuite/ada_lsp/SA22-032.folding/test.json
@@ -38,7 +38,7 @@
                      "capabilities": {
                      "textDocumentSync": 2,
                      "completionProvider": {
-                        "resolveProvider": false,
+                        "resolveProvider": true,
                         "triggerCharacters": [
                             ".",
                             "("

--- a/testsuite/ada_lsp/SA24-055.called_by_on_abstract/test.json
+++ b/testsuite/ada_lsp/SA24-055.called_by_on_abstract/test.json
@@ -84,7 +84,7 @@
                            ".",
                            "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      },
                      "hoverProvider": true,
                      "declarationProvider": true,

--- a/testsuite/ada_lsp/SB14-027.references.tagged_access_kind/test.json
+++ b/testsuite/ada_lsp/SB14-027.references.tagged_access_kind/test.json
@@ -70,7 +70,7 @@
                            ".",
                            "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      },
                      "documentSymbolProvider": true
                   }

--- a/testsuite/ada_lsp/SB14-037.references.access_kind/test.json
+++ b/testsuite/ada_lsp/SB14-037.references.access_kind/test.json
@@ -70,7 +70,7 @@
                            ".",
                            "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      },
                      "documentSymbolProvider": true
                   }

--- a/testsuite/ada_lsp/SB21-042.tooltips.aspects/test.json
+++ b/testsuite/ada_lsp/SB21-042.tooltips.aspects/test.json
@@ -49,7 +49,7 @@
                             ".",
                             "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      },
                      "documentSymbolProvider": true
                   }

--- a/testsuite/ada_lsp/SC16-095.fallback_when_no_body/test.json
+++ b/testsuite/ada_lsp/SC16-095.fallback_when_no_body/test.json
@@ -68,7 +68,7 @@
                             ".",
                             "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      },
                      "documentSymbolProvider": true
                   }

--- a/testsuite/ada_lsp/SC28-001.named.parameters.0/SC28-001.named.parameters.0.json
+++ b/testsuite/ada_lsp/SC28-001.named.parameters.0/SC28-001.named.parameters.0.json
@@ -85,7 +85,7 @@
                                     ".",
                                     "("
                                 ],
-                                "resolveProvider": false
+                                "resolveProvider": true
                             },
                             "hoverProvider": true,
                             "declarationProvider": true,

--- a/testsuite/ada_lsp/T123-048.incremental_editing/test.json
+++ b/testsuite/ada_lsp/T123-048.incremental_editing/test.json
@@ -285,7 +285,7 @@
                             ".",
                             "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      },
                      "documentSymbolProvider": true
                   }

--- a/testsuite/ada_lsp/T709-018.is_called_by.name_collision/test.json
+++ b/testsuite/ada_lsp/T709-018.is_called_by.name_collision/test.json
@@ -87,7 +87,7 @@
                            ".",
                            "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      },
                      "hoverProvider": true,
                      "declarationProvider": true,

--- a/testsuite/ada_lsp/T723-027.signatureHelp.nested/test.json
+++ b/testsuite/ada_lsp/T723-027.signatureHelp.nested/test.json
@@ -41,7 +41,7 @@
                             ".",
                             "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      },
                      "signatureHelpProvider": {
                         "triggerCharacters": [

--- a/testsuite/ada_lsp/T723-027.signatureHelp.overloaded/test.json
+++ b/testsuite/ada_lsp/T723-027.signatureHelp.overloaded/test.json
@@ -40,7 +40,7 @@
                             ".",
                             "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      },
                      "signatureHelpProvider": {
                         "triggerCharacters": [

--- a/testsuite/ada_lsp/T723-027.signatureHelp.simple/test.json
+++ b/testsuite/ada_lsp/T723-027.signatureHelp.simple/test.json
@@ -40,7 +40,7 @@
                             ".",
                             "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      },
                      "signatureHelpProvider": {
                         "triggerCharacters": [

--- a/testsuite/ada_lsp/T826-026.search/test.json
+++ b/testsuite/ada_lsp/T826-026.search/test.json
@@ -84,7 +84,7 @@
                            ".",
                            "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      },
                      "hoverProvider": true,
                      "signatureHelpProvider": {

--- a/testsuite/ada_lsp/T923-019.project_reload.gnatpp/test.json
+++ b/testsuite/ada_lsp/T923-019.project_reload.gnatpp/test.json
@@ -81,7 +81,7 @@
                            ".",
                            "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      },
                      "hoverProvider": true,
                      "declarationProvider": true,

--- a/testsuite/ada_lsp/TB12-017.named.parameters.0/TB12-017.named.parameters.0.json
+++ b/testsuite/ada_lsp/TB12-017.named.parameters.0/TB12-017.named.parameters.0.json
@@ -83,7 +83,7 @@
                                     ".",
                                     "("
                                 ],
-                                "resolveProvider": false
+                                "resolveProvider": true
                             },
                             "hoverProvider": true,
                             "declarationProvider": true,

--- a/testsuite/ada_lsp/TB12-017.named.parameters.1/TB12-017.named.parameters.1.json
+++ b/testsuite/ada_lsp/TB12-017.named.parameters.1/TB12-017.named.parameters.1.json
@@ -83,7 +83,7 @@
                                     ".",
                                     "("
                                 ],
-                                "resolveProvider": false
+                                "resolveProvider": true
                             },
                             "hoverProvider": true,
                             "declarationProvider": true,

--- a/testsuite/ada_lsp/TB12-017.named.parameters.2/TB12-017.named.parameters.2.json
+++ b/testsuite/ada_lsp/TB12-017.named.parameters.2/TB12-017.named.parameters.2.json
@@ -83,7 +83,7 @@
                                     ".",
                                     "("
                                 ],
-                                "resolveProvider": false
+                                "resolveProvider": true
                             },
                             "hoverProvider": true,
                             "declarationProvider": true,

--- a/testsuite/ada_lsp/U121-013.enum_references/test.json
+++ b/testsuite/ada_lsp/U121-013.enum_references/test.json
@@ -82,7 +82,7 @@
                            ".",
                            "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      },
                      "hoverProvider": true,
                      "declarationProvider": true,

--- a/testsuite/ada_lsp/U416-030.refactor_change_parameter_mode_0/test.json
+++ b/testsuite/ada_lsp/U416-030.refactor_change_parameter_mode_0/test.json
@@ -183,7 +183,7 @@
                            ".",
                            "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      },
                      "hoverProvider": true,
                      "declarationProvider": true,

--- a/testsuite/ada_lsp/U416-030.refactor_remove_parameter_0/test.json
+++ b/testsuite/ada_lsp/U416-030.refactor_remove_parameter_0/test.json
@@ -183,7 +183,7 @@
                            ".",
                            "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      },
                      "hoverProvider": true,
                      "declarationProvider": true,

--- a/testsuite/ada_lsp/U429-030.signatureHelp.dot_call/test.json
+++ b/testsuite/ada_lsp/U429-030.signatureHelp.dot_call/test.json
@@ -42,7 +42,7 @@
                             ".",
                             "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      },
                      "signatureHelpProvider": {
                         "triggerCharacters": [

--- a/testsuite/ada_lsp/U511-009.refactoring.import_with_use/test.json
+++ b/testsuite/ada_lsp/U511-009.refactoring.import_with_use/test.json
@@ -39,7 +39,7 @@
                             ".",
                             "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      },
                      "signatureHelpProvider": {
                         "triggerCharacters": [

--- a/testsuite/ada_lsp/U614-038.edits.no_project/test.json
+++ b/testsuite/ada_lsp/U614-038.edits.no_project/test.json
@@ -233,7 +233,7 @@
                            ".",
                            "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      },
                      "hoverProvider": true,
                      "signatureHelpProvider": {

--- a/testsuite/ada_lsp/U721-012.signatureHelp.null_expr_funcs/test.json
+++ b/testsuite/ada_lsp/U721-012.signatureHelp.null_expr_funcs/test.json
@@ -85,7 +85,7 @@
                            ".",
                            "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      },
                      "hoverProvider": true,
                      "signatureHelpProvider": {

--- a/testsuite/ada_lsp/U805-023.signatureHelp.context/test.json
+++ b/testsuite/ada_lsp/U805-023.signatureHelp.context/test.json
@@ -86,7 +86,7 @@
                            ".",
                            "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      },
                      "hoverProvider": true,
                      "signatureHelpProvider": {

--- a/testsuite/ada_lsp/aggregate.is_called_by/test.json
+++ b/testsuite/ada_lsp/aggregate.is_called_by/test.json
@@ -85,7 +85,7 @@
                            ".",
                            "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      },
                      "hoverProvider": true,
                      "declarationProvider": true,

--- a/testsuite/ada_lsp/aggregate.references_after_update/test.json
+++ b/testsuite/ada_lsp/aggregate.references_after_update/test.json
@@ -68,7 +68,7 @@
                             ".",
                             "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      },
                      "documentSymbolProvider": true
                   }

--- a/testsuite/ada_lsp/aggregate.simple/test.json
+++ b/testsuite/ada_lsp/aggregate.simple/test.json
@@ -49,7 +49,7 @@
                             ".",
                             "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      },
                      "documentSymbolProvider": true
                   }

--- a/testsuite/ada_lsp/callHierarchy.abstract_subps/test.json
+++ b/testsuite/ada_lsp/callHierarchy.abstract_subps/test.json
@@ -84,7 +84,7 @@
                            ".",
                            "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      },
                      "hoverProvider": true,
                      "declarationProvider": true,

--- a/testsuite/ada_lsp/called_by.null_subp/test.json
+++ b/testsuite/ada_lsp/called_by.null_subp/test.json
@@ -84,7 +84,7 @@
                            ".",
                            "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      },
                      "hoverProvider": true,
                      "declarationProvider": true,

--- a/testsuite/ada_lsp/called_by.renames/test.json
+++ b/testsuite/ada_lsp/called_by.renames/test.json
@@ -84,7 +84,7 @@
                            ".",
                            "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      },
                      "hoverProvider": true,
                      "declarationProvider": true,

--- a/testsuite/ada_lsp/called_by/test.json
+++ b/testsuite/ada_lsp/called_by/test.json
@@ -84,7 +84,7 @@
                            ".",
                            "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      },
                      "hoverProvider": true,
                      "declarationProvider": true,

--- a/testsuite/ada_lsp/called_by_dispatching/test.json
+++ b/testsuite/ada_lsp/called_by_dispatching/test.json
@@ -84,7 +84,7 @@
                            ".",
                            "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      },
                      "hoverProvider": true,
                      "declarationProvider": true,

--- a/testsuite/ada_lsp/called_by_not_open/test.json
+++ b/testsuite/ada_lsp/called_by_not_open/test.json
@@ -84,7 +84,7 @@
                            ".",
                            "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      },
                      "hoverProvider": true,
                      "declarationProvider": true,

--- a/testsuite/ada_lsp/callgraph.named_blocks/test.json
+++ b/testsuite/ada_lsp/callgraph.named_blocks/test.json
@@ -84,7 +84,7 @@
                            ".",
                            "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      },
                      "hoverProvider": true,
                      "declarationProvider": true,

--- a/testsuite/ada_lsp/calls/test.json
+++ b/testsuite/ada_lsp/calls/test.json
@@ -84,7 +84,7 @@
                            ".",
                            "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      },
                      "hoverProvider": true,
                      "declarationProvider": true,

--- a/testsuite/ada_lsp/completion.aggregates.derived_types/test.json
+++ b/testsuite/ada_lsp/completion.aggregates.derived_types/test.json
@@ -78,7 +78,7 @@
                                   ".",
                                   "("
                               ],
-                              "resolveProvider": false
+                              "resolveProvider": true
                           },
                           "hoverProvider": true,
                           "declarationProvider": true,

--- a/testsuite/ada_lsp/completion.aggregates.simple/test.json
+++ b/testsuite/ada_lsp/completion.aggregates.simple/test.json
@@ -78,7 +78,7 @@
                                   ".",
                                   "("
                               ],
-                              "resolveProvider": false
+                              "resolveProvider": true
                           },
                           "hoverProvider": true,
                           "declarationProvider": true,

--- a/testsuite/ada_lsp/completion.complex_renames/test.json
+++ b/testsuite/ada_lsp/completion.complex_renames/test.json
@@ -73,7 +73,7 @@
                      "capabilities": {
                          "textDocumentSync": 2,
                          "completionProvider": {
-                             "resolveProvider": false,
+                             "resolveProvider": true,
                              "triggerCharacters": [
                                  ".",
                                  "("

--- a/testsuite/ada_lsp/completion.defining_names/test.json
+++ b/testsuite/ada_lsp/completion.defining_names/test.json
@@ -98,7 +98,7 @@
                            ".",
                            "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      }
                   }
                }

--- a/testsuite/ada_lsp/completion.end_labels/test.json
+++ b/testsuite/ada_lsp/completion.end_labels/test.json
@@ -78,7 +78,7 @@
                                  ".",
                                  "("
                              ],
-                             "resolveProvider": false
+                             "resolveProvider": true
                          },
                          "hoverProvider": true,
                          "declarationProvider": true,

--- a/testsuite/ada_lsp/completion.invisible.runtime/test.json
+++ b/testsuite/ada_lsp/completion.invisible.runtime/test.json
@@ -85,7 +85,7 @@
                            ".",
                            "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      },
                      "hoverProvider": true,
                      "signatureHelpProvider": {

--- a/testsuite/ada_lsp/completion.invisible/test.json
+++ b/testsuite/ada_lsp/completion.invisible/test.json
@@ -56,7 +56,7 @@
                                  ".",
                                  "("
                              ],
-                             "resolveProvider": false
+                             "resolveProvider": true
                          }
                      }
                  }

--- a/testsuite/ada_lsp/completion.invisible2/test.json
+++ b/testsuite/ada_lsp/completion.invisible2/test.json
@@ -53,7 +53,7 @@
                                  ".",
                                  "("
                              ],
-                             "resolveProvider": false
+                             "resolveProvider": true
                          }
                      }
                  }

--- a/testsuite/ada_lsp/completion.invisible3/test.json
+++ b/testsuite/ada_lsp/completion.invisible3/test.json
@@ -53,7 +53,7 @@
                                  ".",
                                  "("
                              ],
-                             "resolveProvider": false
+                             "resolveProvider": true
                          }
                      }
                  }

--- a/testsuite/ada_lsp/completion.invisible4/test.json
+++ b/testsuite/ada_lsp/completion.invisible4/test.json
@@ -53,7 +53,7 @@
                                  ".",
                                  "("
                              ],
-                             "resolveProvider": false
+                             "resolveProvider": true
                          }
                      }
                  }

--- a/testsuite/ada_lsp/completion.invisible5/test.json
+++ b/testsuite/ada_lsp/completion.invisible5/test.json
@@ -53,7 +53,7 @@
                                  ".",
                                  "("
                              ],
-                             "resolveProvider": false
+                             "resolveProvider": true
                          }
                      }
                  }

--- a/testsuite/ada_lsp/completion.keywords/test.json
+++ b/testsuite/ada_lsp/completion.keywords/test.json
@@ -96,7 +96,7 @@
                            ".",
                            "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      }
                   }
                }

--- a/testsuite/ada_lsp/completion.no_snippet_for_params/test.json
+++ b/testsuite/ada_lsp/completion.no_snippet_for_params/test.json
@@ -78,7 +78,7 @@
                            ".",
                            "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      },
                      "hoverProvider": true,
                      "declarationProvider": true,

--- a/testsuite/ada_lsp/completion.num_literals/test.json
+++ b/testsuite/ada_lsp/completion.num_literals/test.json
@@ -77,7 +77,7 @@
                            ".",
                            "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      }
                   }
                }

--- a/testsuite/ada_lsp/completion.subp_parameters/test.json
+++ b/testsuite/ada_lsp/completion.subp_parameters/test.json
@@ -74,7 +74,7 @@
                       "capabilities": {
                           "textDocumentSync": 2,
                           "completionProvider": {
-                              "resolveProvider": false,
+                              "resolveProvider": true,
                               "triggerCharacters": [
                                   ".",
                                   "("

--- a/testsuite/ada_lsp/completion.subp_params_dotted_names/test.json
+++ b/testsuite/ada_lsp/completion.subp_params_dotted_names/test.json
@@ -74,7 +74,7 @@
                       "capabilities": {
                           "textDocumentSync": 2,
                           "completionProvider": {
-                              "resolveProvider": false,
+                              "resolveProvider": true,
                               "triggerCharacters": [
                                   ".",
                                   "("

--- a/testsuite/ada_lsp/declaration.overridings_on_usage/test.json
+++ b/testsuite/ada_lsp/declaration.overridings_on_usage/test.json
@@ -84,7 +84,7 @@
                            ".",
                            "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      },
                      "hoverProvider": true,
                      "declarationProvider": true,

--- a/testsuite/ada_lsp/definition_and_overridings/test.json
+++ b/testsuite/ada_lsp/definition_and_overridings/test.json
@@ -68,7 +68,7 @@
                             ".",
                             "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      },
                      "documentSymbolProvider": true
                   }

--- a/testsuite/ada_lsp/definition_parents/test.json
+++ b/testsuite/ada_lsp/definition_parents/test.json
@@ -70,7 +70,7 @@
                             ".",
                             "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      },
                      "documentSymbolProvider": true
                   }

--- a/testsuite/ada_lsp/document_highlight/test.json
+++ b/testsuite/ada_lsp/document_highlight/test.json
@@ -362,7 +362,7 @@
                            ".",
                            "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      },
                      "hoverProvider": true,
                      "declarationProvider": true,

--- a/testsuite/ada_lsp/editor.incremental/test.json
+++ b/testsuite/ada_lsp/editor.incremental/test.json
@@ -285,7 +285,7 @@
                             ".",
                             "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      },
                      "documentSymbolProvider": true
                   }

--- a/testsuite/ada_lsp/find_all_refs_child_package/test.json
+++ b/testsuite/ada_lsp/find_all_refs_child_package/test.json
@@ -70,7 +70,7 @@
                             ".",
                             "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      },
                      "documentSymbolProvider": true
                   }

--- a/testsuite/ada_lsp/find_all_refs_subp/find_all_refs_subp.json
+++ b/testsuite/ada_lsp/find_all_refs_subp/find_all_refs_subp.json
@@ -94,7 +94,7 @@
                             ".",
                             "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      },
                      "referencesProvider": true
                   }

--- a/testsuite/ada_lsp/hover.for_loops/test.json
+++ b/testsuite/ada_lsp/hover.for_loops/test.json
@@ -97,7 +97,7 @@
                            ".",
                            "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      }
                   }
                }

--- a/testsuite/ada_lsp/implementation.aggregates/test.json
+++ b/testsuite/ada_lsp/implementation.aggregates/test.json
@@ -71,7 +71,7 @@
                             ".",
                             "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      },
                      "documentSymbolProvider": true
                   }

--- a/testsuite/ada_lsp/implementation.overridings/test.json
+++ b/testsuite/ada_lsp/implementation.overridings/test.json
@@ -71,7 +71,7 @@
                             ".",
                             "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      },
                      "documentSymbolProvider": true
                   }

--- a/testsuite/ada_lsp/implementation/test.json
+++ b/testsuite/ada_lsp/implementation/test.json
@@ -71,7 +71,7 @@
                             ".",
                             "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      },
                      "documentSymbolProvider": true
                   }

--- a/testsuite/ada_lsp/incorrect_fallback/incorrect_fallback.json
+++ b/testsuite/ada_lsp/incorrect_fallback/incorrect_fallback.json
@@ -108,7 +108,7 @@
                             ".",
                             "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      },
                      "definitionProvider": true
                   }

--- a/testsuite/ada_lsp/indexing_progress/test.json
+++ b/testsuite/ada_lsp/indexing_progress/test.json
@@ -49,7 +49,7 @@
                             ".",
                             "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      },
                      "documentSymbolProvider": true
                   }

--- a/testsuite/ada_lsp/invalidation.file_contents/test.json
+++ b/testsuite/ada_lsp/invalidation.file_contents/test.json
@@ -43,7 +43,7 @@
                             ".",
                             "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      },
                      "documentSymbolProvider": true
                   }

--- a/testsuite/ada_lsp/named_params.dot_calls/test.json
+++ b/testsuite/ada_lsp/named_params.dot_calls/test.json
@@ -71,7 +71,7 @@
                       "capabilities": {
                           "textDocumentSync": 2,
                           "completionProvider": {
-                              "resolveProvider": false,
+                              "resolveProvider": true,
                               "triggerCharacters": [
                                   ".",
                                   "("

--- a/testsuite/ada_lsp/preprocessor/test.json
+++ b/testsuite/ada_lsp/preprocessor/test.json
@@ -82,7 +82,7 @@
                            ".",
                            "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      },
                      "hoverProvider": true,
                      "declarationProvider": true,

--- a/testsuite/ada_lsp/refactor_imports_commands/refactor_imports_commands.json
+++ b/testsuite/ada_lsp/refactor_imports_commands/refactor_imports_commands.json
@@ -41,7 +41,7 @@
                                     ".",
                                     "("
                                 ],
-                                "resolveProvider": false
+                                "resolveProvider": true
                             },
                             "hoverProvider": true,
                             "declarationProvider": true,

--- a/testsuite/ada_lsp/references.child/test.json
+++ b/testsuite/ada_lsp/references.child/test.json
@@ -72,7 +72,7 @@
                             ".",
                             "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      },
                      "documentSymbolProvider": true
                   }

--- a/testsuite/ada_lsp/rename.not_up_to_date/test.json
+++ b/testsuite/ada_lsp/rename.not_up_to_date/test.json
@@ -43,7 +43,7 @@
                             ".",
                             "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      },
                      "documentSymbolProvider": true
                   }

--- a/testsuite/ada_lsp/rename.primitive_parameters/test.json
+++ b/testsuite/ada_lsp/rename.primitive_parameters/test.json
@@ -74,7 +74,7 @@
                            ".",
 			   "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      },
                      "documentSymbolProvider": true
                   }

--- a/testsuite/ada_lsp/rename.tagged_type_primitives/test.json
+++ b/testsuite/ada_lsp/rename.tagged_type_primitives/test.json
@@ -73,7 +73,7 @@
                             ".",
                             "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      },
                      "documentSymbolProvider": true
                   }

--- a/testsuite/ada_lsp/show_dependencies.aggregate/test.json
+++ b/testsuite/ada_lsp/show_dependencies.aggregate/test.json
@@ -78,7 +78,7 @@
                                   ".",
                                   "("
                               ],
-                              "resolveProvider": false
+                              "resolveProvider": true
                           },
                           "hoverProvider": true,
                           "declarationProvider": true,

--- a/testsuite/ada_lsp/show_dependencies/test.json
+++ b/testsuite/ada_lsp/show_dependencies/test.json
@@ -78,7 +78,7 @@
                                   ".",
                                   "("
                               ],
-                              "resolveProvider": false
+                              "resolveProvider": true
                           },
                           "hoverProvider": true,
                           "declarationProvider": true,

--- a/testsuite/ada_lsp/type_definition.aggregate/test.json
+++ b/testsuite/ada_lsp/type_definition.aggregate/test.json
@@ -70,7 +70,7 @@
                             ".",
                             "("
                         ],
-                        "resolveProvider": false
+                        "resolveProvider": true
                      },
                      "documentSymbolProvider": true
                   }


### PR DESCRIPTION
Use the newly added completionItem/resolve request to compute
the 'documentation' and 'detail' fieds of completion items lazily
when the client supports it (i.e: when a given item gets selected
in the completion window).

This makes the ALS way faster to return completion items for packages
that contain a huge number of declarations (e.g: Libadalang.Common).

VS Code already supports this lazy computation method but not other
clients.