### PR TITLE
UB30-020 Hide `no_root_types_` name from completion

### DIFF
--- a/source/ada/lsp-ada_completions-names.adb
+++ b/source/ada/lsp-ada_completions-names.adb
@@ -144,6 +144,7 @@ package body LSP.Ada_Completions.Names is
          BD                  : Basic_Decl;
          Completion_Count    : Natural := Natural (Result.items.Length);
          Name                : VSS.Strings.Virtual_String;
+         Underscore          : constant VSS.Strings.Virtual_String := "_";
 
       begin
          while Next (Raw_Completions, Item) loop
@@ -154,9 +155,13 @@ package body LSP.Ada_Completions.Names is
                   Name :=
                     LSP.Lal_Utils.To_Virtual_String (DN.P_Relative_Name.Text);
 
+                  if Name.Ends_With (Underscore) then
+                     --  Skip `root_types_` until UB30-020 is fixed.
+                     null;
+
                   --  If we are not completing a dotted name, filter the
                   --  raw completion results by the node's prefix.
-                  if Dotted_Node.Kind in
+                  elsif Dotted_Node.Kind in
                        Libadalang.Common.Ada_Dotted_Name_Range
                     or else Name.Starts_With
                       (Prefix, VSS.Strings.Identifier_Caseless)

--- a/source/tester/tester-tests.adb
+++ b/source/tester/tester-tests.adb
@@ -806,8 +806,11 @@ package body Tester.Tests is
         GNATCOLL.JSON.Read (Data);
 
    begin
-      --  Reset watchdog and timer on each message
-      Self.Watch_Dog.Restart;
+      if not Self.In_Debug then
+         --  Reset watchdog and timer on each message
+         Self.Watch_Dog.Restart;
+      end if;
+
       Self.Started := Ada.Calendar.Clock;
 
       GNATCOLL.JSON.Append (Self.Full_Server_Output, JSON);


### PR DESCRIPTION
results, because it's an internal LAL package.
Also add a fix for `tester-run --debug` command.