### PR TITLE
U922-009 Don't index files after `shutdown` request

### DIFF
--- a/source/ada/lsp-ada_handlers.adb
+++ b/source/ada/lsp-ada_handlers.adb
@@ -843,8 +843,11 @@ package body LSP.Ada_Handlers is
       Request : LSP.Messages.Server_Requests.Shutdown_Request)
       return LSP.Messages.Server_Responses.Shutdown_Response
    is
-      pragma Unreferenced (Self, Request);
+      pragma Unreferenced (Request);
    begin
+      --  Suspend files/runtime indexing after shutdown requst
+      Self.Indexing_Enabled := False;
+
       return Response : LSP.Messages.Server_Responses.Shutdown_Response
         (Is_Error => False);
    end On_Shutdown_Request;


### PR DESCRIPTION
because it's useless and causes timeout on some tests.