### PR TITLE
V223-056: Reduce length of named aggregate snippets

### DIFF
--- a/source/ada/lsp-ada_completions-aggregates.adb
+++ b/source/ada/lsp-ada_completions-aggregates.adb
@@ -99,17 +99,26 @@ package body LSP.Ada_Completions.Aggregates is
             if Use_Named_Notation then
                Snippet.Append (VSS.Strings.To_Virtual_String (Id.Text));
                Snippet.Append (" => ");
+               Snippet.Append ("${");
+               Snippet.Append
+                 (VSS.Strings.Conversions.To_Virtual_String
+                    (GNATCOLL.Utils.Image (Idx, Min_Width => 1)));
+               Snippet.Append (":");
+               Snippet.Append
+                 (VSS.Strings.To_Virtual_String (Param_Type.Text));
+               Snippet.Append ("}, ");
+            else
+               Snippet.Append ("${");
+               Snippet.Append
+                 (VSS.Strings.Conversions.To_Virtual_String
+                    (GNATCOLL.Utils.Image (Idx, Min_Width => 1)));
+               Snippet.Append (":");
+               Snippet.Append (VSS.Strings.To_Virtual_String (Id.Text));
+               Snippet.Append (" : ");
+               Snippet.Append
+                 (VSS.Strings.To_Virtual_String (Param_Type.Text));
+               Snippet.Append ("}, ");
             end if;
-
-            Snippet.Append ("${");
-            Snippet.Append
-              (VSS.Strings.Conversions.To_Virtual_String
-                 (GNATCOLL.Utils.Image (Idx, Min_Width => 1)));
-            Snippet.Append (":");
-            Snippet.Append (VSS.Strings.To_Virtual_String (Id.Text));
-            Snippet.Append (" : ");
-            Snippet.Append (VSS.Strings.To_Virtual_String (Param_Type.Text));
-            Snippet.Append ("}, ");
          end loop;
 
          return Snippet;

--- a/testsuite/ada_lsp/completion.aggregates.derived_types/test.json
+++ b/testsuite/ada_lsp/completion.aggregates.derived_types/test.json
@@ -218,7 +218,7 @@
                   "isIncomplete": false,
                   "items": [
                      {
-                        "insertText": "Disc => 1, A => ${2:A : Integer}, D => ${3:D : Integer})$0",
+                        "insertText": "Disc => 1, A => ${2:Integer}, D => ${3:Integer})$0",
                         "kind": 15,
                         "detail": "type Derived_Rec is new Base_Rec with record\n   D : Integer;\nend record;",
                         "label": "Aggregate when Disc => 1",
@@ -226,7 +226,7 @@
                         "insertTextFormat": 2
                      },
                      {
-                        "insertText": "Disc => 2, Z => ${5:Z : Integer}, D => ${6:D : Integer})$0",
+                        "insertText": "Disc => 2, Z => ${5:Integer}, D => ${6:Integer})$0",
                         "kind": 15,
                         "detail": "type Derived_Rec is new Base_Rec with record\n   D : Integer;\nend record;",
                         "label": "Aggregate when Disc => 2",
@@ -234,7 +234,7 @@
                         "insertTextFormat": 2
                      },
                      {
-                        "insertText": "Disc => ${7:others}, B => ${8:B : Integer}, D => ${9:D : Integer})$0",
+                        "insertText": "Disc => ${7:others}, B => ${8:Integer}, D => ${9:Integer})$0",
                         "kind": 15,
                         "detail": "type Derived_Rec is new Base_Rec with record\n   D : Integer;\nend record;",
                         "label": "Aggregate when Disc => others",

--- a/testsuite/ada_lsp/completion.aggregates.simple/test.json
+++ b/testsuite/ada_lsp/completion.aggregates.simple/test.json
@@ -197,7 +197,7 @@
                   "isIncomplete": false,
                   "items": [
                      {
-                        "insertText": "A => ${1:A : Integer}, B => ${2:B : Integer}, C => ${3:C : Integer})$0",
+                        "insertText": "A => ${1:Integer}, B => ${2:Integer}, C => ${3:Integer})$0",
                         "kind": 15,
                         "detail": "type Aggr_Type_1 is record\n   A : Integer;\n   B : Integer;\n   C : Integer;\nend record;",
                         "label": "Aggregate for Aggr_Type_1",


### PR DESCRIPTION
We don't need to put the parameter's name in the snippet's
placeholders when using named notation, since these names
are already visible.