### PR TITLE
Allow more complex sorting in LSP tests.

### DIFF
--- a/testsuite/ada_lsp/README.md
+++ b/testsuite/ada_lsp/README.md
@@ -72,7 +72,7 @@ Property value - an object:
  * "wait" - array of _wait_ objects to expect them in any order.
  * "sortReply" - an object describing how to sort a server reply. Let's
    explain by examples:
-    1.  `"sortReply": {"result", "uri"}` - Server reply should have a property
+    1.  `"sortReply": {"result": "uri"}` - Server reply should have a property
        `result`, that is an array of objects, each of them has a property
        `uri`. Tester driver will sort the array using the `uri` as a sort key.
     2. `"sortReply": { "result": ["label", "detail"] }` - you can have a
@@ -84,6 +84,10 @@ Property value - an object:
        an object, that has a `items` property. Where `items` is an array of
        objects, that should be sorted using the `label` and `detail` as a
        composite sort key.
+    4. `"sortReply": { "result": { "from": "uri" } }` - Server reply should
+       have a property `result`, that is an array of objects. Array items
+       have property `from` which is an object. Tester driver will sort the
+       array using the `uri` property of `from` objects as a sort key.
  * "waitFactor" - see "Execution timeouts"
 
 Where _wait_ object is expected server answer. Each property of this object

--- a/testsuite/ada_lsp/aggregate.is_called_by/test.json
+++ b/testsuite/ada_lsp/aggregate.is_called_by/test.json
@@ -332,6 +332,7 @@
                }
             }
          },
+         "sortReply": {"result": {"from": "uri"}},
          "wait": [
             {
                "id": "ada-7",

--- a/testsuite/ada_lsp/show_dependencies.aggregate/test.json
+++ b/testsuite/ada_lsp/show_dependencies.aggregate/test.json
@@ -172,6 +172,7 @@
             "id": 2,
             "method": "textDocument/alsShowDependencies"
          },
+         "sortReply": {"result": "uri"},
          "wait": [
             {
                "id": 2,
@@ -181,11 +182,11 @@
                      "projectUri": "$URI{}"
                   },
                   {
-                     "uri": "$URI{p/main.adb}",
+                     "uri": "$URI{common/common_pack.ads}",
                      "projectUri": "$URI{}"
                   },
                   {
-                     "uri": "$URI{common/common_pack.ads}",
+                     "uri": "$URI{p/main.adb}",
                      "projectUri": "$URI{}"
                   },
                   {

--- a/testsuite/ada_lsp/type_definition.aggregate/test.json
+++ b/testsuite/ada_lsp/type_definition.aggregate/test.json
@@ -143,6 +143,7 @@
             "id": 2,
             "method": "textDocument/typeDefinition"
          },
+         "sortReply": {"result": {"range": {"start": "line"}}},
          "wait": [
             {
                "id": 2,
@@ -195,6 +196,7 @@
             "id": 6,
             "method": "textDocument/typeDefinition"
          },
+         "sortReply": {"result": {"range": {"start": "line"}}},
          "wait": [
             {
                "id": 6,


### PR DESCRIPTION
Extend `sortReply` to work with keys nested in objects
inside JSON array. With this sort complex reply JSON to have
more stable tests.

For instance

```json
"sortReply": {"result": {"range": {"start": "line"}}}
```

will sort `result` JSON array using `X.range.start.line` as
a sorting key, where `X` is an array item.

Allow integer JSON values as sorting keys also.