### PR TITLE
Don't build gpr2-tools to fix CI

### DIFF
--- a/.github/workflows/build-binaries.sh
+++ b/.github/workflows/build-binaries.sh
@@ -65,7 +65,7 @@ sed -i -e '/langkit/s/.{CURDIR}/../' subprojects/gpr/Makefile
 
 make -C subprojects/gpr setup prefix=$prefix \
  GPR2KBDIR=./gprconfig_kb/db ENABLE_SHARED=no \
- ${DEBUG:+BUILD=debug} all install
+ ${DEBUG:+BUILD=debug} build-static install-static
 
 make LIBRARY_TYPE=static all check
 


### PR DESCRIPTION
gpr2-tools.gpr now contains `-gnat2022`, but GCC 11
doesn't understand it. So let skip gpr2-tools build and
build only libgpr2.