### PR TITLE
U929-049: Completion param provider enhancement

### DIFF
--- a/source/ada/lsp-ada_completions-aggregates.adb
+++ b/source/ada/lsp-ada_completions-aggregates.adb
@@ -376,8 +376,8 @@ package body LSP.Ada_Completions.Aggregates is
       Token  :     Libadalang.Common.Token_Reference;
       Node   :     Libadalang.Analysis.Ada_Node;
       Filter : in out LSP.Ada_Completions.Filters.Filter;
-      Names  : out Ada_Completions.Completion_Maps.Map;
-      Result : out LSP.Messages.CompletionList)
+      Names  : in out Ada_Completions.Completion_Maps.Map;
+      Result : in out LSP.Messages.CompletionList)
    is
       pragma Unreferenced (Filter);
       pragma Unreferenced (Names);

--- a/source/ada/lsp-ada_completions-aggregates.ads
+++ b/source/ada/lsp-ada_completions-aggregates.ads
@@ -37,8 +37,8 @@ package LSP.Ada_Completions.Aggregates is
       Token  : Libadalang.Common.Token_Reference;
       Node   : Libadalang.Analysis.Ada_Node;
       Filter : in out LSP.Ada_Completions.Filters.Filter;
-      Names  : out Ada_Completions.Completion_Maps.Map;
-      Result : out LSP.Messages.CompletionList);
+      Names  : in out Ada_Completions.Completion_Maps.Map;
+      Result : in out LSP.Messages.CompletionList);
    --  Check if we are dealing with an aggregate node. If yes, handle it
    --  separately to propose snipppets to the user, allowing him to fill
    --  all the needed discriminants/components easily.

--- a/source/ada/lsp-ada_completions-aspects.adb
+++ b/source/ada/lsp-ada_completions-aspects.adb
@@ -28,13 +28,13 @@ package body LSP.Ada_Completions.Aspects is
    ------------------------
 
    overriding procedure Propose_Completion
-     (Self   :     Aspect_Completion_Provider;
-      Sloc   :     Langkit_Support.Slocs.Source_Location;
-      Token  :     Libadalang.Common.Token_Reference;
-      Node   :     Libadalang.Analysis.Ada_Node;
+     (Self   : Aspect_Completion_Provider;
+      Sloc   : Langkit_Support.Slocs.Source_Location;
+      Token  : Libadalang.Common.Token_Reference;
+      Node   : Libadalang.Analysis.Ada_Node;
       Filter : in out LSP.Ada_Completions.Filters.Filter;
-      Names  : out Ada_Completions.Completion_Maps.Map;
-      Result : out LSP.Messages.CompletionList)
+      Names  : in out Ada_Completions.Completion_Maps.Map;
+      Result : in out LSP.Messages.CompletionList)
    is
       pragma Unreferenced (Filter);
       pragma Unreferenced (Names);

--- a/source/ada/lsp-ada_completions-aspects.ads
+++ b/source/ada/lsp-ada_completions-aspects.ads
@@ -26,8 +26,8 @@ package LSP.Ada_Completions.Aspects is
       Token  : Libadalang.Common.Token_Reference;
       Node   : Libadalang.Analysis.Ada_Node;
       Filter : in out LSP.Ada_Completions.Filters.Filter;
-      Names  : out Ada_Completions.Completion_Maps.Map;
-      Result : out LSP.Messages.CompletionList);
+      Names  : in out Ada_Completions.Completion_Maps.Map;
+      Result : in out LSP.Messages.CompletionList);
    --  Get completion for aspects if we are within an aspect association
    --  node and return immediatly since we only expect aspects here.
 

--- a/source/ada/lsp-ada_completions-keywords.adb
+++ b/source/ada/lsp-ada_completions-keywords.adb
@@ -38,8 +38,8 @@ package body LSP.Ada_Completions.Keywords is
       Token  : Libadalang.Common.Token_Reference;
       Node   : Libadalang.Analysis.Ada_Node;
       Filter : in out LSP.Ada_Completions.Filters.Filter;
