### PR TITLE
UA20-011: Fix completion parameter sort when having >10 results

### DIFF
--- a/testsuite/ada_lsp/U913-028.completion.params/test.json
+++ b/testsuite/ada_lsp/U913-028.completion.params/test.json
@@ -139,25 +139,9 @@
                   "isIncomplete": false,
                   "items": [
                      {
-                        "label": "I",
-                        "kind": 5,
-                        "sortText": "1",
-                        "insertText": "I => ",
-                        "insertTextFormat": 1,
-                        "additionalTextEdits": []
-                     },
-                     {
-                        "label": "F",
-                        "kind": 5,
-                        "sortText": "2",
-                        "insertText": "F => ",
-                        "insertTextFormat": 1,
-                        "additionalTextEdits": []
-                     },
-                     {
                         "label": "Params of Bar",
                         "kind": 15,
-                        "sortText": "0",
+                        "sortText": "+0",
                         "insertText": "I => $1, F => $2)$0",
                         "insertTextFormat": 2,
                         "additionalTextEdits": [],
@@ -178,23 +162,23 @@
                      {
                         "label": "I",
                         "kind": 5,
-                        "sortText": "4",
+                        "sortText": "+1",
                         "insertText": "I => ",
                         "insertTextFormat": 1,
                         "additionalTextEdits": []
                      },
                      {
-                        "label": "J",
+                        "label": "F",
                         "kind": 5,
-                        "sortText": "5",
-                        "insertText": "J => ",
+                        "sortText": "+2",
+                        "insertText": "F => ",
                         "insertTextFormat": 1,
                         "additionalTextEdits": []
                      },
                      {
                         "label": "Params of Bar",
                         "kind": 15,
-                        "sortText": "3",
+                        "sortText": "+3",
                         "insertText": "I => $1, J => $2)$0",
                         "insertTextFormat": 2,
                         "additionalTextEdits": [],
@@ -211,6 +195,22 @@
                               }
                            }
                         }
+                     },
+                     {
+                        "label": "I",
+                        "kind": 5,
+                        "sortText": "+4",
+                        "insertText": "I => ",
+                        "insertTextFormat": 1,
+                        "additionalTextEdits": []
+                     },
+                     {
+                        "label": "J",
+                        "kind": 5,
+                        "sortText": "+5",
+                        "insertText": "J => ",
+                        "insertTextFormat": 1,
+                        "additionalTextEdits": []
                      }
                   ]
                }
@@ -389,17 +389,9 @@
                   "isIncomplete": false,
                   "items": [
                      {
-                        "label": "I",
-                        "kind": 5,
-                        "sortText": "1",
-                        "insertText": "I => ",
-                        "insertTextFormat": 1,
-                        "additionalTextEdits": []
-                     },
-                     {
                         "label": "Params of Bar",
                         "kind": 15,
-                        "sortText": "0",
+                        "sortText": "+0",
                         "insertText": "I => $1)$0",
                         "insertTextFormat": 2,
                         "additionalTextEdits": [],
@@ -416,6 +408,14 @@
                               }
                            }
                         }
+                     },
+                     {
+                        "label": "I",
+                        "kind": 5,
+                        "sortText": "+1",
+                        "insertText": "I => ",
+                        "insertTextFormat": 1,
+                        "additionalTextEdits": []
                      }
                   ]
                }

