### PR TITLE
V624-007: Fix valgrind testsuite

### DIFF
--- a/testsuite/testsuite.py
+++ b/testsuite/testsuite.py
@@ -69,10 +69,7 @@ class ALSTestsuite(Testsuite):
 
         # Absolute paths to programs that test drivers can use
         if self.env.options.valgrind_memcheck:
-            self.env.als = "{} {} {}".format(
-                self.lookup_program("valgrind"),
-                " ".join(VALGRIND_OPTIONS).format(base=self.env.repo_base),
-                self.lookup_program('server', 'ada_language_server'))
+            self.env.als = os.path.join(self.env.repo_base, 'testsuite', 'valgrind_wrapper.sh')
             self.env.wait_factor = 40  # valgrind is slow
         else:
             self.env.als = self.lookup_program('server', 'ada_language_server')

--- a/testsuite/valgrind_wrapper.sh
+++ b/testsuite/valgrind_wrapper.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+
+# This is a wrapper to run the Ada Language Sever with valgrind
+# and all the needed arguments from the testsuite.
+
+dir_path=$(dirname $0)
+valgrind --quiet --tool=memcheck --leak-check=full --suppressions=$dir_path/leaks.supp $dir_path/../.obj/server/ada_language_server $@


### PR DESCRIPTION
Use a bash script wrapper to run the ALS with valgrind and all
its needed arguments. This is needed in order to spawn the process
successfully in the test runner.