-      Names  : out Ada_Completions.Completion_Maps.Map;
-      Result : out LSP.Messages.CompletionList)
+      Names  : in out Ada_Completions.Completion_Maps.Map;
+      Result : in out LSP.Messages.CompletionList)
    is
       pragma Unreferenced (Names);
       Prev   : constant Libadalang.Common.Token_Reference :=

--- a/source/ada/lsp-ada_completions-keywords.ads
+++ b/source/ada/lsp-ada_completions-keywords.ads
@@ -27,8 +27,8 @@ package LSP.Ada_Completions.Keywords is
       Token  : Libadalang.Common.Token_Reference;
       Node   : Libadalang.Analysis.Ada_Node;
       Filter : in out LSP.Ada_Completions.Filters.Filter;
-      Names  : out Ada_Completions.Completion_Maps.Map;
-      Result : out LSP.Messages.CompletionList);
+      Names  : in out Ada_Completions.Completion_Maps.Map;
+      Result : in out LSP.Messages.CompletionList);
    --  Get completion for keywords, filtering them with the prefix.
 
 end LSP.Ada_Completions.Keywords;

--- a/source/ada/lsp-ada_completions-names.adb
+++ b/source/ada/lsp-ada_completions-names.adb
@@ -37,10 +37,9 @@ package body LSP.Ada_Completions.Names is
       Token  : Libadalang.Common.Token_Reference;
       Node   : Libadalang.Analysis.Ada_Node;
       Filter : in out LSP.Ada_Completions.Filters.Filter;
-      Names  : out Ada_Completions.Completion_Maps.Map;
-      Result : out LSP.Messages.CompletionList)
+      Names  : in out Ada_Completions.Completion_Maps.Map;
+      Result : in out LSP.Messages.CompletionList)
    is
-      pragma Unreferenced (Result);
       use all type Libadalang.Analysis.Base_Id;
       use all type Libadalang.Common.Ada_Node_Kind_Type;
 
@@ -136,7 +135,7 @@ package body LSP.Ada_Completions.Names is
 
          Item                : Completion_Item;
          BD                  : Basic_Decl;
-         Completion_Count    : Natural := 0;
+         Completion_Count    : Natural := Natural (Result.items.Length);
          Name                : VSS.Strings.Virtual_String;
       begin
          while Next (Raw_Completions, Item) loop

--- a/source/ada/lsp-ada_completions-names.ads
+++ b/source/ada/lsp-ada_completions-names.ads
@@ -27,7 +27,7 @@ package LSP.Ada_Completions.Names is
       Token  : Libadalang.Common.Token_Reference;
       Node   : Libadalang.Analysis.Ada_Node;
       Filter : in out LSP.Ada_Completions.Filters.Filter;
-      Names  : out Ada_Completions.Completion_Maps.Map;
-      Result : out LSP.Messages.CompletionList);
+      Names  : in out Ada_Completions.Completion_Maps.Map;
+      Result : in out LSP.Messages.CompletionList);
 
 end LSP.Ada_Completions.Names;

--- a/source/ada/lsp-ada_completions-parameters.ads
+++ b/source/ada/lsp-ada_completions-parameters.ads
@@ -21,7 +21,8 @@ with LSP.Ada_Handlers;
 package LSP.Ada_Completions.Parameters is
 
    type Parameter_Completion_Provider
-     (Context : not null LSP.Ada_Handlers.Context_Access)
+     (Context                 : not null LSP.Ada_Handlers.Context_Access;
+      Compute_Doc_And_Details : Boolean)
    is new Completion_Provider with null record;
 
    overriding procedure Propose_Completion
@@ -30,8 +31,8 @@ package LSP.Ada_Completions.Parameters is
       Token  : Libadalang.Common.Token_Reference;
       Node   : Libadalang.Analysis.Ada_Node;
       Filter : in out LSP.Ada_Completions.Filters.Filter;