--- a/testsuite/ada_lsp/UA20-011.parameter_completion.multiple_order/foo.adb
+++ b/testsuite/ada_lsp/UA20-011.parameter_completion.multiple_order/foo.adb
@@ -1,0 +1,19 @@
+procedure Foo is
+   procedure Bar (I, J, K, L, M, N, O, P : Integer);
+   procedure Bar (I, J, K, L, M, N, O, P : Integer) is
+   begin
+      null;
+   end Bar;
+   procedure Bar (A, B, C, D, E, F : Float);
+   procedure Bar (A1, A2, A3, A4, A5 : String) is
+   begin
+      null;
+   end Bar;
+   procedure Bar (A1, A2, A3, A4, A5 : String);
+   procedure Bar (A1, A2, A3, A4, A5 : String) is
+   begin
+      null;
+   end Bar;
+begin
+   Bar (
+end Foo;

--- a/testsuite/ada_lsp/UA20-011.parameter_completion.multiple_order/test.gpr
+++ b/testsuite/ada_lsp/UA20-011.parameter_completion.multiple_order/test.gpr
@@ -1,0 +1,3 @@
+project Test is
+   for Main use ("foo.adb");
+end Test;

--- a/testsuite/ada_lsp/UA20-011.parameter_completion.multiple_order/test.json
+++ b/testsuite/ada_lsp/UA20-011.parameter_completion.multiple_order/test.json
@@ -1,0 +1,432 @@
+[
+   {
+      "comment": [
+         "Test the completion parameter when there are more than 10 results"
+      ]
+   }, 
+   {
+      "start": {
+         "cmd": [
+            "${ALS}"
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+               "processId": 199714,
+               "rootUri": "$URI{.}",
+               "capabilities": {
+                  "workspace": {
+                     "applyEdit": true
+                  },
+                  "textDocument": {
+                     "completion": {
+                        "completionItem": {
+                           "snippetSupport": true,
+                           "documentationFormat": [
+                              "markdown",
+                              "plaintext"
+                           ],
+                            "resolveSupport": {
+                                "properties": [
+                                    "documentation",
+                                    "detail"
+                                ]
+                            }
+                        }
+                     }
+                  },
+                  "window": {
+                     "workDoneProgress": true
+                  }
+               }
+            }
+         },
+         "wait": [
+             {
+                 "jsonrpc": "2.0",
+                 "id": 1,
+                 "result": {
+                     "capabilities": {
+                         "textDocumentSync": 2,
+                         "completionProvider": {
+                             "triggerCharacters": [
+                                 ".",
+                                 ",",
+                                 "'",
+                                 "("
+                             ],
+                             "resolveProvider": true
+                         }
+                     }
+                 }
+             }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "initialized"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "workspace/didChangeConfiguration",
+            "params": {
+               "settings": {
+                  "ada": {
+                     "projectFile": "$URI{test.gpr}",
+                     "scenarioVariables": {},
+                     "defaultCharset": "ISO-8859-1",
+                     "enableDiagnostics": true,
+                     "followSymlinks": false
+                  }
+               }
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}",
+                  "languageId": "Ada",
+                  "version": 0,
+                  "text": "procedure Foo is\n   procedure Bar (I, J, K, L, M, N, O, P : Integer);\n   procedure Bar (I, J, K, L, M, N, O, P : Integer) is\n   begin\n      null;\n   end Bar;\n   procedure Bar (A, B, C, D, E, F : Float);\n   procedure Bar (A1, A2, A3, A4, A5 : String) is\n   begin\n      null;\n   end Bar;\n   procedure Bar (A1, A2, A3, A4, A5 : String);\n   procedure Bar (A1, A2, A3, A4, A5 : String) is\n   begin\n      null;\n   end Bar;\nbegin\n   Bar \nend Foo;\n"
+               }
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}",
+                  "version": 2
+               },
+               "contentChanges": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 17,
+                           "character": 7
+                        },
+                        "end": {
+                           "line": 17,
+                           "character": 7
+                        }
+                     },
+                     "text": "("
+                  }
+               ]
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": 5,
+            "method": "textDocument/completion",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}"
+               },
+               "position": {
+                  "line": 17,
+                  "character": 8
+               }
+            }
+         },
+         "wait": [
+            {
+               "id": 5,
+               "result": {
+                  "isIncomplete": false,
+                  "items": [
+                     {
+                        "label": "Params of Bar",
+                        "kind": 15,
+                        "sortText": "+00",
+                        "insertText": "A1 => $1, A2 => $2, A3 => $3, A4 => $4, A5 => $5)$0",
+                        "insertTextFormat": 2,
+                        "additionalTextEdits": [],
+                        "data": {
+                           "uri": "$URI{foo.adb}",
+                           "range": {
+                              "start": {
+                                 "line": 11,
+                                 "character": 3
+                              },
+                              "end": {
+                                 "line": 11,
+                                 "character": 47
+                              }
+                           }
+                        }
+                     },
+                     {
+                        "label": "A1",
+                        "kind": 5,
+                        "sortText": "+01",
+                        "insertText": "A1 => ",
+                        "insertTextFormat": 1,
+                        "additionalTextEdits": []
+                     },
+                     {
+                        "label": "A2",
+                        "kind": 5,
+                        "sortText": "+02",
+                        "insertText": "A2 => ",
+                        "insertTextFormat": 1,
+                        "additionalTextEdits": []
+                     },
+                     {
+                        "label": "A3",
+                        "kind": 5,
+                        "sortText": "+03",
+                        "insertText": "A3 => ",
+                        "insertTextFormat": 1,
+                        "additionalTextEdits": []
+                     },
+                     {
+                        "label": "A4",
+                        "kind": 5,
+                        "sortText": "+04",
+                        "insertText": "A4 => ",
+                        "insertTextFormat": 1,
+                        "additionalTextEdits": []
+                     },
+                     {
+                        "label": "A5",
+                        "kind": 5,
+                        "sortText": "+05",
+                        "insertText": "A5 => ",
+                        "insertTextFormat": 1,
+                        "additionalTextEdits": []
+                     },
+                     {
+                        "label": "Params of Bar",
+                        "kind": 15,
+                        "sortText": "+06",
+                        "insertText": "A => $1, B => $2, C => $3, D => $4, E => $5, F => $6)$0",
+                        "insertTextFormat": 2,
+                        "additionalTextEdits": [],
+                        "data": {
+                           "uri": "$URI{foo.adb}",
+                           "range": {
+                              "start": {
+                                 "line": 6,
+                                 "character": 3
+                              },
+                              "end": {
+                                 "line": 6,
+                                 "character": 44
+                              }
+                           }
+                        }
+                     },
+                     {
+                        "label": "A",
+                        "kind": 5,
+                        "sortText": "+07",
+                        "insertText": "A => ",
+                        "insertTextFormat": 1,
+                        "additionalTextEdits": []
+                     },
+                     {
+                        "label": "B",
+                        "kind": 5,
+                        "sortText": "+08",
+                        "insertText": "B => ",
+                        "insertTextFormat": 1,
+                        "additionalTextEdits": []
+                     },
+                     {
+                        "label": "C",
+                        "kind": 5,
+                        "sortText": "+09",
+                        "insertText": "C => ",
+                        "insertTextFormat": 1,
+                        "additionalTextEdits": []
+                     },
+                     {
+                        "label": "D",
+                        "kind": 5,
+                        "sortText": "+10",
+                        "insertText": "D => ",
+                        "insertTextFormat": 1,
+                        "additionalTextEdits": []
+                     },
+                     {
+                        "label": "E",
+                        "kind": 5,
+                        "sortText": "+11",
+                        "insertText": "E => ",
+                        "insertTextFormat": 1,
+                        "additionalTextEdits": []
+                     },
+                     {
+                        "label": "F",
+                        "kind": 5,
+                        "sortText": "+12",
+                        "insertText": "F => ",
+                        "insertTextFormat": 1,
+                        "additionalTextEdits": []
+                     },
+                     {
+                        "label": "Params of Bar",
+                        "kind": 15,
+                        "sortText": "+13",
+                        "insertText": "I => $1, J => $2, K => $3, L => $4, M => $5, N => $6, O => $7, P => $8)$0",
+                        "insertTextFormat": 2,
+                        "additionalTextEdits": [],
+                        "data": {
+                           "uri": "$URI{foo.adb}",
+                           "range": {
+                              "start": {
+                                 "line": 1,
+                                 "character": 3
+                              },
+                              "end": {
+                                 "line": 1,
+                                 "character": 52
+                              }
+                           }
+                        }
+                     },
+                     {
+                        "label": "I",
+                        "kind": 5,
+                        "sortText": "+14",
+                        "insertText": "I => ",
+                        "insertTextFormat": 1,
+                        "additionalTextEdits": []
+                     },
+                     {
+                        "label": "J",
+                        "kind": 5,
+                        "sortText": "+15",
+                        "insertText": "J => ",
+                        "insertTextFormat": 1,
+                        "additionalTextEdits": []
+                     },
+                     {
+                        "label": "K",
+                        "kind": 5,
+                        "sortText": "+16",
+                        "insertText": "K => ",
+                        "insertTextFormat": 1,
+                        "additionalTextEdits": []
+                     },
+                     {
+                        "label": "L",
+                        "kind": 5,
+                        "sortText": "+17",
+                        "insertText": "L => ",
+                        "insertTextFormat": 1,
+                        "additionalTextEdits": []
+                     },
+                     {
+                        "label": "M",
+                        "kind": 5,
+                        "sortText": "+18",
+                        "insertText": "M => ",
+                        "insertTextFormat": 1,
+                        "additionalTextEdits": []
+                     },
+                     {
+                        "label": "N",
+                        "kind": 5,
+                        "sortText": "+19",
+                        "insertText": "N => ",
+                        "insertTextFormat": 1,
+                        "additionalTextEdits": []
+                     },
+                     {
+                        "label": "O",
+                        "kind": 5,
+                        "sortText": "+20",
+                        "insertText": "O => ",
+                        "insertTextFormat": 1,
+                        "additionalTextEdits": []
+                     },
+                     {
+                        "label": "P",
+                        "kind": 5,
+                        "sortText": "+21",
+                        "insertText": "P => ",
+                        "insertTextFormat": 1,
+                        "additionalTextEdits": []
+                     }
+                  ]
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didClose",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}"
+               }
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": 8,
+            "method": "shutdown"
+         },
+         "wait": [
+            {
+               "method": "textDocument/publishDiagnostics",
+               "params": {
+                  "uri": "$URI{foo.adb}",
+                  "diagnostics": []
+               }
+            },
+            {
+               "id": 8,
+               "result": null
+            }
+         ]
+      }
+   },
+   {
+      "stop": {
+         "exit_code": 0
+      }
+   }
+]

