### PR TITLE
UA25-015 Added Experimental Client Capabilities and <DOES_NOT_HAVE> pattern

### DIFF
--- a/integration/vscode/ada/src/alsClientFeatures.ts
+++ b/integration/vscode/ada/src/alsClientFeatures.ts
@@ -1,0 +1,80 @@
+/*----------------------------------------------------------------------------
+--                         Language Server Protocol                         --
+--                                                                          --
+--                       Copyright (C) 2021, AdaCore                        --
+--                                                                          --
+-- This is free software;  you can redistribute it  and/or modify it  under --
+-- terms of the  GNU General Public License as published  by the Free Soft- --
+-- ware  Foundation;  either version 3,  or (at your option) any later ver- --
+-- sion.  This software is distributed in the hope  that it will be useful, --
+-- but WITHOUT ANY WARRANTY;  without even the implied warranty of MERCHAN- --
+-- TABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public --
+-- License for  more details.  You should have  received  a copy of the GNU --
+-- General  Public  License  distributed  with  this  software;   see  file --
+-- COPYING3.  If not, go to http://www.gnu.org/licenses for a complete copy --
+-- of the license.                                                          --
+----------------------------------------------------------------------------*/
+
+/**
+ * Implementation of a LanguageClient feature for Ada
+ */
+
+import {
+    ClientCapabilities,
+    DocumentSelector,
+    InitializeParams,
+    ServerCapabilities,
+    StaticFeature,
+} from 'vscode-languageclient/node';
+
+/**
+ * Class that determines that the client has a feature to provide user input
+ */
+
+export class ALSClientFeatures implements StaticFeature {
+    /**
+     * Unused since there is no need to manipulate params
+     */
+    fillInitializeParams?: ((params: InitializeParams) => void) | undefined = (
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        _params: InitializeParams
+    ) => {
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+    };
+
+    /**
+     * Extend capabilities.experimental with an userInputProvider boolean that determines
+     * that this client can provide user inputs
+     */
+    fillClientCapabilities(capabilities: ClientCapabilities): void {
+        if (capabilities.experimental === undefined) {
+            capabilities.experimental = {
+                advanced_refactorings: ['add_parameter'],
+            };
+        } else {
+            (
+                capabilities.experimental as { advanced_refactorings: string[] }
+            ).advanced_refactorings = ['add_parameter'];
+        }
+    }
+
+    /**
+     * Unused since there are no necessary actions when initializing an object of this class
+     */
+    initialize(
+        // eslint-disable-next-line max-len
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any
+        _capabilities: ServerCapabilities<any>,
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        _documentSelector: DocumentSelector | undefined
+    ): void {
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+    }
+
+    /**
+     * Unused since there are no necessary actions when disposing an object of this class
+     */
+    dispose(): void {
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+    }
+}

--- a/integration/vscode/ada/src/extension.ts
+++ b/integration/vscode/ada/src/extension.ts
@@ -28,6 +28,7 @@ import * as process from 'process';
 import GPRTaskProvider from './gprTaskProvider';
 import gnatproveTaskProvider from './gnatproveTaskProvider';
 import { alsCommandExecutor } from './alsExecuteCommand';