-      Names  : out Ada_Completions.Completion_Maps.Map;
-      Result : out LSP.Messages.CompletionList);
+      Names  : in out Ada_Completions.Completion_Maps.Map;
+      Result : in out LSP.Messages.CompletionList);
    --  Using the context, check if we are inside a function call and get its
    --  unset parameters while filtering them with the prefix.
 

--- a/source/ada/lsp-ada_completions-pragmas.adb
+++ b/source/ada/lsp-ada_completions-pragmas.adb
@@ -28,13 +28,13 @@ package body LSP.Ada_Completions.Pragmas is
    ------------------------
 
    overriding procedure Propose_Completion
-     (Self   :     Pragma_Completion_Provider;
-      Sloc   :     Langkit_Support.Slocs.Source_Location;
-      Token  :     Libadalang.Common.Token_Reference;
-      Node   :     Libadalang.Analysis.Ada_Node;
+     (Self   : Pragma_Completion_Provider;
+      Sloc   : Langkit_Support.Slocs.Source_Location;
+      Token  : Libadalang.Common.Token_Reference;
+      Node   : Libadalang.Analysis.Ada_Node;
       Filter : in out LSP.Ada_Completions.Filters.Filter;
-      Names  : out Ada_Completions.Completion_Maps.Map;
-      Result : out LSP.Messages.CompletionList)
+      Names  : in out Ada_Completions.Completion_Maps.Map;
+      Result : in out LSP.Messages.CompletionList)
    is
       pragma Unreferenced (Filter);
       pragma Unreferenced (Names);

--- a/source/ada/lsp-ada_completions-pragmas.ads
+++ b/source/ada/lsp-ada_completions-pragmas.ads
@@ -26,8 +26,8 @@ package LSP.Ada_Completions.Pragmas is
       Token  : Libadalang.Common.Token_Reference;
       Node   : Libadalang.Analysis.Ada_Node;
       Filter : in out LSP.Ada_Completions.Filters.Filter;
-      Names  : out Ada_Completions.Completion_Maps.Map;
-      Result : out LSP.Messages.CompletionList);
+      Names  : in out Ada_Completions.Completion_Maps.Map;
+      Result : in out LSP.Messages.CompletionList);
    --  Get completion for pragmas if we are within an pragma node and return
    --  immediately, since we don't want to propose other items than pragmas
    --  when wthin a pragma node.

--- a/source/ada/lsp-ada_completions.ads
+++ b/source/ada/lsp-ada_completions.ads
@@ -74,8 +74,8 @@ package LSP.Ada_Completions is
       Token  : Libadalang.Common.Token_Reference;
       Node   : Libadalang.Analysis.Ada_Node;
       Filter : in out LSP.Ada_Completions.Filters.Filter;
-      Names  : out Ada_Completions.Completion_Maps.Map;
-      Result : out LSP.Messages.CompletionList) is abstract;
+      Names  : in out Ada_Completions.Completion_Maps.Map;
+      Result : in out LSP.Messages.CompletionList) is abstract;
    --  Populate Names and Result with completions for given Source_Location.
    --  Names works for defining name completions to create snippets and to
    --  avoid duplicates. The Token's span encloses Sloc or Sloc can be at the

--- a/source/ada/lsp-ada_documents.ads
+++ b/source/ada/lsp-ada_documents.ads
@@ -261,6 +261,14 @@ package LSP.Ada_Documents is
    --  when computing subprogram snippets.
    --  Completions_Count is the total number of completion items.
 
+   procedure Set_Completion_Item_Documentation
+     (Context                 : LSP.Ada_Contexts.Context;
+      BD                      : Libadalang.Analysis.Basic_Decl;
+      Item                    : in out LSP.Messages.CompletionItem;
+      Compute_Doc_And_Details : Boolean);
+   --  Either set the item documentation and details or setup it to produce
+   --  them for the Completion_Resolve request.
+
    function Get_Source_Location
      (Self     : Document'Class;
       Position : LSP.Messages.Position)

--- a/source/ada/lsp-ada_handlers-invisibles.adb
+++ b/source/ada/lsp-ada_handlers-invisibles.adb
@@ -29,13 +29,13 @@ package body LSP.Ada_Handlers.Invisibles is
    ------------------------
 
    overriding procedure Propose_Completion
