### PR TITLE
Adapt test on edge after LAL improvements...

### DIFF
--- a/testsuite/ada_lsp/U429-030.signatureHelp.dot_call/test.json
+++ b/testsuite/ada_lsp/U429-030.signatureHelp.dot_call/test.json
@@ -75,7 +75,7 @@
             "params": {
                "settings": {
                   "ada": {
-                     "projectFile": "$URI{test.gpr}", 
+                     "projectFile": "$URI{default.gpr}",
                      "scenarioVariables": {},
                      "defaultCharset": "ISO-8859-1"
                   }
@@ -1631,7 +1631,7 @@
                               "label": "B"
                            }
                         ],
-                        "activeParameter": 0
+                        "activeParameter": 1
                      },
                      {
                         "label": "procedure Hello (A : Integer; B : Float)",
@@ -3199,7 +3199,7 @@
                               "label": "B"
                            }
                         ],
-                        "activeParameter": 2
+                        "activeParameter": 1
                      }
                   ],
                   "activeSignature": 0,


### PR DESCRIPTION
... this is related to a better handling of "A => " when no value
is provided (before the related nodes were discarded).