### PR TITLE
V216-030: Fix attribute completion in declarations

### DIFF
--- a/source/ada/lsp-ada_completions-attributes.adb
+++ b/source/ada/lsp-ada_completions-attributes.adb
@@ -36,15 +36,24 @@ package body LSP.Ada_Completions.Attributes is
       Result : in out LSP.Messages.CompletionList)
    is
       pragma Unreferenced (Names);
+
+      use Libadalang.Analysis;
+      use Libadalang.Common;
    begin
       if Filter.Is_Attribute_Ref then
          declare
             use type VSS.Strings.Virtual_String;
-
+            Token_Kind : constant Libadalang.Common.Token_Kind :=
+              Libadalang.Common.Kind (Libadalang.Common.Data (Token));
             Prefix : constant VSS.Strings.Virtual_String :=
-              VSS.Strings.To_Virtual_String (Node.Text);
+              (if Token_Kind = Ada_Tick then
+                  VSS.Strings.To_Virtual_String ("'")
+               else
+                  VSS.Strings.To_Virtual_String (Node.Text));
 
          begin
+            --  If we are right after the "'" we should list all the possible
+            --  attributes, so set the prefix to the empty string.
             LSP.Predefined_Completion.Get_Attributes
               (Prefix => (if Prefix /= "'" then Prefix else ""),
                Result => Result.items);

--- a/testsuite/ada_lsp/V216-030.completion.attribute_in_decl/default.gpr
+++ b/testsuite/ada_lsp/V216-030.completion.attribute_in_decl/default.gpr
@@ -1,0 +1,2 @@
+project Default is
+end Default;

--- a/testsuite/ada_lsp/V216-030.completion.attribute_in_decl/main.adb
+++ b/testsuite/ada_lsp/V216-030.completion.attribute_in_decl/main.adb
@@ -1,0 +1,8 @@
+with Ada.Text_IO;
+with Test_3;
+
+procedure Main is
+   X : Integer := Integer
+begin
+   null;
+end Main;