-     (Self   :     Invisible_Completion_Provider;
-      Sloc   :     Langkit_Support.Slocs.Source_Location;
-      Token  :     Libadalang.Common.Token_Reference;
-      Node   :     Libadalang.Analysis.Ada_Node;
+     (Self   : Invisible_Completion_Provider;
+      Sloc   : Langkit_Support.Slocs.Source_Location;
+      Token  : Libadalang.Common.Token_Reference;
+      Node   : Libadalang.Analysis.Ada_Node;
       Filter : in out LSP.Ada_Completions.Filters.Filter;
-      Names  : out Ada_Completions.Completion_Maps.Map;
-      Result : out LSP.Messages.CompletionList)
+      Names  : in out Ada_Completions.Completion_Maps.Map;
+      Result : in out LSP.Messages.CompletionList)
    is
       pragma Unreferenced (Result);
       use all type Libadalang.Common.Token_Kind;

--- a/source/ada/lsp-ada_handlers-invisibles.ads
+++ b/source/ada/lsp-ada_handlers-invisibles.ads
@@ -35,7 +35,7 @@ package LSP.Ada_Handlers.Invisibles is
       Token  : Libadalang.Common.Token_Reference;
       Node   : Libadalang.Analysis.Ada_Node;
       Filter : in out LSP.Ada_Completions.Filters.Filter;
-      Names  : out Ada_Completions.Completion_Maps.Map;
-      Result : out LSP.Messages.CompletionList);
+      Names  : in out Ada_Completions.Completion_Maps.Map;
+      Result : in out LSP.Messages.CompletionList);
 
 end LSP.Ada_Handlers.Invisibles;

--- a/source/ada/lsp-ada_handlers.adb
+++ b/source/ada/lsp-ada_handlers.adb
@@ -4030,6 +4030,17 @@ package body LSP.Ada_Handlers is
 
       Limit : constant := 10;
 
+      --  If lazy computation for the 'detail' and 'documentation' fields is
+      --  supported by the client, set the Compute_Doc_And_Details flag to
+      --  False.
+      Compute_Doc_And_Details : constant Boolean :=
+        not
+          (Self.Completion_Resolve_Properties.Contains
+             (VSS.Strings.Conversions.To_Virtual_String ("detail"))
+           and then
+             Self.Completion_Resolve_Properties.Contains
+                (VSS.Strings.Conversions.To_Virtual_String ("documentation")));
+
       P1 : aliased LSP.Ada_Completions.Aggregates
         .Aggregate_Completion_Provider
           (Named_Notation_Threshold => Self.Named_Notation_Threshold);
@@ -4042,7 +4053,9 @@ package body LSP.Ada_Handlers is
       P6 : aliased LSP.Ada_Handlers.Invisibles.Invisible_Completion_Provider
         (Self, Context);
       P7 : aliased
