### PR TITLE
Refetch tags from origin to fix CHANGELOG.md generation

### DIFF
--- a/.github/workflows/pack-binaries.sh
+++ b/.github/workflows/pack-binaries.sh
@@ -17,6 +17,14 @@ function make_change_log()
     done
 }
 
+if [[ ${GITHUB_REF##*/} = 2*.[0-9]*.[0-9]* ]] ; then
+    # For tags `actions/checkout@v2` action fetches a tag's commit, but
+    # not the tag annotation itself. Let's refetch the tag from origin.
+    # This makes `git show --no-patch --format=%n $TAG` work again.
+    git tag --delete ${GITHUB_REF##*/}
+    git fetch --tags
+fi
+
 chmod -R -v +x als-*-$DEBUG
 for X in Linux macOS Windows ; do mv -v -f als-$X-$DEBUG/* integration/vscode/ada/; done
 cp -v -f LICENSE integration/vscode/ada/


### PR DESCRIPTION
Since `23.0.4` CHANGELOG.md isn't generated correctly,
it misses the last tag entry. The investigation shows that
GitHub Action checkout SHA for the tag, but not the tag annotation.

For instance:
```
git rev-parse refs/tags/23.0.5
05ea548d65e6607e4fbb0facb0aee94be1f702ee

git fetch --no-tags origin +de660fc7f50123e22a82b9363e095accd834c6c9:refs/tags/23.0.5

git rev-parse refs/tags/23.0.5
de660fc7f50123e22a82b9363e095accd834c6c9
```

So `de660fc` replaces `05ea548d` in tag `23.0.5`.

We drop the tag and fetch all tags from the origin again.