### PR TITLE
Add partial gnatpp option to On_Range_Formatting_Request handler

### DIFF
--- a/source/ada/lsp-ada_contexts.adb
+++ b/source/ada/lsp-ada_contexts.adb
@@ -779,6 +779,37 @@ package body LSP.Ada_Contexts is
          Messages => Messages);
    end Format;
 
+   ------------------
+   -- Range_Format --
+   ------------------
+
+   procedure Range_Format
+     (Self     : in out Context;
+      Document : LSP.Ada_Documents.Document_Access;
+      Span     : LSP.Messages.Span;
+      Options  : LSP.Messages.FormattingOptions;
+      Edit     : out LSP.Messages.TextEdit_Vector;
+      Success  : out Boolean;
+      Messages : out VSS.String_Vectors.Virtual_String_Vector) is
+   begin
+      Pp.Command_Lines.Pp_Nat_Switches.Set_Arg
+        (Self.PP_Options,
+         Pp.Command_Lines.Indentation,
+         Natural (Options.tabSize));
+
+      Pp.Command_Lines.Pp_Flag_Switches.Set_Arg
+        (Self.PP_Options,
+         Pp.Command_Lines.No_Tab,
+         Options.insertSpaces);
+
+      Success := Document.Range_Formatting
+        (Context    => Self,
+         Span       => Span,
+         PP_Options => Self.PP_Options,
+         Edit       => Edit,
+         Messages   => Messages);
+   end Range_Format;
+
    ----------
    -- Free --
    ----------

--- a/source/ada/lsp-ada_contexts.ads
+++ b/source/ada/lsp-ada_contexts.ads
@@ -111,6 +111,15 @@ package LSP.Ada_Contexts is
       Success  : out Boolean;
       Messages : out VSS.String_Vectors.Virtual_String_Vector);
 
+   procedure Range_Format
+     (Self     : in out Context;
+      Document : LSP.Ada_Documents.Document_Access;
+      Span     : LSP.Messages.Span;
+      Options  : LSP.Messages.FormattingOptions;
+      Edit     : out LSP.Messages.TextEdit_Vector;
+      Success  : out Boolean;
+      Messages : out VSS.String_Vectors.Virtual_String_Vector);
+
    procedure Find_All_References
      (Self       : Context;
       Definition : Libadalang.Analysis.Defining_Name;

--- a/source/ada/lsp-ada_documents.ads
+++ b/source/ada/lsp-ada_documents.ads
@@ -181,6 +181,16 @@ package LSP.Ada_Documents is
       return Boolean;
    --  Format document or its part defined in Span
 
+   function Range_Formatting
+     (Self       : Document;
+      Context    : LSP.Ada_Contexts.Context;
+      Span       : LSP.Messages.Span;
+      PP_Options : Pp.Command_Lines.Cmd_Line;
+      Edit       : out LSP.Messages.TextEdit_Vector;
+      Messages   : out VSS.String_Vectors.Virtual_String_Vector)
+      return Boolean;
+   --  Format document or its part defined in Span
+
    procedure Get_Imported_Units
      (Self          : Document;
       Context       : LSP.Ada_Contexts.Context;
@@ -353,9 +363,9 @@ private
       New_Span : LSP.Messages.Span := LSP.Messages.Empty_Span;
       Edit     : out LSP.Messages.TextEdit_Vector);
    --  Create a diff between document Text and New_Text and return Text_Edit
-   --  based on Needleman-Wunsch algorithm
+   --  based on Needleman-Wunsch algorithm.
    --  Old_Span and New_Span are used when we need to compare certain
-   --  old/new lines instead of whole buffers
+   --  old/new lines instead of whole buffers.
 
    function URI (Self : Document) return LSP.Messages.DocumentUri is
      (Self.URI);

--- a/source/ada/lsp-ada_handlers.adb
+++ b/source/ada/lsp-ada_handlers.adb
@@ -119,7 +119,7 @@ package body LSP.Ada_Handlers is
 
    Partial_GNATpp : constant GNATCOLL.Traces.Trace_Handle :=
      GNATCOLL.Traces.Create ("ALS.PARTIAL_GNATPP",
-                             GNATCOLL.Traces.Off);
+                             GNATCOLL.Traces.On);
    --  Use partial formatting mode of gnatpp if On. Otherwise, use diff
    --  algorithm.
 