-        LSP.Ada_Completions.Parameters.Parameter_Completion_Provider (Context);
+        LSP.Ada_Completions.Parameters.Parameter_Completion_Provider
+          (Context                 => Context,
+           Compute_Doc_And_Details => Compute_Doc_And_Details);
 
       Providers : constant LSP.Ada_Completions.Completion_Provider_List :=
         (P1'Unchecked_Access,
@@ -4058,23 +4071,7 @@ package body LSP.Ada_Handlers is
 
       Response : LSP.Messages.Server_Responses.Completion_Response
         (Is_Error => False);
-      Compute_Doc_And_Details : Boolean := True;
-
    begin
-
-      --  If lazy computation for the 'detail' and 'documentation' fields is
-      --  supported by the client, set the Compute_Doc_And_Details flag to
-      --  False.
-
-      if Self.Completion_Resolve_Properties.Contains
-         (VSS.Strings.Conversions.To_Virtual_String ("detail"))
-        and then
-          Self.Completion_Resolve_Properties.Contains
-            (VSS.Strings.Conversions.To_Virtual_String ("documentation"))
-      then
-         Compute_Doc_And_Details := False;
-      end if;
-
       Document.Get_Completions_At
         (Context                  => Context.all,
          Providers                => Providers,

--- a/testsuite/ada_lsp/U913-028.completion.params/test.json
+++ b/testsuite/ada_lsp/U913-028.completion.params/test.json
@@ -19,92 +19,53 @@
             "id": 1,
             "method": "initialize",
             "params": {
-               "processId": 4969,
+               "processId": 199714,
                "rootUri": "$URI{.}",
                "capabilities": {
                   "workspace": {
-                     "applyEdit": true,
-                     "workspaceEdit": {},
-                     "didChangeConfiguration": {},
-                     "didChangeWatchedFiles": {},
-                     "executeCommand": {}
+                     "applyEdit": true
                   },
                   "textDocument": {
-                     "synchronization": {},
                      "completion": {
-                        "dynamicRegistration": true,
                         "completionItem": {
                            "snippetSupport": true,
                            "documentationFormat": [
-                              "plaintext",
-                              "markdown"
-                           ]
+                              "markdown",
+                              "plaintext"
+                           ],
+                            "resolveSupport": {
+                                "properties": [
+                                    "documentation",
+                                    "detail"
+                                ]
+                            }
                         }
-                     },
-                     "hover": {},
-                     "signatureHelp": {},
-                     "declaration": {},
-                     "definition": {},
-                     "typeDefinition": {},
-                     "implementation": {},
-                     "references": {},
-                     "documentHighlight": {},
-                     "documentSymbol": {
-                        "hierarchicalDocumentSymbolSupport": true
-                     },
-                     "codeLens": {},
-                     "colorProvider": {},
-                     "formatting": {
-                        "dynamicRegistration": true
-                     },
-                     "rangeFormatting": {},
-                     "onTypeFormatting": {},
-                     "foldingRange": {
-                        "lineFoldingOnly": true
-                     },
-                     "selectionRange": {}
+                     }
+                  },
+                  "window": {
+                     "workDoneProgress": true
                   }
                }
             }
          },
          "wait": [
-            {
-               "id": 1,
-               "result": {
-                  "capabilities": {
-                     "textDocumentSync": 2,
-                     "completionProvider": {
-                        "triggerCharacters": [
-                           ".",
-                           ",",
-                           "("
-                        ],
-                        "resolveProvider": true
-                     },
-                     "hoverProvider": true,
-                     "declarationProvider": true,
-                     "definitionProvider": true,
-                     "typeDefinitionProvider": true,
-                     "implementationProvider": true,
-                     "referencesProvider": true,
-                     "codeActionProvider": {},
-                     "documentFormattingProvider": true,
-                     "renameProvider": {},
-                     "foldingRangeProvider": true,
-                     "executeCommandProvider": {},
-                     "alsShowDepsProvider": true,
-                     "alsReferenceKinds": [
-                        "reference",
-                        "access",
-                        "write",
-                        "call",
-                        "dispatching call",
-                        "parent",
-                        "child"
-                     ]
-                  }
-               }
-            }
+             {
+                 "jsonrpc": "2.0",
+                 "id": 1,
+                 "result": {
+                     "capabilities": {
+                         "textDocumentSync": 2,
+                         "completionProvider": {
+                             "triggerCharacters": [
+                                 ".",
+                                 ",",
+                                 "("
+                             ],
+                             "resolveProvider": true
+                         }
+                     }
+                 }
+             }
          ]
       }
    },
