### PR TITLE
Empty LD_LIBRARY_PATH seen by npm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ clean:
 	rm -rf integration/vscode/ada/$(PLATFORM)
 
 vscode:
-	cd integration/vscode/ada; npm install && npm run compile
+	cd integration/vscode/ada; LD_LIBRARY_PATH= npm install && npm run compile
 	@echo Now run:
 	@echo code --extensionDevelopmentPath=`pwd`/integration/vscode/ada/ `pwd`
 


### PR DESCRIPTION
This allows to build the vscode extension in the environment
development that has the gtk3 closure, avoiding an issue with
zlib versions mismatch.