### PR TITLE
UB29-023: Provide log file name in programInfo

### DIFF
--- a/source/ada/lsp-ada_handlers.adb
+++ b/source/ada/lsp-ada_handlers.adb
@@ -978,6 +978,13 @@ package body LSP.Ada_Handlers is
          end if;
       end;
 
+      Response.result.serverInfo := LSP.Messages.Optional_ProgramInfo'
+        (True,
+         (log_filename =>
+              (True, VSS.Strings.Conversions.To_Virtual_String
+                 (Runtime_Indexing.Get_Stream_File.Display_Full_Name)),
+          others       => <>));
+
       --  Experimental Client Capabilities
       Self.Experimental_Client_Capabilities :=
         Parse (Experimental_Client_Capabilities);

--- a/source/protocol/generated/lsp-message_io.adb
+++ b/source/protocol/generated/lsp-message_io.adb
@@ -4394,6 +4394,8 @@ package body LSP.Message_IO is
                LSP.Types.Read_String (S, V.name);
             elsif Key = "version" then
                Optional_Virtual_String'Read (S, V.version);
+            elsif Key = "log_filename" then
+               Optional_Virtual_String'Read (S, V.log_filename);
             else
                JS.Skip_Value;
             end if;
@@ -4414,6 +4416,8 @@ package body LSP.Message_IO is
       LSP.Types.Write_String (S, V.name);
       JS.Key ("version");
       Optional_Virtual_String'Write (S, V.version);
+      JS.Key ("log_filename");
+      Optional_Virtual_String'Write (S, V.log_filename);
       JS.End_Object;
    end Write_ProgramInfo;
 

--- a/source/protocol/lsp-messages.ads
+++ b/source/protocol/lsp-messages.ads
@@ -4798,8 +4798,11 @@ package LSP.Messages is
    for Text_Progress_Params'Write use Write_Text_Progress_Params;
 
    type ProgramInfo is record
-      name    : VSS.Strings.Virtual_String;
-      version : Optional_Virtual_String;
+      name         : VSS.Strings.Virtual_String;
+      version      : Optional_Virtual_String;
+
+      log_filename : Optional_Virtual_String;
+      --  The absolute path of the Ada Language Server log file, if any
    end record;
 
    procedure Read_ProgramInfo


### PR DESCRIPTION
This can be used by GS to know which is the log file of the
current ALS session. Needed to include the correct log file in
bug report archives.