@@ -178,14 +139,16 @@
                   "items": [
                      {
                         "label": "I",
-                        "kind": 1,
+                        "kind": 5,
+                        "sortText": "1",
                         "insertText": "I => ",
                         "insertTextFormat": 1,
                         "additionalTextEdits": []
                      },
                      {
                         "label": "F",
-                        "kind": 1,
+                        "kind": 5,
+                        "sortText": "2",
                         "insertText": "F => ",
                         "insertTextFormat": 1,
                         "additionalTextEdits": []
@@ -193,20 +156,36 @@
                      {
                         "label": "Params of Bar",
                         "kind": 15,
+                        "sortText": "0",
                         "insertText": "I => $1, F => $2)$0",
                         "insertTextFormat": 2,
-                        "additionalTextEdits": []
+                        "additionalTextEdits": [],
+                        "data": {
+                           "uri": "$URI{foo.adb}",
+                           "range": {
+                              "start": {
+                                  "line": 2,
+                                  "character": 3
+                              },
+                              "end": {
+                                  "line": 2,
+                                  "character": 42
+                              }
+                           }
+                        }
                      },
                      {
                         "label": "I",
-                        "kind": 1,
+                        "kind": 5,
+                        "sortText": "4",
                         "insertText": "I => ",
                         "insertTextFormat": 1,
                         "additionalTextEdits": []
                      },
                      {
                         "label": "J",
-                        "kind": 1,
+                        "kind": 5,
+                        "sortText": "5",
                         "insertText": "J => ",
                         "insertTextFormat": 1,
                         "additionalTextEdits": []
@@ -214,9 +193,23 @@
                      {
                         "label": "Params of Bar",
                         "kind": 15,
+                        "sortText": "3",
                         "insertText": "I => $1, J => $2)$0",
                         "insertTextFormat": 2,
-                        "additionalTextEdits": []
+                        "additionalTextEdits": [],
+                        "data": {
+                           "uri": "$URI{foo.adb}",
+                           "range": {
+                              "start": {
+                                  "line": 1,
+                                  "character": 3
+                              },
+                              "end": {
+                                  "line": 1,
+                                  "character": 34
+                              }
+                           }
+                        }
                      }
                   ]
                }
@@ -396,7 +389,8 @@
                   "items": [
                      {
                         "label": "I",
-                        "kind": 1,
+                        "kind": 5,
+                        "sortText": "1",
                         "insertText": "I => ",
                         "insertTextFormat": 1,
                         "additionalTextEdits": []
@@ -404,9 +398,23 @@
                      {
                         "label": "Params of Bar",
                         "kind": 15,
+                        "sortText": "0",
                         "insertText": "I => $1)$0",
                         "insertTextFormat": 2,
-                        "additionalTextEdits": []
+                        "additionalTextEdits": [],
+                        "data": {
+                           "uri": "$URI{foo.adb}",
+                           "range": {
+                              "start": {
+                                  "line": 2,
+                                  "character": 3
+                              },
+                              "end": {
+                                  "line": 2,
+                                  "character": 42
+                              }
+                           }
+                        }
                      }
                   ]
                }

--- a/testsuite/ada_lsp/U915-024.completion.invisible_snippets/test.json
+++ b/testsuite/ada_lsp/U915-024.completion.invisible_snippets/test.json
@@ -213,7 +213,7 @@
                      {
                         "label": "Do_Something (invisible)",
                         "kind": 3,
-                        "sortText": "~Do_Something",
+                        "sortText": "~0Do_Something",
                         "filterText": "Do_Something",
                         "insertText": "Do_Something",
                         "additionalTextEdits": [],

--- a/testsuite/ada_lsp/completion.invisible.runtime/test.json
+++ b/testsuite/ada_lsp/completion.invisible.runtime/test.json
@@ -222,7 +222,7 @@
                                   "kind": 9,
                                   "detail": "package Ada.Short_Float_Text_IO is\nnew Ada.Text_IO.Float_IO (Short_Float);",
                                   "documentation": "at a-sfteio.ads (18:1)",
-                                  "sortText": "~Short_Float_Text_IO",
+                                  "sortText": "~48Short_Float_Text_IO",
                                   "filterText": "Short_Float_Text_IO",
                                   "insertText": "Short_Float_Text_IO",
                                   "additionalTextEdits": [

--- a/testsuite/ada_lsp/completion.invisible/test.json
+++ b/testsuite/ada_lsp/completion.invisible/test.json
@@ -151,14 +151,14 @@
                         "kind": 6,
                         "detail": "Invisible : Integer;",
                         "documentation": "at aaa.ads (2:4)",
-                        "sortText": "~Invisible"
+                        "sortText": "~0Invisible"
                      },
                      {
                         "label": "Invisible_Function (invisible)",
                         "kind": 3,
                         "detail": "function Invisible_Function (X, Y : Integer) return Integer",
                         "documentation": "at aaa.ads (4:4)",
-                        "sortText": "~Invisible_Function",
+                        "sortText": "~1Invisible_Function",
                         "insertText": "Invisible_Function",
                         "additionalTextEdits": [
                         ]
@@ -304,14 +304,14 @@
                         "kind": 6,
                         "detail": "Invisible : Integer;",
                         "documentation": "at aaa.ads (2:4)",
-                        "sortText": "~Invisible"
+                        "sortText": "~0Invisible"
                      },
                      {
                         "label": "Invisible_Function (invisible)",
                         "kind": 3,
                         "detail": "function Invisible_Function (X, Y : Integer) return Integer",
                         "documentation": "at aaa.ads (4:4)",
-                        "sortText": "~Invisible_Function",
+                        "sortText": "~1Invisible_Function",
                         "insertText": "Invisible_Function",
                         "additionalTextEdits": [
                         ]

--- a/testsuite/ada_lsp/completion.invisible3/test.json
+++ b/testsuite/ada_lsp/completion.invisible3/test.json
@@ -147,7 +147,7 @@
                         "kind": 3,
                         "detail": "function ABC1 return Integer",
                         "documentation": "at pkg.ads (3:4)",
-                        "sortText": "~ABC1",
+                        "sortText": "~0ABC1",
                         "insertText": "ABC1",
                         "additionalTextEdits": []
                      },
@@ -156,7 +156,7 @@
                         "kind": 9,
                         "detail": "generic\n      ABC13 : Integer;\npackage ABC14 ",
                         "documentation": "at pkg.ads (19:4)",
-                        "sortText": "~ABC14",
+                        "sortText": "~1ABC14",
                         "insertText": "ABC14",
                         "additionalTextEdits": []
                      },
@@ -165,7 +165,7 @@
                         "kind": 7,
                         "detail": "type ABC4 (ABC5 : Integer) is record\n   ABC6 : Boolean := (for some ABC7 in Boolean => ABC7);\nend record;",
                         "documentation": "at pkg.ads (5:4)",
-                        "sortText": "~ABC4",
+                        "sortText": "~2ABC4",
                         "insertText": "ABC4",
                         "additionalTextEdits": []
                      }

