### PR TITLE
Bundle vscode extension on publishing

### DIFF
--- a/.github/workflows/pack-binaries.sh
+++ b/.github/workflows/pack-binaries.sh
@@ -34,6 +34,7 @@ sed -i -e "/version/s/[0-9][0-9.]*/$TAG/" package.json
                           -e '/displayName/s/Ada/Ada (with debug info)/' package.json
 npm install
 sudo npm install -g vsce --unsafe-perm
+sudo npm install -g esbuild --unsafe-perm
 make_change_log > CHANGELOG.md
 if [[ ${GITHUB_REF##*/} = 2*.[0-9]*.[0-9]* ]] ; then
     vsce publish -p "$VSCE_TOKEN" || true

--- a/integration/vscode/ada/.vscodeignore
+++ b/integration/vscode/ada/.vscodeignore
@@ -1,4 +1,13 @@
 .vscode/**
 .vscode-test/**
+node_modules/**
+out/test/**
+src/**
+testsuite_grammar/**
 .gitignore
-vsc-extension-quickstart.md
+.prettierrc
+run_grammar_tests.sh
+**/tsconfig.json
+**/.eslintrc.json
+**/*.map
+**/*.ts

--- a/integration/vscode/ada/package.json
+++ b/integration/vscode/ada/package.json
@@ -495,7 +495,8 @@
         "vscode-tmgrammar-test": "0.0.11"
     },
     "scripts": {
-        "vscode:prepublish": "npm run compile",
+        "vscode:prepublish": "npm run esbuild-base -- --minify",
+        "esbuild-base": "esbuild ./src/extension.ts --bundle --outfile=out/extension.js --external:vscode --format=cjs --platform=node",
         "compile": "node ./node_modules/typescript/bin/tsc",
         "watch": "node ./node_modules/typescript/bin/tsc -watch",
         "pretest": "npm run compile",


### PR DESCRIPTION
Install esbuild and use it before packaging vscode extension
to reduce number of packaged files, speed extension up.

This fixes warnings on `vsce publish` and `vsce package`.

According to the guide:
https://code.visualstudio.com/api/working-with-extensions/bundling-extension