@@ -953,19 +953,17 @@ package body LSP.Ada_Handlers is
       Response.result.capabilities.documentFormattingProvider :=
         (Is_Set => True,
          Value  => (workDoneProgress => LSP.Types.None));
+      if Partial_GNATpp.Is_Active then
+         Response.result.capabilities.documentRangeFormattingProvider :=
+           (Is_Set => True,
+            Value  => (workDoneProgress => LSP.Types.None));
+      end if;
       Response.result.capabilities.callHierarchyProvider :=
         (Is_Set => True,
          Value  => (Is_Boolean => False, Options => <>));
       Response.result.capabilities.documentHighlightProvider :=
         (Is_Set => True,
          Value => (workDoneProgress => LSP.Types.None));
-
-      --  lalpp does not support range formatting for now
-      --  do not set the option
-      --
-      --  Response.result.capabilities.documentRangeFormattingProvider :=
-      --    (Is_Set => True,
-      --     Value  => (workDoneProgress => LSP.Types.None));
 
       Response.result.capabilities.workspaceSymbolProvider :=
         (Is_Set => True,

--- a/source/ada/lsp-ada_handlers.adb
+++ b/source/ada/lsp-ada_handlers.adb
@@ -117,6 +117,12 @@ package body LSP.Ada_Handlers is
                              GNATCOLL.Traces.On);
    --  Trace to enable/disable runtime indexing. Useful for the testsuite.
 
+   Partial_GNATpp : constant GNATCOLL.Traces.Trace_Handle :=
+     GNATCOLL.Traces.Create ("ALS.PARTIAL_GNATPP",
+                             GNATCOLL.Traces.Off);
+   --  Use partial formatting mode of gnatpp if On. Otherwise, use diff
+   --  algorithm.
+
    Is_Parent : constant LSP.Messages.AlsReferenceKind_Set :=
      (Is_Server_Side => True,
       As_Flags => [LSP.Messages.Parent => True, others => False]);
@@ -225,6 +231,14 @@ package body LSP.Ada_Handlers is
    --  notifications.
 
    function Format
+     (Self     : in out LSP.Ada_Contexts.Context;
+      Document : LSP.Ada_Documents.Document_Access;
+      Span     : LSP.Messages.Span;
+      Options  : LSP.Messages.FormattingOptions)
+      return LSP.Messages.Server_Responses.Formatting_Response;
+   --  Format the text of the given document in the given range (span).
+
+   function Range_Format
      (Self     : in out LSP.Ada_Contexts.Context;
       Document : LSP.Ada_Documents.Document_Access;
       Span     : LSP.Messages.Span;
@@ -800,7 +814,7 @@ package body LSP.Ada_Handlers is
       Document : LSP.Ada_Documents.Document_Access;
       Span     : LSP.Messages.Span;
       Options  : LSP.Messages.FormattingOptions)
-         return LSP.Messages.Server_Responses.Formatting_Response
+      return LSP.Messages.Server_Responses.Formatting_Response
    is
       Response : LSP.Messages.Server_Responses.Formatting_Response
         (Is_Error => False);
@@ -839,6 +853,56 @@ package body LSP.Ada_Handlers is
 
       return Response;
    end Format;
