### PR TITLE
UB10-025 Do not raise errors for missing object dirs

### DIFF
--- a/source/ada/lsp-ada_handlers.adb
+++ b/source/ada/lsp-ada_handlers.adb
@@ -3635,7 +3635,8 @@ package body LSP.Ada_Handlers is
          Self.Project_Tree.Load
            (GPR,
             Self.Project_Environment,
-            Errors => On_Error'Unrestricted_Access);
+            Report_Missing_Dirs => False,
+            Errors              => On_Error'Unrestricted_Access);
          for File of Self.Project_Environment.Predefined_Source_Files loop
             Self.Project_Predefined_Sources.Include (File);
          end loop;


### PR DESCRIPTION
This is noise most of the time, as gprbuild now creates
the missing directories by default.