### PR TITLE
Fix ambiguity for "=" operator involving String and Unbounded_String

### DIFF
--- a/source/ada/lsp-ada_handlers.adb
+++ b/source/ada/lsp-ada_handlers.adb
@@ -5586,8 +5586,8 @@ package body LSP.Ada_Handlers is
                   Result.Advanced_Refactorings (Add_Parameter) :=
                     (for some Refactoring of Advanced_Refactorings =>
                        Refactoring.Kind in GNATCOLL.JSON.JSON_String_Type
-                       and then GNATCOLL.JSON.Get (Refactoring) =
-                                  GNATCOLL.JSON.UTF8_String'("add_parameter"));
+                       and then Standard."=" (GNATCOLL.JSON.Get (Refactoring),
+                                 GNATCOLL.JSON.UTF8_String'("add_parameter")));
                end;
             end if;
          end if;


### PR DESCRIPTION
Author: Eric Botcazou <ebotcazou@adacore.com>

The usage of the "=" operator with an overloaded left operand with String
and Unbounded_String interpretations and a String right operand is illegal
because it is ambiguous.  This will be diagnosed by an enhanced compiler:

 lsp-ada_handlers.adb:5589:65:
   error: ambiguous expression (cannot resolve "=")
 lsp-ada_handlers.adb:5589:65:
   error: possible interpretation at a-strunb.ads:248
 lsp-ada_handlers.adb:5589:65:
   error: possible interpretation in package Standard

TN: V112-041