+
+   ------------------
+   -- Range_Format --
+   ------------------
+
+   function Range_Format
+     (Self     : in out LSP.Ada_Contexts.Context;
+      Document : LSP.Ada_Documents.Document_Access;
+      Span     : LSP.Messages.Span;
+      Options  : LSP.Messages.FormattingOptions)
+      return LSP.Messages.Server_Responses.Formatting_Response
+   is
+      Response : LSP.Messages.Server_Responses.Formatting_Response
+        (Is_Error => False);
+      Success  : Boolean;
+      Messages : VSS.String_Vectors.Virtual_String_Vector;
+
+   begin
+      Self.Range_Format
+        (Document => Document,
+         Span     => Span,
+         Options  => Options,
+         Edit     => Response.result,
+         Success  => Success,
+         Messages => Messages);
+
+      if not Success then
+         declare
+            use VSS.Strings;
+
+            Response  : LSP.Messages.Server_Responses.Formatting_Response
+              (Is_Error => True);
+            Error_Msg : VSS.Strings.Virtual_String;
+         begin
+            --  Display error messages from gnatpp, if any
+            for Msg of Messages loop
+               Error_Msg := Error_Msg & Msg;
+            end loop;
+
+            Response.error :=
+              (True,
+               (code    => LSP.Errors.InternalError,
+                message => Error_Msg,
+                data    => <>));
+            return Response;
+         end;
+      end if;
+
+      return Response;
+   end Range_Format;
 
    ------------------------
    -- Initialize_Request --
@@ -5798,7 +5862,7 @@ package body LSP.Ada_Handlers is
             Response.error :=
               (True,
                (code    => LSP.Errors.InternalError,
-                message => "Incorrect code can't be formatted",
+                message => "Syntactically incorrect code can't be formatted",
                 data    => <>));
          end return;
       end if;
@@ -5807,11 +5871,18 @@ package body LSP.Ada_Handlers is
          use LSP.Messages;
 
          Result   : constant Server_Responses.Formatting_Response :=
-           Format
-             (Self     => Context.all,
-              Document => Document,
-              Span     => Request.params.span,
-              Options  => Request.params.options);
+           (if Partial_GNATpp.Is_Active then
+              Range_Format
+                (Self     => Context.all,
+                 Document => Document,
+                 Span     => Request.params.span,
+                 Options  => Request.params.options)
+            else
+              Format
+                (Self     => Context.all,
+                 Document => Document,
+                 Span     => Request.params.span,
+                 Options  => Request.params.options));
          Response : Server_Responses.Range_Formatting_Response
            (Is_Error => Result.Is_Error);
       begin

--- a/testsuite/ada_lsp/T527-019.range_formatting/test.json
+++ b/testsuite/ada_lsp/T527-019.range_formatting/test.json
@@ -134,15 +134,15 @@
                   {
                      "range": {
                         "start": {
-                           "line": 2,
+                           "line": 0,
                            "character": 0
                         },
                         "end": {
-                           "line": 7,
-                           "character": 0
+                           "line": 8,
+                           "character": 9
                         }
                      },
-                     "newText": "   X : Integer := (1 + 2 + 3);\nbegin\n   --  Insert code here.\n"
+                     "newText": "procedure Main is\n   --  comment\n   X : Integer := (1 + 2 + 3);\nbegin\n   --  Insert code here.\n   null;\nend Main;"
                   }
                ]
             }
@@ -269,15 +269,15 @@
                   {
                      "range": {
                         "start": {
-                           "line": 4,
+                           "line": 0,
                            "character": 0
                         },
                         "end": {
-                           "line": 5,
-                           "character": 0
+                           "line": 6,
+                           "character": 9
                         }
                      },
-                     "newText": "   --  Insert code here.\n"
+                     "newText": "procedure Main is\n   --  comment\n   X : Integer := (1 + 2 + 3);\nbegin\n   --  Insert code here.\n   null;\nend Main;"
                   }
                ]
             }


### PR DESCRIPTION
When setting the ALS.PARTIAL_GNATPP=yes trace, On_Range_Formatting_Request now uses partial gnatpp to perform a range formatting.