### PR TITLE
U415-027: project should be loaded before FileOperations capabilities

### DIFF
--- a/source/ada/lsp-ada_handlers.adb
+++ b/source/ada/lsp-ada_handlers.adb
@@ -3714,6 +3714,8 @@ package body LSP.Ada_Handlers is
          end;
       end if;
 
+      Self.Ensure_Project_Loaded;
+
       --  Register rangeFormatting provider is the client supports
       --  dynamic registration for it (and we haven't done it before).
       if not Self.Range_Formatting_Enabled
@@ -3799,8 +3801,6 @@ package body LSP.Ada_Handlers is
             Self.Server.On_RegisterCapability_Request (Request);
          end;
       end if;
-
-      Self.Ensure_Project_Loaded;
    end On_DidChangeConfiguration_Notification;
 
    -------------------------------------------

--- a/testsuite/ada_lsp/T318-086.suppress.separates.0/test.json
+++ b/testsuite/ada_lsp/T318-086.suppress.separates.0/test.json
@@ -39,16 +39,7 @@
                      "executeCommand": {
                         "dynamicRegistration": true
                      },
-                     "configuration": true,
-                     "fileOperations": {
-                        "dynamicRegistration": true,
-                        "didCreate": true,
-                        "didRename": true,
-                        "didDelete": true,
-                        "willCreate": true,
-                        "willRename": true,
-                        "willDelete": true
-                     }
+                     "configuration": true
                   },
                   "textDocument": {
                      "publishDiagnostics": {

--- a/testsuite/ada_lsp/refactoring_add_parameter/S314-015/test.json
+++ b/testsuite/ada_lsp/refactoring_add_parameter/S314-015/test.json
@@ -30,15 +30,6 @@
                             },
                             "executeCommand": {
                                 "dynamicRegistration": true
-                            },
-                            "fileOperations": {
-                                "dynamicRegistration": true,
-                                "didCreate": true,
-                                "didRename": true,
-                                "didDelete": true,
-                                "willCreate": true,
-                                "willRename": true,
-                                "willDelete": true
                             }
                         },
                         "textDocument": {

--- a/testsuite/ada_lsp/refactoring_add_parameter/UA25-015/test.json
+++ b/testsuite/ada_lsp/refactoring_add_parameter/UA25-015/test.json
@@ -30,15 +30,6 @@
                             },
                             "executeCommand": {
                                 "dynamicRegistration": true
-                            },
-                            "fileOperations": {
-                                "dynamicRegistration": true,
-                                "didCreate": true,
-                                "didRename": true,
-                                "didDelete": true,
-                                "willCreate": true,
-                                "willRename": true,
-                                "willDelete": true
                             }
                         },
                         "textDocument": {


### PR DESCRIPTION
Because we use the project's source directories to compute the FileFilters
of these capabilities (i.e: the files that should be monitored for file
operations' notifications).