### PR TITLE
U922-018: Don't send publishDiagnostics on didClose

### DIFF
--- a/source/ada/lsp-ada_handlers.adb
+++ b/source/ada/lsp-ada_handlers.adb
@@ -1976,7 +1976,6 @@ package body LSP.Ada_Handlers is
    is
       URI      : LSP.Messages.DocumentUri renames Value.textDocument.uri;
       File     : constant GNATCOLL.VFS.Virtual_File := Self.To_File (URI);
-      Diag     : LSP.Messages.PublishDiagnosticsParams;
       Document : Internal_Document_Access;
    begin
       if Self.Open_Documents.Contains (File) then
@@ -2000,12 +1999,6 @@ package body LSP.Ada_Handlers is
          Self.Trace.Trace
            ("received a didCloseTextDocument for non-open document with uri: "
             & To_UTF_8_String (URI));
-      end if;
-
-      --  Clean diagnostics up on closing document
-      if Self.Diagnostics_Enabled then
-         Diag.uri := URI;
-         Self.Server.On_Publish_Diagnostics (Diag);
       end if;
    end On_DidCloseTextDocument_Notification;
 

--- a/testsuite/ada_lsp/T923-019.project_reload.gnatpp/test.json
+++ b/testsuite/ada_lsp/T923-019.project_reload.gnatpp/test.json
@@ -229,15 +229,7 @@
                }
             }
          },
-         "wait": [
-            {
-               "method": "textDocument/publishDiagnostics",
-               "params": {
-                  "uri": "$URI{a.adb}",
-                  "diagnostics": []
-               }
-            }
-         ]
+         "wait": []
       }
    },
    {

--- a/testsuite/ada_lsp/publish_diag/diag_on_open.json
+++ b/testsuite/ada_lsp/publish_diag/diag_on_open.json
@@ -93,13 +93,7 @@
                     }
                 }
             },
-            "wait":[{
-                "method":"textDocument/publishDiagnostics",
-                "params":{
-                    "uri":"$URI{main.adb}",
-                    "diagnostics":[]
-                }
-            }]
+            "wait":[]
         }
     },  {
         "send": {

--- a/testsuite/ada_lsp/publish_diag/publish_diag.json
+++ b/testsuite/ada_lsp/publish_diag/publish_diag.json
@@ -129,15 +129,7 @@
                     }
                 }
             },
-            "wait":[
-               {
-               "params": {
-                  "uri": "$URI{aaa.ads}",
-                  "diagnostics": []
-               },
-               "method": "textDocument/publishDiagnostics"
-              }
-           ]
+            "wait":[]
         }
     }, {
         "send": {


### PR DESCRIPTION
We were sending diagnostics after the document was already closed,
at this point this is the responsability of the client to free
the diagnostics (without receiving an empty list).