### PR TITLE
V419-041: Incoming Calls for entity outside of the project

### DIFF
--- a/source/ada/lsp-ada_handlers.adb
+++ b/source/ada/lsp-ada_handlers.adb
@@ -443,7 +443,8 @@ package body LSP.Ada_Handlers is
         Laltools.Common.Get_Node_As_Name
           (In_Context.Get_Node_At
              (Get_Open_Document (Self, Position.textDocument.uri),
-              Position));
+              Position,
+              Project_Only => False));
 
       Imprecise  : Boolean;
    begin


### PR DESCRIPTION
The modification of prepareCallHierarchy returning the body
and not the spec had for side effect of using a non-indexed
document resulting in empty result (only the "ads" are indexed)