### PR TITLE
Fix bad casing warnings

### DIFF
--- a/source/ada/lsp-ada_handlers.adb
+++ b/source/ada/lsp-ada_handlers.adb
@@ -787,7 +787,7 @@ package body LSP.Ada_Handlers is
         (Document => Document,
          Span     => Span,
          Options  => Options,
-         Edit     => Response.Result,
+         Edit     => Response.result,
          Success  => Success,
          Messages => Messages);
 
@@ -804,7 +804,7 @@ package body LSP.Ada_Handlers is
                Error_Msg := Error_Msg & Msg;
             end loop;
 
-            Response.Error :=
+            Response.error :=
               (True,
                (code    => LSP.Errors.InternalError,
                 message => Error_Msg,
@@ -1853,7 +1853,7 @@ package body LSP.Ada_Handlers is
 
       --  No particular response in case of success.
       return (Is_Error => False,
-              Error    => (Is_Set => False),
+              error    => (Is_Set => False),
               others   => <>);
    end On_Execute_Command_Request;
 
@@ -2623,7 +2623,7 @@ package body LSP.Ada_Handlers is
       begin
          if not Laltools.Common.Is_End_Label (Node.As_Ada_Node) then
             Append_Location
-              (Result   => Response.Result,
+              (Result   => Response.result,
                Document => Document,
                File     => File,
                Node     => Node,
@@ -3780,7 +3780,7 @@ package body LSP.Ada_Handlers is
          return Response : LSP.Messages.Server_Responses.Rename_Response
            (Is_Error => True)
          do
-            Response.Error :=
+            Response.error :=
               (True,
                (code    => LSP.Errors.InternalError,
                 message => VSS.Strings.Conversions.To_Virtual_String
@@ -4538,7 +4538,7 @@ package body LSP.Ada_Handlers is
 
       --  No particular response in case of success.
       return (Is_Error => False,
-              Error    => (Is_Set => False),
+              error    => (Is_Set => False),
               others   => <>);
    end On_Workspace_Execute_Command_Request;
 
@@ -5540,9 +5540,9 @@ package body LSP.Ada_Handlers is
            (Is_Error => Result.Is_Error);
       begin
          if not Result.Is_Error then
-            Response.Result := Result.result;
+            Response.result := Result.result;
          else
-            Response.Error := Result.error;
+            Response.error := Result.error;
          end if;
 
          return Response;

--- a/source/protocol/lsp-messages.adb
+++ b/source/protocol/lsp-messages.adb
@@ -2875,7 +2875,7 @@ package body LSP.Messages is
       case JS.R.Event_Kind is
          when VSS.JSON.Pull_Readers.String_Value =>
             V := (Is_String => True,
-                  Value     => JS.R.String_Value);
+                  value     => JS.R.String_Value);
 
             JS.R.Read_Next;
          when VSS.JSON.Pull_Readers.Start_Object =>


### PR DESCRIPTION
Fixes the following warning when using GNAT Pro 23.0w (20220411-112)
```
lsp-messages.adb:2878:19: (style) bad casing of "value" declared at lsp-messages.ads:7679                                                                                                                                                                                                                                     
lsp-ada_handlers.adb:790:31: (style) bad casing of "result" declared at lsp-generic_responses.ads:40, instance at lsp-messages-server_responses.ads:306                                                                                                                                                                       
lsp-ada_handlers.adb:807:22: (style) bad casing of "error" declared at lsp-messages.ads:228                                                                                                                                                                                                                                   
lsp-ada_handlers.adb:1856:15: (style) bad casing of "error" declared at lsp-messages.ads:228                                                                                                                                                                                                                                  
lsp-ada_handlers.adb:2626:37: (style) bad casing of "result" declared at lsp-generic_responses.ads:40, instance at lsp-messages-server_responses.ads:83                                                                                                                                                                       
lsp-ada_handlers.adb:3783:22: (style) bad casing of "error" declared at lsp-messages.ads:228
lsp-ada_handlers.adb:4541:15: (style) bad casing of "error" declared at lsp-messages.ads:228
lsp-ada_handlers.adb:5543:22: (style) bad casing of "result" declared at lsp-generic_responses.ads:40, instance at lsp-messages-server_responses.ads:317
lsp-ada_handlers.adb:5545:22: (style) bad casing of "error" declared at lsp-messages.ads:228
```