### PR TITLE
Fix `npm install -g vsce`

### DIFF
--- a/.github/workflows/pack-binaries.sh
+++ b/.github/workflows/pack-binaries.sh
@@ -25,7 +25,7 @@ sed -i -e "/version/s/[0-9][0-9.]*/$TAG/" package.json
 [ -z "$DEBUG" ] || sed -i -e '/^    "name"/s/ada/ada-debug/' \
                           -e '/displayName/s/Ada/Ada (with debug info)/' package.json
 npm install
-sudo npm install -g vsce
+sudo npm install -g vsce --unsafe-perm
 make_change_log > CHANGELOG.md
 if [[ ${GITHUB_REF##*/} = 2*.[0-9]*.[0-9]* ]] ; then
     vsce publish -p "$VSCE_TOKEN" || true


### PR DESCRIPTION
by forcing it with `--unsafe-perm` option.