### PR TITLE
UB11-011 Call "npm audit" to check for vulnerabilities

### DIFF
--- a/.github/workflows/build-binaries.sh
+++ b/.github/workflows/build-binaries.sh
@@ -32,6 +32,13 @@ if [[ ${GITHUB_REF##*/} != 2*.[0-9]*.[0-9]* ]]; then
     git rebase --verbose origin/edge
 fi
 
+# Audit the npm packages
+cd integration/vscode/ada
+npm install
+# Run npm audit to check for any vulnerabilities
+npm audit
+cd -
+
 # Get libadalang binaries
 mkdir -p $prefix
 FILE=libadalang-$RUNNER_OS-$BRANCH${DEBUG:+-dbg}-static.tar.gz

--- a/integration/vscode/ada/package.json
+++ b/integration/vscode/ada/package.json
@@ -255,7 +255,6 @@
         "glob": "^7.1.7",
         "mocha": "^9.0.2",
         "prettier": "^2.3.2",
-        "prettier-eslint": "^12.0.0",
         "typescript": "^4.3.5",
         "vscode-test": "^1.5.2",
         "vscode-tmgrammar-test": "^0.0.11"


### PR DESCRIPTION
And interrupt the build if any is found.