--- a/testsuite/ada_lsp/V216-030.completion.attribute_in_decl/test.json
+++ b/testsuite/ada_lsp/V216-030.completion.attribute_in_decl/test.json
@@ -1,0 +1,286 @@
+[
+   {
+      "comment": [
+         "test automatically generated"
+      ]
+   },
+   {
+      "start": {
+         "cmd": [
+            "${ALS}"
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+               "processId": 30104,
+               "rootUri": "$URI{.}",
+               "capabilities": {
+                  "workspace": {
+                     "applyEdit": true,
+                     "workspaceEdit": {
+                        "documentChanges": true,
+                        "resourceOperations": [
+                           "rename"
+                        ]
+                     }
+                  },
+                  "textDocument": {
+                     "synchronization": {},
+                     "completion": {
+                        "dynamicRegistration": true,
+                        "completionItem": {
+                           "snippetSupport": false,
+                           "documentationFormat": [
+                              "plaintext",
+                              "markdown"
+                           ],
+                           "resolveSupport": {
+                              "properties": [
+                                 "detail",
+                                 "documentation"
+                              ]
+                           }
+                        }
+                     },
+                     "hover": {},
+                     "signatureHelp": {},
+                     "declaration": {},
+                     "definition": {},
+                     "typeDefinition": {},
+                     "implementation": {},
+                     "documentSymbol": {
+                        "hierarchicalDocumentSymbolSupport": true
+                     },
+                     "formatting": {
+                        "dynamicRegistration": false
+                     },
+                     "rangeFormatting": {
+                        "dynamicRegistration": false
+                     },
+                     "onTypeFormatting": {
+                        "dynamicRegistration": false
+                     },
+                     "foldingRange": {
+                        "lineFoldingOnly": true
+                     }
+                  }
+               }
+            }
+         },
+         "wait": [
+            {
+               "id": 1,
+               "result": {
+                  "capabilities": {
+                     "textDocumentSync": 2,
+                     "completionProvider": {
+                        "triggerCharacters": [
+                           ".",
+                           ",",
+                           "'",
+                           "("
+                        ],
+                        "resolveProvider": true
+                     },
+                     "hoverProvider": true,
+                     "signatureHelpProvider": {
+                        "triggerCharacters": [
+                           ",",
+                           "("
+                        ],
+                        "retriggerCharacters": [
+                           "\b"
+                        ]
+                     },
+                     "declarationProvider": true,
+                     "definitionProvider": true,
+                     "typeDefinitionProvider": true,
+                     "implementationProvider": true,
+                     "referencesProvider": true,
+                     "documentHighlightProvider": true,
+                     "documentSymbolProvider": true,
+                     "codeActionProvider": {},
+                     "documentFormattingProvider": true,
+                     "renameProvider": {},
+                     "foldingRangeProvider": true,
+                     "executeCommandProvider": {
+                        "commands": [
+                           "<HAS>",
+                           "als-named-parameters"
+                        ]
+                     },
+                     "workspaceSymbolProvider": true,
+                     "callHierarchyProvider": {},
+                     "alsShowDepsProvider": true,
+                     "alsReferenceKinds": [
+                        "reference",
+                        "access",
+                        "write",
+                        "call",
+                        "dispatching call",
+                        "parent",
+                        "child",
+                        "overriding"
+                     ],
+                     "alsCheckSyntaxProvider": true
+                  }
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "initialized"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "workspace/didChangeConfiguration",
+            "params": {
+               "settings": {
+                  "ada": {
+                     "scenarioVariables": {},
+                     "defaultCharset": "ISO-8859-1",
+                     "enableDiagnostics": true,
+                     "followSymlinks": false
+                  }
+               }
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "result": null
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{main.adb}",
+                  "languageId": "Ada",
+                  "version": 0,
+                  "text": "with Ada.Text_IO;\nwith Test_3;\n\nprocedure Main is\n   X : Integer := Integer\nbegin\n   null;\nend Main;\n"
+               }
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{main.adb}",
+                  "version": 1
+               },
+               "contentChanges": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 4,
+                           "character": 25
+                        },
+                        "end": {
+                           "line": 4,
+                           "character": 25
+                        }
+                     },
+                     "text": "'"
+                  }
+               ]
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": 5,
+            "method": "textDocument/completion",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{main.adb}"
+               },
+               "position": {
+                  "line": 4,
+                  "character": 26
+               }
+            }
+         },
+         "wait": [
+            {
+               "id": 5,
+               "result": {
+                  "isIncomplete": false,
+                  "items": [
+                     "<HAS>",
+                     {
+                        "label": "Abort_Signal",
+                        "kind": 1,
+                        "detail": "GNAT RM",
+                        "documentation": "`Standard'Abort_Signal' (`Standard' is the only allowed prefix)\nprovides the entity for the special exception used to signal task abort\nor asynchronous transfer of control.  Normally this attribute should\nonly be used in the tasking runtime (it is highly peculiar, and\ncompletely outside the normal semantics of Ada, for a user program to\nintercept the abort exception).",
+                        "additionalTextEdits": []
+                     },
+                     {
+                        "label": "First_Bit",
+                        "kind": 1,
+                        "detail": "Ada RM",
+                        "documentation": "For a component C of a composite, non-array object R:\n\n\nIf the nondefault bit ordering applies to the composite type,\nand if a component_clause specifies the placement of C,\ndenotes the value given for the first_bit of the\ncomponent_clause; otherwise, denotes the offset, from the\nstart of the first of the storage elements occupied by C, of\nthe first bit occupied by C. This offset is measured in bits.\nThe first bit of a storage element is numbered zero. The value\nof this attribute is of the type universal_integer. See",
+                        "additionalTextEdits": []
+                     }
+                  ]
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": 8,
+            "method": "shutdown"
+         },
+         "wait": [
+            {
+               "id": 8,
+               "result": null
+            }
+         ]
+      }
+   },
+   {
+      "stop": {
+         "exit_code": 0
+      }
+   }
+]

--- a/testsuite/ada_lsp/V216-030.completion.attribute_in_decl/test.yaml
+++ b/testsuite/ada_lsp/V216-030.completion.attribute_in_decl/test.yaml
@@ -1,0 +1,1 @@
+title: 'V216-030.completion.attribute_in_decl'


### PR DESCRIPTION
We should not rely on the current node's text to be the completion
prefix when the user just typed "'". Instead, we should set it to
null in order to list all the possible attributes.

Add an automatic test.