### PR TITLE
UA26-012: Don't set isIncomplete to True for completion

### DIFF
--- a/source/ada/lsp-ada_handlers.adb
+++ b/source/ada/lsp-ada_handlers.adb
@@ -4035,8 +4035,6 @@ package body LSP.Ada_Handlers is
       Request : LSP.Messages.Server_Requests.Completion_Request)
       return LSP.Messages.Server_Responses.Completion_Response
    is
-      use type Ada.Containers.Count_Type;
-
       --  We're completing only based on one context, ie one project
       --  tree: this seems reasonable. One further refinement could
       --  be to return only results that are available for all
@@ -4049,8 +4047,6 @@ package body LSP.Ada_Handlers is
         Self.Contexts.Get_Best_Context (Value.textDocument.uri);
 
       Names     : LSP.Ada_Completions.Completion_Maps.Map;
-
-      Limit : constant := 10;
 
       --  If lazy computation for the 'detail' and 'documentation' fields is
       --  supported by the client, set the Compute_Doc_And_Details flag to
@@ -4111,8 +4107,6 @@ package body LSP.Ada_Handlers is
          Named_Notation_Threshold => Self.Named_Notation_Threshold,
          Compute_Doc_And_Details  => Compute_Doc_And_Details,
          Result                   => Response.result.items);
-
-      Response.result.isIncomplete := Names.Length >= Limit;
 
       return Response;
    end On_Completion_Request;

--- a/testsuite/ada_lsp/completion.invisible.runtime/main.adb
+++ b/testsuite/ada_lsp/completion.invisible.runtime/main.adb
@@ -1,5 +1,5 @@
 
 procedure Main is
 begin
-   Ada.Te
+   Ada.Decim
 end Main;

--- a/testsuite/ada_lsp/completion.invisible.runtime/test.json
+++ b/testsuite/ada_lsp/completion.invisible.runtime/test.json
@@ -216,16 +216,16 @@
             {
                 "id": 6,
                 "result": {
-                    "isIncomplete": true,
+                    "isIncomplete": false,
                     "items": ["<HAS>",
                               {
-                                  "label": "Short_Float_Text_IO (invisible)",
+                                  "label": "Decimal (invisible)",
                                   "kind": 9,
-                                  "detail": "package Ada.Short_Float_Text_IO is\nnew Ada.Text_IO.Float_IO (Short_Float);",
-                                  "documentation": "at a-sfteio.ads (18:1)",
-                                  "sortText": "~48Short_Float_Text_IO",
-                                  "filterText": "Short_Float_Text_IO",
-                                  "insertText": "Short_Float_Text_IO",
+                                  "detail": "package Ada.Decimal ",
+                                  "documentation": "at a-decima.ads (38:1)\n\nThis is the 128-bit version of this package",
+                                  "sortText": "~08Decimal",
+                                  "filterText": "Decimal",
+                                  "insertText": "Decimal",
                                   "additionalTextEdits": [
                                   ]
                               }


### PR DESCRIPTION
Since we don't properly handle it in GS and we don't limit
the results we write in the ALS side.

This has just for effect to slow down completion on VS Code, since
it tries to retrigger it on each character while we already return
all the results the first time.