### PR TITLE
U910-043: Fix parsing error for optional client capabilities

### DIFF
--- a/source/ada/lsp-ada_handlers.adb
+++ b/source/ada/lsp-ada_handlers.adb
@@ -784,7 +784,8 @@ package body LSP.Ada_Handlers is
              completionItem.Value.resolveSupport.Value.properties;
       end if;
 
-      if Value.capabilities.workspace.didChangeWatchedFiles
+      if Value.capabilities.workspace.didChangeWatchedFiles.Is_Set
+        and then Value.capabilities.workspace.didChangeWatchedFiles.Value
            .dynamicRegistration = True
       then
          Self.File_Monitor := new LSP.Client_Side_File_Monitors.File_Monitor
@@ -3311,8 +3312,9 @@ package body LSP.Ada_Handlers is
       --  Register rangeFormatting provider is the client supports
       --  dynamic registration for it (and we haven't done it before).
       if not Self.Range_Formatting_Enabled
-        and then Self.Client.capabilities.textDocument.rangeFormatting
-                   .dynamicRegistration = True
+        and then Self.Client.capabilities.textDocument.rangeFormatting.Is_Set
+        and then Self.Client.capabilities.textDocument.rangeFormatting.Value
+          .dynamicRegistration = True
       then
          declare
             Request : LSP.Messages.Client_Requests.RegisterCapability_Request;

--- a/source/protocol/lsp-messages.ads
+++ b/source/protocol/lsp-messages.ads
@@ -1656,6 +1656,12 @@ package LSP.Messages is
    for dynamicRegistration'Read use Read_dynamicRegistration;
    for dynamicRegistration'Write use Write_dynamicRegistration;
 
+   package Optional_dynamicRegistrations is
+     new LSP.Generic_Optional (dynamicRegistration);
+
+   type Optional_dynamicRegistration is
+     new Optional_dynamicRegistrations.Optional_Type;
+
    --
    --```typescript
    --export interface WorkspaceEditClientCapabilities {
@@ -1860,7 +1866,8 @@ package LSP.Messages is
    --	dynamicRegistration?: boolean;
    --}
    --```
-   subtype DidChangeConfigurationClientCapabilities is dynamicRegistration;
+   subtype DidChangeConfigurationClientCapabilities
+     is Optional_dynamicRegistration;
 
    --```typescript
    --export interface DidChangeWatchedFilesClientCapabilities {
@@ -1872,7 +1879,8 @@ package LSP.Messages is
    --	dynamicRegistration?: boolean;
    --}
    --```
-   subtype DidChangeWatchedFilesClientCapabilities is dynamicRegistration;
+   subtype DidChangeWatchedFilesClientCapabilities
+     is Optional_dynamicRegistration;
 
    --```typescript
    --interface WorkspaceSymbolClientCapabilities {
@@ -2083,7 +2091,7 @@ package LSP.Messages is
    --	dynamicRegistration?: boolean;
    --}
    --```
-   subtype ExecuteCommandClientCapabilities is dynamicRegistration;
+   subtype ExecuteCommandClientCapabilities is Optional_dynamicRegistration;
 
    --```typescript
    --export interface SemanticTokensWorkspaceClientCapabilities {
@@ -3217,7 +3225,7 @@ package LSP.Messages is
    --	dynamicRegistration?: boolean;
    --}
    --```
-   subtype ReferenceClientCapabilities is dynamicRegistration;
+   subtype ReferenceClientCapabilities is Optional_dynamicRegistration;
 
    --```typescript
    --export interface DocumentHighlightClientCapabilities {
@@ -3227,7 +3235,7 @@ package LSP.Messages is
    --	dynamicRegistration?: boolean;
    --}
    --```
-   subtype DocumentHighlightClientCapabilities is dynamicRegistration;
+   subtype DocumentHighlightClientCapabilities is Optional_dynamicRegistration;
 
    --```typescript
    --export interface CodeActionClientCapabilities {
@@ -3379,7 +3387,7 @@ package LSP.Messages is
    --	dynamicRegistration?: boolean;
    --}
    --```
-   subtype CodeLensClientCapabilities is dynamicRegistration;
+   subtype CodeLensClientCapabilities is Optional_dynamicRegistration;
 
    --```typescript
    --export interface DocumentLinkClientCapabilities {
@@ -3426,7 +3434,7 @@ package LSP.Messages is
    --	dynamicRegistration?: boolean;
    --}
    --```
-   subtype DocumentColorClientCapabilities is dynamicRegistration;
+   subtype DocumentColorClientCapabilities is Optional_dynamicRegistration;
 
    --```typescript
    --export interface DocumentFormattingClientCapabilities {
@@ -3436,7 +3444,7 @@ package LSP.Messages is
    --	dynamicRegistration?: boolean;
    --}
    --```
-   subtype DocumentFormattingClientCapabilities is dynamicRegistration;
+   subtype DocumentFormattingClientCapabilities is Optional_dynamicRegistration;
 
    --```typescript
    --export interface DocumentRangeFormattingClientCapabilities {
@@ -3446,7 +3454,7 @@ package LSP.Messages is
    --	dynamicRegistration?: boolean;
    --}
    --```
-   subtype DocumentRangeFormattingClientCapabilities is dynamicRegistration;
+   subtype DocumentRangeFormattingClientCapabilities is Optional_dynamicRegistration;
 
    --```typescript
    --export interface DocumentOnTypeFormattingClientCapabilities {
@@ -3456,7 +3464,7 @@ package LSP.Messages is
    --	dynamicRegistration?: boolean;
    --}
    --```
-   subtype DocumentOnTypeFormattingClientCapabilities is dynamicRegistration;
+   subtype DocumentOnTypeFormattingClientCapabilities is Optional_dynamicRegistration;
 
    --```typescript
    --export namespace PrepareSupportDefaultBehavior {
@@ -3694,7 +3702,7 @@ package LSP.Messages is
    --	dynamicRegistration?: boolean;
    --}
    --```
-   subtype SelectionRangeClientCapabilities is dynamicRegistration;
+   subtype SelectionRangeClientCapabilities is Optional_dynamicRegistration;
 
    --```typescript
    --export interface LinkedEditingRangeClientCapabilities {
@@ -3707,7 +3715,7 @@ package LSP.Messages is
    --	dynamicRegistration?: boolean;
    --}
    --```
-   subtype LinkedEditingRangeClientCapabilities is dynamicRegistration;
+   subtype LinkedEditingRangeClientCapabilities is Optional_dynamicRegistration;
 
    --```typescript
    --interface CallHierarchyClientCapabilities {
@@ -3720,7 +3728,7 @@ package LSP.Messages is
    --	dynamicRegistration?: boolean;
    --}
    --```
-   subtype CallHierarchyClientCapabilities is dynamicRegistration;
+   subtype CallHierarchyClientCapabilities is Optional_dynamicRegistration;
 
    --```typescript
    --export enum SemanticTokenTypes {
@@ -3993,7 +4001,7 @@ package LSP.Messages is
    --	dynamicRegistration?: boolean;
    --}
    --```
-   subtype MonikerClientCapabilities is dynamicRegistration;
+   subtype MonikerClientCapabilities is Optional_dynamicRegistration;
 
    --```typescript
    --/**

--- a/testsuite/ada_lsp/U910-043.client_capabilities.optional/test.json
+++ b/testsuite/ada_lsp/U910-043.client_capabilities.optional/test.json
@@ -1,0 +1,169 @@
+[
+   {
+      "comment": [
+         "Verify that the server doesn't crash when receiving null and not {}",
+         "for an optional client capability."
+      ]
+   },
+   {
+      "start": {
+         "cmd": [
+            "${ALS}"
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+               "processId": 40561,
+               "rootUri": "$URI{.}",
+               "capabilities": {
+                  "workspace": {
+                     "applyEdit": true,
+                     "workspaceEdit": {},
+                     "didChangeConfiguration": {},
+                     "didChangeWatchedFiles": {},
+                     "executeCommand": {}
+                  },
+                  "textDocument": {
+                     "synchronization": {},
+                     "completion": {
+                        "dynamicRegistration": true,
+                        "completionItem": {
+                           "snippetSupport": true,
+                           "documentationFormat": [
+                              "plaintext",
+                              "markdown"
+                           ]
+                        }
+                     },
+                     "hover": {},
+                     "signatureHelp": {},
+                     "declaration": {},
+                     "definition": {},
+                     "typeDefinition": {},
+                     "implementation": {},
+                     "references": {},
+                     "documentHighlight": {},
+                     "documentSymbol": {
+                        "hierarchicalDocumentSymbolSupport": true
+                     },
+                     "codeLens": {},
+                     "colorProvider": {},
+                     "formatting": {
+                        "dynamicRegistration": false
+                     },
+                     "rangeFormatting": {
+                        "dynamicRegistration": false
+                     },
+                     "onTypeFormatting": {
+                        "dynamicRegistration": false
+                     },
+                     "foldingRange": {
+                        "lineFoldingOnly": true
+                     },
+                     "selectionRange": null,
+                     "linkedEditingRange": null,
+                     "callHierarchy": null,
+                     "moniker": null
+                  }
+               }
+            }
+         },
+         "wait": [
+            {
+               "id": 1,
+               "result": {
+                  "capabilities": {
+                     "textDocumentSync": 2,
+                     "completionProvider": {
+                        "triggerCharacters": [
+                           ".",
+                           "("
+                        ],
+                        "resolveProvider": true
+                     },
+                     "hoverProvider": true,
+                     "signatureHelpProvider": {
+                        "triggerCharacters": [
+                           ",",
+                           "("
+                        ],
+                        "retriggerCharacters": [
+                           "\b"
+                        ]
+                     },
+                     "declarationProvider": true,
+                     "definitionProvider": true,
+                     "typeDefinitionProvider": true,
+                     "implementationProvider": true,
+                     "referencesProvider": true,
+                     "documentHighlightProvider": true,
+                     "documentSymbolProvider": true,
+                     "codeActionProvider": {},
+                     "documentFormattingProvider": true,
+                     "renameProvider": {},
+                     "foldingRangeProvider": true,
+                     "executeCommandProvider": {
+                        "commands": [
+                           "als-other-file",
+                           "als-named-parameters",
+                           "als-refactor-imports",
+                           "als-refactor-remove-parameters",
+                           "als-refactor-move-parameter",
+                           "als-refactor-change-parameter-mode",
+                           "als-suppress-separate"
+                        ]
+                     },
+                     "workspaceSymbolProvider": true,
+                     "callHierarchyProvider": {},
+                     "alsShowDepsProvider": true,
+                     "alsReferenceKinds": [
+                        "reference",
+                        "access",
+                        "write",
+                        "call",
+                        "dispatching call",
+                        "parent",
+                        "child"
+                     ]
+                  }
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "initialized"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": 16,
+            "method": "shutdown"
+         },
+         "wait": [
+            {
+               "id": 16,
+               "result": null
+            }
+         ]
+      }
+   },
+   {
+      "stop": {
+         "exit_code": 0
+      }
+   }
+]

--- a/testsuite/ada_lsp/U910-043.client_capabilities.optional/test.yaml
+++ b/testsuite/ada_lsp/U910-043.client_capabilities.optional/test.yaml
@@ -1,0 +1,1 @@
+title: 'U910-043.client_capabilities.optional'


### PR DESCRIPTION
Some client capabilities like "moniker" were not defined as
optional => The server was crashing if their value was "null".