### PR TITLE
Do not call p_canonical_type for aggregate completion

### DIFF
--- a/source/ada/lsp-ada_completions-aggregates.adb
+++ b/source/ada/lsp-ada_completions-aggregates.adb
@@ -43,11 +43,9 @@ package body LSP.Ada_Completions.Aggregates is
       use LSP.Messages;
 
       Expr_Type : constant Base_Type_Decl := Node.P_Expression_Type;
-      Aggr_Type          : constant Base_Type_Decl :=
-        (if not Expr_Type.Is_Null then
-            Expr_Type.P_Canonical_Type
-         else
-            No_Base_Type_Decl);
+      Aggr_Type : constant Base_Type_Decl :=
+        (if Expr_Type.Is_Null then No_Base_Type_Decl else Expr_Type);
+
       Use_Named_Notation : Boolean := False;
 
       function Get_Snippet_For_Component

--- a/testsuite/ada_lsp/completion.aggregates.incomplete_type/default.gpr
+++ b/testsuite/ada_lsp/completion.aggregates.incomplete_type/default.gpr
@@ -1,0 +1,9 @@
+project Default is
+
+   package Compiler is
+      for Switches ("Ada") use ("-g", "-O2");
+   end Compiler;
+
+   for Main use ("main.adb") & project'Main;
+
+end Default;

--- a/testsuite/ada_lsp/completion.aggregates.incomplete_type/main.adb
+++ b/testsuite/ada_lsp/completion.aggregates.incomplete_type/main.adb
@@ -1,0 +1,17 @@
+procedure Main is
+
+   type Cell;
+   type Link is access Cell;
+
+   type Cell is
+   record
+      Value : Integer;
+      Succ  : Link;
+      Pred  : Link;
+   end record;
+
+   Head : Link := new Cell'(
+
+begin
+   null;
+end Main;

--- a/testsuite/ada_lsp/completion.aggregates.incomplete_type/test.json
+++ b/testsuite/ada_lsp/completion.aggregates.incomplete_type/test.json
@@ -1,0 +1,247 @@
+[
+   {
+      "comment": [
+          "This test checks that aggregate completion works fine when ",
+          "an incomplete type is involved in the aggregate declaration"
+      ]
+   },
+   {
+      "start": {
+         "cmd": [
+            "${ALS}"
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "processId": 31570,
+               "capabilities": {
+                  "textDocument": {
+                     "completion": {
+                        "completionItem": {
+                           "documentationFormat": [
+                              "plaintext",
+                              "markdown"
+                           ],
+                           "snippetSupport": true
+                        },
+                        "dynamicRegistration": true
+                     },
+                     "definition": {},
+                     "hover": {},
+                     "formatting": {
+                        "dynamicRegistration": true
+                     },
+                     "implementation": {},
+                     "codeLens": {},
+                     "typeDefinition": {},
+                     "selectionRange": {},
+                     "documentHighlight": {},
+                     "documentSymbol": {
+                        "hierarchicalDocumentSymbolSupport": true
+                     },
+                     "synchronization": {},
+                     "references": {},
+                     "rangeFormatting": {},
+                     "onTypeFormatting": {},
+                     "declaration": {},
+                     "foldingRange": {
+                        "lineFoldingOnly": true
+                     },
+                     "colorProvider": {}
+                  },
+                  "workspace": {
+                     "applyEdit": true,
+                     "executeCommand": {},
+                     "didChangeWatchedFiles": {},
+                     "workspaceEdit": {},
+                     "didChangeConfiguration": {}
+                  }
+               },
+               "rootUri": "$URI{.}"
+            },
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize"
+         },
+          "wait": [
+              {
+                  "jsonrpc": "2.0",
+                  "id": 1,
+                  "result": {
+                      "capabilities": {
+                          "textDocumentSync": 2,
+                          "completionProvider": {
+                              "triggerCharacters": [
+                                  ".",
+                                  ",",
+                                  "'",
+                                  "("
+                              ],
+                              "resolveProvider": true
+                          },
+                          "hoverProvider": true,
+                          "declarationProvider": true,
+                          "definitionProvider": true,
+                          "typeDefinitionProvider": true,
+                          "implementationProvider": true,
+                          "referencesProvider": true,
+                          "codeActionProvider": {
+                          },
+                          "renameProvider": {
+                          },
+                          "foldingRangeProvider": true,
+                          "executeCommandProvider": {},
+                          "alsReferenceKinds": [
+                              "reference",
+                              "access",
+                              "write",
+                              "call",
+                              "dispatching call",
+                              "parent",
+                              "child",
+                              "overriding"
+                          ]
+                      }
+                  }
+              }
+          ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "initialized"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "settings": {
+                  "ada": {
+                     "scenarioVariables": {},
+                     "enableDiagnostics": false,
+                     "defaultCharset": "ISO-8859-1"
+                  }
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "workspace/didChangeConfiguration"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "text": "procedure Main is\n\n   type Cell;\n   type Link is access Cell;\n\n   type Cell is\n   record\n      Value : Integer;\n      Succ  : Link;\n      Pred  : Link;\n   end record;\n\n   Head : Link := new Cell'\n\nbegin\n   null;\nend Main;\n",
+                  "version": 0,
+                  "uri": "$URI{main.adb}",
+                  "languageId": "Ada"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "contentChanges": [
+                  {
+                     "text": "procedure Main is\n\n   type Cell;\n   type Link is access Cell;\n\n   type Cell is\n   record\n      Value : Integer;\n      Succ  : Link;\n      Pred  : Link;\n   end record;\n\n   Head : Link := new Cell'(\n\nbegin\n   null;\nend Main;\n"
+                  }
+               ],
+               "textDocument": {
+                  "version": 1,
+                  "uri": "$URI{main.adb}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "position": {
+                  "line": 13,
+                  "character": 29
+               },
+               "textDocument": {
+                  "uri": "$URI{main.adb}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "textDocument/completion"
+         },
+         "wait": [
+            {
+               "id": 3,
+               "result": {
+                  "isIncomplete": false,
+                  "items": [
+                     {
+                        "insertText": "Value => ${1:Integer}, Succ => ${2:Link}, Pred => ${3:Link})$0",
+                        "kind": 15,
+                        "detail": "type Cell is\nrecord\n   Value : Integer;\n   Succ  : Link;\n   Pred  : Link;\nend record;",
+                        "label": "Aggregate for Cell",
+                        "additionalTextEdits": [],
+                        "insertTextFormat": 2
+                     }
+                  ]
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{main.adb}"
+               }
+            },
+            "jsonrpc": "2.0",
+            "method": "textDocument/didClose"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": 6,
+            "method": "shutdown"
+         },
+         "wait": [
+            {
+               "id": 6,
+               "result": null
+            }
+         ]
+      }
+   },
+   {
+      "stop": {
+         "exit_code": 0
+      }
+   }
+]

--- a/testsuite/ada_lsp/completion.aggregates.incomplete_type/test.yaml
+++ b/testsuite/ada_lsp/completion.aggregates.incomplete_type/test.yaml
@@ -1,0 +1,1 @@
+title: 'completion.aggregates.incomplete_type'


### PR DESCRIPTION
This patch removes the call to `p_canonical_type` when looking for
aggregate completions. This call seems useless and can leads to a
property error exception when an incomplete type is involved in the
completion.

TN: V225-032