### PR TITLE
Deactivate warnings on () for array aggregates

### DIFF
--- a/gnat/lsp.gpr
+++ b/gnat/lsp.gpr
@@ -82,7 +82,7 @@ project LSP is
 
             --  Enable all warnings and GNAT stylechecks (plus O: check for
             --  overriding indicators).
-            "-gnatwa", "-gnatygO",
+            "-gnatwaJ", "-gnatygO",
 
             --  Enable assertions and all validity checking options
             "-gnata", "-gnatVa",


### PR DESCRIPTION
At the moment we can't transition to using [] for array aggregates,
since we support older compilers: silence the warning about these
in development mode.