--- a/testsuite/ada_lsp/UA20-011.parameter_completion.multiple_order/test.yaml
+++ b/testsuite/ada_lsp/UA20-011.parameter_completion.multiple_order/test.yaml
@@ -1,0 +1,1 @@
+title: 'UA20-011.parameter_completion.multiple_order'

--- a/testsuite/ada_lsp/UA21-041.parameter_completion.dotted_call/test.json
+++ b/testsuite/ada_lsp/UA21-041.parameter_completion.dotted_call/test.json
@@ -166,33 +166,9 @@
                   "isIncomplete": false,
                   "items": [
                      {
-                        "label": "M",
-                        "kind": 5,
-                        "sortText": "1",
-                        "insertText": "M => ",
-                        "insertTextFormat": 1,
-                        "additionalTextEdits": []
-                     },
-                     {
-                        "label": "A",
-                        "kind": 5,
-                        "sortText": "2",
-                        "insertText": "A => ",
-                        "insertTextFormat": 1,
-                        "additionalTextEdits": []
-                     },
-                     {
-                        "label": "B",
-                        "kind": 5,
-                        "sortText": "3",
-                        "insertText": "B => ",
-                        "insertTextFormat": 1,
-                        "additionalTextEdits": []
-                     },
-                     {
                         "label": "Params of Hello",
                         "kind": 15,
-                        "sortText": "0",
+                        "sortText": "+0",
                         "insertText": "M => $1, A => $2, B => $3)$0",
                         "insertTextFormat": 2,
                         "additionalTextEdits": [],
@@ -211,9 +187,17 @@
                         }
                      },
                      {
+                        "label": "M",
+                        "kind": 5,
+                        "sortText": "+1",
+                        "insertText": "M => ",
+                        "insertTextFormat": 1,
+                        "additionalTextEdits": []
+                     },
+                     {
                         "label": "A",
                         "kind": 5,
-                        "sortText": "5",
+                        "sortText": "+2",
                         "insertText": "A => ",
                         "insertTextFormat": 1,
                         "additionalTextEdits": []
@@ -221,7 +205,7 @@
                      {
                         "label": "B",
                         "kind": 5,
-                        "sortText": "6",
+                        "sortText": "+3",
                         "insertText": "B => ",
                         "insertTextFormat": 1,
                         "additionalTextEdits": []
@@ -229,7 +213,7 @@
                      {
                         "label": "Params of Hello",
                         "kind": 15,
-                        "sortText": "4",
+                        "sortText": "+4",
                         "insertText": "A => $1, B => $2)$0",
                         "insertTextFormat": 2,
                         "additionalTextEdits": [],
@@ -246,6 +230,22 @@
                               }
                            }
                         }
