### PR TITLE
V614-021: Use completion weight in sortText

### DIFF
--- a/source/ada/lsp-ada_completions-names.adb
+++ b/source/ada/lsp-ada_completions-names.adb
@@ -128,7 +128,8 @@ package body LSP.Ada_Completions.Names is
                (Is_Dot_Call  => False,
                 Is_Visible   => True,
                 Use_Snippets => Use_Snippets,
-                Pos          => 1));
+                Pos          => 1,
+                Weight       => 0));
             return;
          end if;
       end if;
@@ -174,7 +175,8 @@ package body LSP.Ada_Completions.Names is
                         (Is_Dot_Call (Item),
                          Is_Visible (Item),
                          Use_Snippets,
-                         Completion_Count));
+                         Completion_Count,
+                         Weight (Item)));
                   end if;
                end loop;
             end if;

--- a/source/ada/lsp-ada_completions.adb
+++ b/source/ada/lsp-ada_completions.adb
@@ -99,6 +99,7 @@ package body LSP.Ada_Completions is
                         Is_Dot_Call              => Info.Is_Dot_Call,
                         Is_Visible               => Info.Is_Visible,
                         Pos                      => Info.Pos,
+                        Weight                   => Info.Weight,
                         Completions_Count        => Length));
                end if;
             end;

--- a/source/ada/lsp-ada_completions.ads
+++ b/source/ada/lsp-ada_completions.ads
@@ -43,6 +43,10 @@ package LSP.Ada_Completions is
    --  for completion, since LAL can return several times the same declaration
    --  and specially subprograms from generic instantiations.
 
+   subtype Completion_Item_Weight_Type is Integer range 0 .. 100;
+   --  Type representing the weight returned by LAL for each completion item.
+   --  Used to sort them accordingly on the client-side.
+
    type Name_Information is record
       Is_Dot_Call  : Boolean;
       --  True if we are dealing with a dotted call.
@@ -57,6 +61,9 @@ package LSP.Ada_Completions is
       Pos          : Integer := -1;
       --  The position of the item in the fully computed completion list. Used
       --  for sorting properly the items on client-side.
+
+      Weight : Completion_Item_Weight_Type := 0;
+      --  The completion item's weight. Used for sorting on the client-side.
    end record;
 
    package Completion_Maps is new Ada.Containers.Hashed_Maps

--- a/source/ada/lsp-ada_documents.adb
+++ b/source/ada/lsp-ada_documents.adb
@@ -1838,6 +1838,7 @@ package body LSP.Ada_Documents is
       Is_Dot_Call              : Boolean;
       Is_Visible               : Boolean;
       Pos                      : Integer;
+      Weight                   : Completion_Item_Weight_Type;
       Completions_Count        : Natural)
       return LSP.Messages.CompletionItem
    is
@@ -1860,14 +1861,22 @@ package body LSP.Ada_Documents is
 
       function Get_Sort_Text
         (Base_Label : VSS.Strings.Virtual_String)
-         return VSS.Strings.Virtual_String is
+         return VSS.Strings.Virtual_String
+      is
+         use VSS.Strings;
       begin
          return Sort_Text : VSS.Strings.Virtual_String do
-            if Pos /= -1 then
-               Sort_Text :=
-                 VSS.Strings.Conversions.To_Virtual_String
-                   (GNATCOLL.Utils.Image (Pos, Min_Width => Min_Width));
-            end if;
+
+            Sort_Text :=
+              VSS.Strings.Conversions.To_Virtual_String
+                (GNATCOLL.Utils.Image
+                   (Value     => Completion_Item_Weight_Type'Last - Weight,
+                    Min_Width =>
+                      Completion_Item_Weight_Type'Last'Img'Length - 1)) & "&";
+
+            Sort_Text := Sort_Text &
+              VSS.Strings.Conversions.To_Virtual_String
+              (GNATCOLL.Utils.Image (Pos, Min_Width => Min_Width));
 
             Sort_Text.Append (Base_Label);
 
@@ -2146,7 +2155,8 @@ package body LSP.Ada_Documents is
                (Is_Dot_Call  => False,
                 Is_Visible   => False,
                 Use_Snippets => False,
-                Pos          => <>));
+                Pos          => <>,
+                Weight       => <>));
          end if;
       end Insert;
 

--- a/source/ada/lsp-ada_documents.ads
+++ b/source/ada/lsp-ada_documents.ads
@@ -33,7 +33,7 @@ with GNATCOLL.Traces;
 with Pp.Command_Lines;
 
 limited with LSP.Ada_Contexts;
-with LSP.Ada_Completions;
+with LSP.Ada_Completions; use LSP.Ada_Completions;
 with LSP.Ada_Highlighters;
 with LSP.Diagnostic_Sources;
 with LSP.Messages;
