### PR TITLE
UC01-021: recompute predefined tasks when scenario vars change

### DIFF
--- a/integration/vscode/ada/src/extension.ts
+++ b/integration/vscode/ada/src/extension.ts
@@ -90,6 +90,24 @@ export function activate(context: vscode.ExtensionContext): void {
         });
     }
 
+    //  React to changes in configuration to recompute predefined tasks if the user
+    //  changes scenario variables' values.
+    function configChanged(e: vscode.ConfigurationChangeEvent) {
+        if (e.affectsConfiguration('ada.scenarioVariables')) {
+            for (const item of alsTaskProvider) {
+                item.dispose();
+            }
+            alsTaskProvider = [
+                vscode.tasks.registerTaskProvider(GPRTaskProvider.gprBuildType, new GPRTaskProvider()),
+                vscode.tasks.registerTaskProvider(
+                    gnatproveTaskProvider.gnatproveType,
+                    new gnatproveTaskProvider()
+                ),
+            ];
+        }
+    }
+
+    context.subscriptions.push(vscode.workspace.onDidChangeConfiguration(configChanged));
     context.subscriptions.push(vscode.commands.registerCommand('ada.otherFile', otherFileHandler));
 }
 


### PR DESCRIPTION
The predefined tasks for gprbuild should be recomputed when the scenario
variables change, to provide the right command line when building.