+                     },
+                     {
+                        "label": "A",
+                        "kind": 5,
+                        "sortText": "+5",
+                        "insertText": "A => ",
+                        "insertTextFormat": 1,
+                        "additionalTextEdits": []
+                     },
+                     {
+                        "label": "B",
+                        "kind": 5,
+                        "sortText": "+6",
+                        "insertText": "B => ",
+                        "insertTextFormat": 1,
+                        "additionalTextEdits": []
                      }
                   ]
                }
@@ -262,7 +262,7 @@
             "params": {
                "label": "Params of Hello",
                "kind": 15,
-               "sortText": "0",
+               "sortText": "+0",
                "insertText": "M => $1, A => $2, B => $3)$0",
                "insertTextFormat": 2,
                "additionalTextEdits": [],
@@ -289,7 +289,7 @@
                   "kind": 15,
                   "detail": "procedure Hello (M : access My_Type; A : Integer; B : Float)",
                   "documentation": "at bar.ads (11:4)",
-                  "sortText": "0",
+                  "sortText": "+0",
                   "insertText": "M => $1, A => $2, B => $3)$0",
                   "insertTextFormat": 2,
                   "additionalTextEdits": [],
@@ -394,33 +394,9 @@
                   "isIncomplete": false,
                   "items": [
                      {
-                        "label": "M",
-                        "kind": 5,
-                        "sortText": "1",
-                        "insertText": "M => ",
-                        "insertTextFormat": 1,
-                        "additionalTextEdits": []
-                     },
-                     {
-                        "label": "A",
-                        "kind": 5,
-                        "sortText": "2",
-                        "insertText": "A => ",
-                        "insertTextFormat": 1,
-                        "additionalTextEdits": []
-                     },
-                     {
-                        "label": "B",
-                        "kind": 5,
-                        "sortText": "3",
-                        "insertText": "B => ",
-                        "insertTextFormat": 1,
-                        "additionalTextEdits": []
-                     },
-                     {
                         "label": "Params of Bar.Hello",
                         "kind": 15,
-                        "sortText": "0",
+                        "sortText": "+0",
                         "insertText": "M => $1, A => $2, B => $3)$0",
                         "insertTextFormat": 2,
                         "additionalTextEdits": [],
@@ -439,9 +415,17 @@
                         }
                      },
                      {
+                        "label": "M",
+                        "kind": 5,
+                        "sortText": "+1",
+                        "insertText": "M => ",
+                        "insertTextFormat": 1,
+                        "additionalTextEdits": []
+                     },
+                     {
                         "label": "A",
                         "kind": 5,
-                        "sortText": "5",
+                        "sortText": "+2",
                         "insertText": "A => ",
                         "insertTextFormat": 1,
                         "additionalTextEdits": []
@@ -449,7 +433,7 @@
                      {
                         "label": "B",
                         "kind": 5,
-                        "sortText": "6",
+                        "sortText": "+3",
                         "insertText": "B => ",
                         "insertTextFormat": 1,
                         "additionalTextEdits": []
@@ -457,7 +441,7 @@
                      {
                         "label": "Params of Bar.Hello",
                         "kind": 15,
-                        "sortText": "4",
+                        "sortText": "+4",
                         "insertText": "A => $1, B => $2)$0",
                         "insertTextFormat": 2,
                         "additionalTextEdits": [],
@@ -474,6 +458,22 @@
                               }
                            }
                         }
+                     },
+                     {
+                        "label": "A",
+                        "kind": 5,
+                        "sortText": "+5",
+                        "insertText": "A => ",
+                        "insertTextFormat": 1,
+                        "additionalTextEdits": []
+                     },
+                     {
+                        "label": "B",
+                        "kind": 5,
+                        "sortText": "+6",
+                        "insertText": "B => ",
+                        "insertTextFormat": 1,
+                        "additionalTextEdits": []
                      }
                   ]
                }
