### PR TITLE
V202-064: Make ALS more robust to several didOpen

### DIFF
--- a/source/ada/lsp-ada_handlers.adb
+++ b/source/ada/lsp-ada_handlers.adb
@@ -2324,7 +2324,7 @@ package body LSP.Ada_Handlers is
 
       --  We have received a document: add it to the documents container
       Object.Initialize (URI, Value.textDocument.text, Diag);
-      Self.Open_Documents.Insert (File, Object);
+      Self.Open_Documents.Include (File, Object);
 
       --  Handle the case where we're loading the implicit project: do
       --  we need to add the directory in which the document is open?


### PR DESCRIPTION
by using Include instead of Insert, allowing the client
to send several didOpen notifications for the same
document.