@@ -252,6 +252,7 @@ package LSP.Ada_Documents is
       Is_Dot_Call              : Boolean;
       Is_Visible               : Boolean;
       Pos                      : Integer;
+      Weight                   : Completion_Item_Weight_Type;
       Completions_Count        : Natural)
       return LSP.Messages.CompletionItem;
    --  Compute a completion item.
@@ -264,6 +265,8 @@ package LSP.Ada_Documents is
    --  named notation is used for subprogram completion snippets.
    --  Is_Dot_Call is used to know if we should omit the first parameter
    --  when computing subprogram snippets.
+   --  Weight is used for sorting: items with an higher weight will be placed
+   --  at the top.
    --  Completions_Count is the total number of completion items.
 
    procedure Set_Completion_Item_Documentation

--- a/source/ada/lsp-ada_handlers-invisibles.adb
+++ b/source/ada/lsp-ada_handlers-invisibles.adb
@@ -68,7 +68,8 @@ package body LSP.Ada_Handlers.Invisibles is
                (Is_Dot_Call  => False,
                 Is_Visible   => False,
                 Use_Snippets => False,
-                Pos          => Pos));
+                Pos          => Pos,
+                Weight       => <>));
 
             Pos := Pos + 1;
 

--- a/source/ada/lsp-ada_handlers.adb
+++ b/source/ada/lsp-ada_handlers.adb
@@ -5121,7 +5121,8 @@ package body LSP.Ada_Handlers is
                (Is_Dot_Call  => False,
                 Is_Visible   => False,
                 Use_Snippets => False,
-                Pos          => <>));
+                Pos          => <>,
+                Weight       => <>));
          end if;
 
          Stop := Canceled.Has_Been_Canceled;

--- a/testsuite/ada_lsp/U915-024.completion.invisible_snippets/test.json
+++ b/testsuite/ada_lsp/U915-024.completion.invisible_snippets/test.json
@@ -204,7 +204,7 @@
                      {
                         "label": "Do_Something (invisible)",
                         "kind": 3,
-                        "sortText": "~0Do_Something",
+                        "sortText": "~100&0Do_Something",
                         "filterText": "Do_Something",
                         "insertText": "Do_Something",
                         "additionalTextEdits": [],

--- a/testsuite/ada_lsp/U921-010.completion.no_generic_duplicates/test.json
+++ b/testsuite/ada_lsp/U921-010.completion.no_generic_duplicates/test.json
@@ -244,7 +244,7 @@
                      {
                         "label": "Primitive",
                         "kind": 3,
-                        "sortText": "2Primitive",
+                        "sortText": "100&2Primitive",
                         "insertText": "Primitive (${1:Obj : Parent})$0",
                         "insertTextFormat": 2,
                         "additionalTextEdits": [],

--- a/testsuite/ada_lsp/completion.duplicates/test.json
+++ b/testsuite/ada_lsp/completion.duplicates/test.json
@@ -199,7 +199,7 @@
                      {
                         "label": "Do_Something",
                         "kind": 3,
-                        "sortText": "2Do_Something",
+                        "sortText": "100&2Do_Something",
                         "additionalTextEdits": [],
                         "data": {
                            "uri": "$URI{main.adb}",

--- a/testsuite/ada_lsp/completion.invisible.runtime/test.json
+++ b/testsuite/ada_lsp/completion.invisible.runtime/test.json
@@ -212,7 +212,7 @@
                                   "kind": 9,
                                   "detail": "package Ada.Decimal ",
                                   "documentation": "at a-decima.ads (38:1)\n\nThis is the 128-bit version of this package",
-                                  "sortText": "~08Decimal",
+                                  "sortText": "~100&08Decimal",
                                   "filterText": "Decimal",
                                   "insertText": "Decimal",
                                   "additionalTextEdits": [

--- a/testsuite/ada_lsp/completion.invisible/test.json
+++ b/testsuite/ada_lsp/completion.invisible/test.json
@@ -152,14 +152,14 @@
                         "kind": 6,
                         "detail": "Invisible : Integer;",
                         "documentation": "at aaa.ads (2:4)",
-                        "sortText": "~0Invisible"
+                        "sortText": "~100&0Invisible"
                      },
                      {
                         "label": "Invisible_Function (invisible)",
                         "kind": 3,
                         "detail": "function Invisible_Function (X, Y : Integer) return Integer",
                         "documentation": "at aaa.ads (4:4)",
-                        "sortText": "~1Invisible_Function",
+                        "sortText": "~100&1Invisible_Function",
                         "insertText": "Invisible_Function",
                         "additionalTextEdits": [
                         ]
@@ -250,7 +250,7 @@
                         "kind": 6,
                         "detail": "Invisible : Integer;",
                         "documentation": "at aaa.ads (3:4)",
-                        "sortText": "~Invisible"
+                        "sortText": "~100&-1Invisible"
                      }
                   ]
                }
@@ -305,14 +305,14 @@
                         "kind": 6,
                         "detail": "Invisible : Integer;",
                         "documentation": "at aaa.ads (2:4)",
-                        "sortText": "~0Invisible"
+                        "sortText": "~100&0Invisible"
                      },
                      {
                         "label": "Invisible_Function (invisible)",
                         "kind": 3,
                         "detail": "function Invisible_Function (X, Y : Integer) return Integer",
                         "documentation": "at aaa.ads (4:4)",
-                        "sortText": "~1Invisible_Function",
+                        "sortText": "~100&1Invisible_Function",
                         "insertText": "Invisible_Function",
                         "additionalTextEdits": [
                         ]

--- a/testsuite/ada_lsp/completion.invisible3/test.json
+++ b/testsuite/ada_lsp/completion.invisible3/test.json
@@ -148,7 +148,7 @@
                         "kind": 3,
                         "detail": "function ABC1 return Integer",
                         "documentation": "at pkg.ads (3:4)",
-                        "sortText": "~0ABC1",
+                        "sortText": "~100&0ABC1",
                         "insertText": "ABC1",
                         "additionalTextEdits": []
                      },
@@ -157,7 +157,7 @@
                         "kind": 9,
                         "detail": "generic\n      ABC13 : Integer;\npackage ABC14 ",
                         "documentation": "at pkg.ads (19:4)",
-                        "sortText": "~1ABC14",
+                        "sortText": "~100&1ABC14",
                         "insertText": "ABC14",
                         "additionalTextEdits": []
                      },