+import { ALSClientFeatures } from './alsClientFeatures';
 
 let alsTaskProvider: vscode.Disposable[] = [
     vscode.tasks.registerTaskProvider(GPRTaskProvider.gprBuildType, new GPRTaskProvider()),
@@ -66,6 +67,7 @@ export function activate(context: vscode.ExtensionContext): void {
         executeCommand: alsCommandExecutor(client),
     };
     client.clientOptions.middleware = alsMiddleware;
+    client.registerFeature(new ALSClientFeatures());
 
     const disposable = client.start();
     // Push the disposable to the context's subscriptions so that the

--- a/source/ada/lsp-ada_handlers.ads
+++ b/source/ada/lsp-ada_handlers.ads
@@ -153,6 +153,25 @@ private
      No_Project_Found .. Invalid_Project_Configured;
    --  Project status when an implicit project loaded
 
+   type Advanced_Refactorings is (Add_Parameter);
+   --  Enum with the advanced refactorings that clients might support
+
+   type Advanced_Refactorings_Capabilities is
+     array (Advanced_Refactorings) of Boolean;
+   --  Array that determines what advanced refactorings clients support
+
+   type Experimental_Client_Capabilities is record
+      Advanced_Refactorings : Advanced_Refactorings_Capabilities;
+   end record;
+   --  Experimental client capabilities that are extensions of the ones defined
+   --  in the LSP
+
+   function Parse
+     (Value : LSP.Types.Optional_LSP_Any)
+      return Experimental_Client_Capabilities;
+   --  Parses an LSP.Types.Optional_LSP_Any and creates an
+   --  Experimental_Client_Capabilities object.
+
    type Message_Handler
      (Server  : access LSP.Servers.Server;
       Trace   : GNATCOLL.Traces.Trace_Handle)
@@ -289,6 +308,15 @@ private
 
       File_Monitor    : LSP.File_Monitors.File_Monitor_Access;
       --  Filesystem monitoring
+
+      ---------------------------------------
+      --  Experimental Client Capabilities --
+      ---------------------------------------
+
+      Experimental_Client_Capabilities :
+        LSP.Ada_Handlers.Experimental_Client_Capabilities :=
+          (Advanced_Refactorings => (others => False));
+
    end record;
 
    overriding procedure Before_Work

--- a/source/protocol/generated/lsp-message_io.adb
+++ b/source/protocol/generated/lsp-message_io.adb
@@ -4208,6 +4208,8 @@ package body LSP.Message_IO is
                Optional_WindowClientCapabilities'Read (S, V.window);
             elsif Key = "general" then
                Optional_GeneralClientCapabilities'Read (S, V.general);
+            elsif Key = "experimental" then
+               Optional_LSP_Any'Read (S, V.experimental);
             else
                JS.Skip_Value;
             end if;
@@ -4232,6 +4234,8 @@ package body LSP.Message_IO is
       Optional_WindowClientCapabilities'Write (S, V.window);
       JS.Key ("general");
       Optional_GeneralClientCapabilities'Write (S, V.general);
+      JS.Key ("experimental");
+      Optional_LSP_Any'Write (S, V.experimental);
       JS.End_Object;
    end Write_ClientCapabilities;
 

--- a/source/protocol/lsp-messages.ads
+++ b/source/protocol/lsp-messages.ads
@@ -4634,7 +4634,7 @@ package LSP.Messages is
       textDocument: TextDocumentClientCapabilities;
       window: Optional_WindowClientCapabilities;
       general: Optional_GeneralClientCapabilities;
-      --  experimental?: any;
+      experimental: Optional_LSP_Any;
    end record;
 
    procedure Read_ClientCapabilities

--- a/source/protocol/lsp-types.ads
+++ b/source/protocol/lsp-types.ads
@@ -244,6 +244,13 @@ package LSP.Types is
     (Stream : in out LSP.JSON_Streams.JSON_Stream'Class;
      Item   : VSS.Unicode.UTF16_Code_Unit_Count);
 
+   ----------------------
+   -- Optional_LSP_Any --
+   ----------------------
+
+   package Optional_LSP_Anys is new LSP.Generic_Optional (LSP_Any);
+   type Optional_LSP_Any is new Optional_LSP_Anys.Optional_Type;
+
    ---------------------
    -- Optional_Number --
    ---------------------

--- a/testsuite/ada_lsp/README.md
+++ b/testsuite/ada_lsp/README.md
@@ -92,6 +92,8 @@ should be in server response, but some values have a special meaning:
  * string `<ABSENT>` - ensures that there is no such property at all
  * array `['<HAS>', item1, item2, ...]` - ensures that all given items are
    included into the array, any other array items are considered irrelevant and ignored
+ * array `['<DOES_NOT_HAVE>', item1, item2, ...]` - ensures that all given items are
+   not included into the array, any other array items are considered irrelevant and ignored
 
 ### Command `shell`
 

--- a/testsuite/ada_lsp/refactoring_add_parameter/S314-015/test.yaml
+++ b/testsuite/ada_lsp/refactoring_add_parameter/S314-015/test.yaml
@@ -1,1 +1,5 @@
 title: 'refactoring_add_parameters_S314-015_0'
+
+description: >
+    Check that the Add_Parameter codeAction is not available if the client
+    does not provide the userInputProvider capability.

--- a/testsuite/ada_lsp/refactoring_add_parameter/UA25-015/default.gpr
+++ b/testsuite/ada_lsp/refactoring_add_parameter/UA25-015/default.gpr
@@ -1,0 +1,3 @@
+project Default is
+   for Main use ("main.adb");
+end Default;

--- a/testsuite/ada_lsp/refactoring_add_parameter/UA25-015/main.adb
+++ b/testsuite/ada_lsp/refactoring_add_parameter/UA25-015/main.adb
@@ -1,0 +1,5 @@
+procedure Main is
+   procedure Foo (A : Integer) is null;
+begin
+   null;
+end Main;

--- a/testsuite/ada_lsp/refactoring_add_parameter/UA25-015/test.json
+++ b/testsuite/ada_lsp/refactoring_add_parameter/UA25-015/test.json
@@ -56,6 +56,11 @@
                                     }
                                 }
                             }
+                        },
+                        "experimental": {
+                            "advanced_refactorings": [
+                                "add_parameter"
+                            ]
                         }
                     }
                 }
@@ -118,12 +123,12 @@
             },
             "wait": [
                 {
-                   "jsonrpc": "2.0",
-                   "id": 2,
-                   "method": "window/workDoneProgress/create",
-                   "params": {
-                      "token": "<ANY>"
-                   }
+                    "jsonrpc": "2.0",
+                    "id": 2,
+                    "method": "window/workDoneProgress/create",
+                    "params": {
+                        "token": "<ANY>"
+                    }
                 }
             ]
         }
@@ -175,7 +180,7 @@
                     "jsonrpc": "2.0",
                     "id": 1,
                     "result": [
-                        "<DOES_NOT_HAVE>",
+                        "<HAS>",
                         {
                             "title": "Add Parameter",
                             "kind": "refactor.rewrite",
@@ -254,8 +259,7 @@
                 {
                     "jsonrpc": "2.0",
                     "id": 3,
-                    "result": {
-                    }
+                    "result": {}
                 }
             ]
         }
@@ -356,7 +360,7 @@
                     "jsonrpc": "2.0",
                     "id": 5,
                     "result": [
-                        "<DOES_NOT_HAVE>",
+                        "<HAS>",
                         {
                             "title": "Add Parameter",
                             "kind": "refactor.rewrite",

--- a/testsuite/ada_lsp/refactoring_add_parameter/UA25-015/test.yaml
+++ b/testsuite/ada_lsp/refactoring_add_parameter/UA25-015/test.yaml
@@ -1,0 +1,6 @@
+title: 'refactoring_add_parameters_UA25-015_0'
+
+description: >
+    Check that the Add_Parameter codeAction is avaiable when the client
+    provides the userInputProvider capability, and that it executes
+    correctly.


### PR DESCRIPTION
Added check to confirm that client supports advanced refactorings before sending advanced refactoring code actions.
Added test case and adjusted existing ones by adding a <DOES_NOT_HAVE> pattern. This pattern is used to confirm that the server does not send advanced refactoring code actions to clients that don't support it.