### PR TITLE
Support Ada 2022 arrays

### DIFF
--- a/gnat/lsp_server.gpr
+++ b/gnat/lsp_server.gpr
@@ -47,7 +47,7 @@ project LSP_Server is
    package Compiler is
       for Default_Switches ("Ada") use LSP.Compiler'Default_Switches ("Ada");
       for Switches ("lsp-ada_driver.adb") use
-        LSP.Ada_Switches & ("-gnateDVERSION=""" & VERSION & """");
+        LSP.Compiler'Default_Switches ("Ada") & ("-gnateDVERSION=""" & VERSION & """");
       for Switches ("s-memory.adb") use ("-g", "-O2", "-gnatpg");
       for Local_Configuration_Pragmas use "gnat.adc";
    end Compiler;


### PR DESCRIPTION
In `lsp.gpr` we have:
``` ada
Common_Ada_Switches := (
   --  Generate debug information even in production: this is useful to
   --  get meaningful tracebacks.
   "-g",

   --  Compile with "-gnatX" to support the "[]" syntax for array
   --  aggregates: this is the common ground between all compilers
   --  commonly used to build the language server.
   "-gnatX");
```

Note in specific the comment about `-gnatX`.
We define specific switches for `lsp-ada_driver.adb` in `lsp_server.gpr`.
So I propose adding `-gnatX` to `lsp-ada_driver.adb` too so that we can use the new arrays syntax.