--- a/testsuite/ada_lsp/completion.invisible4/test.json
+++ b/testsuite/ada_lsp/completion.invisible4/test.json
@@ -147,6 +147,7 @@
                         "kind": 9,
                         "detail": "package Pkg_1.Child ",
                         "documentation": "at pkg_1-child.ads (3:1)",
+                        "sortText": "1Child",
                         "additionalTextEdits": []
                      },
                      {
@@ -154,7 +155,7 @@
                         "kind": 9,
                         "detail": "package Pkg_1.Child2 ",
                         "documentation": "at pkg_1-child2.ads (1:1)",
-                        "sortText": "~Child2",
+                        "sortText": "~2Child2",
                         "insertText": "Child2",
                         "additionalTextEdits": [
                         ]

--- a/testsuite/ada_lsp/completion.lazy_computation/test.json
+++ b/testsuite/ada_lsp/completion.lazy_computation/test.json
@@ -155,7 +155,7 @@
                      {
                         "label": "Select_Some",
                         "kind": 3,
-                        "sortText": "1Select_Some",
+                        "sortText": "2Select_Some",
                         "additionalTextEdits": [],
                         "data": {
                            "uri": "$URI{test.ads}",


### PR DESCRIPTION
- Add documentation for "Params of X" item (use lazy computation
if possible)
- Keep the results grouped by family
- Fix the kind of param item
- Fix sortText for invisible symbols

Adapt tests