@@ -166,7 +166,7 @@
                         "kind": 7,
                         "detail": "type ABC4 (ABC5 : Integer) is record\n   ABC6 : Boolean := (for some ABC7 in Boolean => ABC7);\nend record;",
                         "documentation": "at pkg.ads (5:4)",
-                        "sortText": "~2ABC4",
+                        "sortText": "~100&2ABC4",
                         "insertText": "ABC4",
                         "additionalTextEdits": []
                      }

--- a/testsuite/ada_lsp/completion.invisible4/test.json
+++ b/testsuite/ada_lsp/completion.invisible4/test.json
@@ -148,7 +148,7 @@
                         "kind": 9,
                         "detail": "package Pkg_1.Child ",
                         "documentation": "at pkg_1-child.ads (3:1)",
-                        "sortText": "1Child",
+                        "sortText": "100&1Child",
                         "additionalTextEdits": []
                      },
                      {
@@ -156,7 +156,7 @@
                         "kind": 9,
                         "detail": "package Pkg_1.Child2 ",
                         "documentation": "at pkg_1-child2.ads (1:1)",
-                        "sortText": "~2Child2",
+                        "sortText": "~100&2Child2",
                         "insertText": "Child2",
                         "additionalTextEdits": [
                         ]

--- a/testsuite/ada_lsp/completion.invisible5/test.json
+++ b/testsuite/ada_lsp/completion.invisible5/test.json
@@ -148,7 +148,7 @@
                            "kind": 9,
                            "detail": "package Ada ",
                            "documentation": "<ANY>",
-                           "sortText": "1Ada",
+                           "sortText": "100&1Ada",
                            "additionalTextEdits": []
                         }
                      ]

--- a/testsuite/ada_lsp/completion.lazy_computation/test.json
+++ b/testsuite/ada_lsp/completion.lazy_computation/test.json
@@ -156,7 +156,7 @@
                      {
                         "label": "Select_Some",
                         "kind": 3,
-                        "sortText": "2Select_Some",
+                        "sortText": "100&2Select_Some",
                         "additionalTextEdits": [],
                         "data": {
                            "uri": "$URI{test.ads}",
@@ -188,7 +188,7 @@
                "label": "Select_Some",
                "insertTextFormat": 1,
                "kind": 3,
-               "sortText": "1Select_Some",
+               "sortText": "100&1Select_Some",
                "additionalTextEdits": [],
                "data": {
                   "uri": "$URI{test.ads}",
@@ -213,7 +213,7 @@
                   "kind": 3,
                   "detail": "procedure Select_Some is null",
                   "documentation": "at test.ads (3:4)\n\nThis a very useful comment.",
-                  "sortText": "1Select_Some",
+                  "sortText": "100&1Select_Some",
                   "insertTextFormat": 1,
                   "additionalTextEdits": [],
                   "data": {


### PR DESCRIPTION
In order to place items with an higher weight at the
top of the completion window.