@@ -490,7 +490,7 @@
             "params": {
                "label": "Params of Bar.Hello",
                "kind": 15,
-               "sortText": "0",
+               "sortText": "+0",
                "insertText": "M => $1, A => $2, B => $3)$0",
                "insertTextFormat": 2,
                "additionalTextEdits": [],
@@ -517,7 +517,7 @@
                   "kind": 15,
                   "detail": "procedure Hello (M : access My_Type; A : Integer; B : Float)",
                   "documentation": "at bar.ads (11:4)",
-                  "sortText": "0",
+                  "sortText": "+0",
                   "insertText": "M => $1, A => $2, B => $3)$0",
                   "insertTextFormat": 2,
                   "additionalTextEdits": [],
@@ -622,25 +622,9 @@
                   "isIncomplete": false,
                   "items": [
                      {
-                        "label": "A",
-                        "kind": 5,
-                        "sortText": "1",
-                        "insertText": "A => ",
-                        "insertTextFormat": 1,
-                        "additionalTextEdits": []
-                     },
-                     {
-                        "label": "B",
-                        "kind": 5,
-                        "sortText": "2",
-                        "insertText": "B => ",
-                        "insertTextFormat": 1,
-                        "additionalTextEdits": []
-                     },
-                     {
                         "label": "Params of M.Hello",
                         "kind": 15,
-                        "sortText": "0",
+                        "sortText": "+0",
                         "insertText": "A => $1, B => $2)$0",
                         "insertTextFormat": 2,
                         "additionalTextEdits": [],
@@ -657,6 +641,22 @@
                               }
                            }
                         }
+                     },
+                     {
+                        "label": "A",
+                        "kind": 5,
+                        "sortText": "+1",
+                        "insertText": "A => ",
+                        "insertTextFormat": 1,
+                        "additionalTextEdits": []
+                     },
+                     {
+                        "label": "B",
+                        "kind": 5,
+                        "sortText": "+2",
+                        "insertText": "B => ",
+                        "insertTextFormat": 1,
+                        "additionalTextEdits": []
                      }
                   ]
                }
@@ -673,7 +673,7 @@
             "params": {
                "label": "Params of M.Hello",
                "kind": 15,
-               "sortText": "0",
+               "sortText": "+0",
                "insertText": "A => $1, B => $2)$0",
                "insertTextFormat": 2,
                "additionalTextEdits": [],
@@ -700,7 +700,7 @@
                   "kind": 15,
                   "detail": "procedure Hello (M : access My_Type; A : Integer; B : Float)",
                   "documentation": "at bar.ads (11:4)",
-                  "sortText": "0",
+                  "sortText": "+0",
                   "insertText": "A => $1, B => $2)$0",
                   "insertTextFormat": 2,
                   "additionalTextEdits": [],


### PR DESCRIPTION
Separate the completion parameter results using a "+" before and
properly index them.

Add a test.