### PR TITLE
V701-011: Fix precedence of pretty printer options

### DIFF
--- a/source/ada/lsp-ada_handlers.adb
+++ b/source/ada/lsp-ada_handlers.adb
@@ -230,7 +230,8 @@ package body LSP.Ada_Handlers is
      (Self     : in out LSP.Ada_Contexts.Context;
       Document : LSP.Ada_Documents.Document_Access;
       Span     : LSP.Messages.Span;
-      Options  : LSP.Messages.FormattingOptions)
+      Options  : LSP.Messages.FormattingOptions;
+      Handler  : access Message_Handler)
       return LSP.Messages.Server_Responses.Formatting_Response;
    --  Format the text of the given document in the given range (span).
 
@@ -813,7 +814,8 @@ package body LSP.Ada_Handlers is
      (Self     : in out LSP.Ada_Contexts.Context;
       Document : LSP.Ada_Documents.Document_Access;
       Span     : LSP.Messages.Span;
-      Options  : LSP.Messages.FormattingOptions)
+      Options  : LSP.Messages.FormattingOptions;
+      Handler  : access Message_Handler)
       return LSP.Messages.Server_Responses.Formatting_Response
    is
       Response : LSP.Messages.Server_Responses.Formatting_Response
@@ -849,6 +851,15 @@ package body LSP.Ada_Handlers is
                 data    => <>));
             return Response;
          end;
+      else
+         --  If the formntting succeeded, still display messages in the client
+         --  if any.
+         for Msg of Messages loop
+            Show_Message
+              (Self => Handler,
+               Text => Msg,
+               Mode => LSP.Messages.Info);
+         end loop;
       end if;
 
       return Response;
@@ -5508,7 +5519,8 @@ package body LSP.Ada_Handlers is
              (Self     => Context.all,
               Document => Document,
               Span     => LSP.Messages.Empty_Span,
-              Options  => Request.params.options);
+              Options  => Request.params.options,
+              Handler  => Self);
       begin
          return Response;
       end;
@@ -5907,7 +5919,8 @@ package body LSP.Ada_Handlers is
                 (Self     => Context.all,
                  Document => Document,
                  Span     => Request.params.span,
-                 Options  => Request.params.options));
+                 Options  => Request.params.options,
+                 Handler  => Self));
          Response : Server_Responses.Range_Formatting_Response
            (Is_Error => Result.Is_Error);
       begin

--- a/testsuite/ada_lsp/V701-011.formatting.options_precedence/default.gpr
+++ b/testsuite/ada_lsp/V701-011.formatting.options_precedence/default.gpr
@@ -1,0 +1,9 @@
+project Default is
+
+   for Main use ("main.adb");
+
+   package Pretty_Printer is
+      for Default_Switches ("Ada") use ("--indentation=10");
+   end Pretty_Printer;
+
+end Default;

--- a/testsuite/ada_lsp/V701-011.formatting.options_precedence/main.adb
+++ b/testsuite/ada_lsp/V701-011.formatting.options_precedence/main.adb
@@ -1,0 +1,13 @@
+with Ada.Unchecked_Deallocation;
+
+procedure Main is
+
+    type My_Type is new Integer;
+    type My_Type_Access is access all My_Type;
+
+    procedure Free is new Ada.Unchecked_Deallocation (My_Type, My_Type_Access);
+
+    A : My_Type_Access := new My_Type'(3);
+begin
+    Free (A);
+end Main;

--- a/testsuite/ada_lsp/V701-011.formatting.options_precedence/test.json
+++ b/testsuite/ada_lsp/V701-011.formatting.options_precedence/test.json
@@ -1,0 +1,529 @@
+[
+   {
+      "comment": [
+         "This test checks that pretty printer options set in the .gpr file ",
+         "take precedence over LSP formatting settings set by the client."
+      ]
+   },
+   {
+      "start": {
+         "cmd": [
+            "${ALS}"
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+               "processId": 153434,
+               "rootUri": "$URI{.}",
+               "capabilities": {
+                  "workspace": {
+                     "applyEdit": true,
+                     "workspaceEdit": {
+                        "documentChanges": true,
+                        "resourceOperations": [
+                           "rename"
+                        ]
+                     }
+                  },
+                  "textDocument": {
+                     "synchronization": {},
+                     "completion": {
+                        "dynamicRegistration": true,
+                        "completionItem": {
+                           "snippetSupport": false,
+                           "documentationFormat": [
+                              "plaintext",
+                              "markdown"
+                           ],
+                           "resolveSupport": {
+                              "properties": [
+                                 "detail",
+                                 "documentation"
+                              ]
+                           }
+                        }
+                     },
+                     "hover": {},
+                     "signatureHelp": {},
+                     "declaration": {},
+                     "definition": {},
+                     "typeDefinition": {},
+                     "implementation": {},
+                     "documentSymbol": {
+                        "hierarchicalDocumentSymbolSupport": true
+                     },
+                     "formatting": {
+                        "dynamicRegistration": false
+                     },
+                     "rangeFormatting": {
+                        "dynamicRegistration": false
+                     },
+                     "onTypeFormatting": {
+                        "dynamicRegistration": false
+                     },
+                     "foldingRange": {
+                        "lineFoldingOnly": true
+                     }
+                  }
+               }
+            }
+         },
+         "wait": [
+            {
+               "id": 1,
+               "result": {
+                  "capabilities": {
+                     "textDocumentSync": 2,
+                     "completionProvider": {
+                        "triggerCharacters": [
+                           ".",
+                           ",",
+                           "'",
+                           "("
+                        ],
+                        "resolveProvider": true
+                     },
+                     "hoverProvider": true,
+                     "signatureHelpProvider": {
+                        "triggerCharacters": [
+                           ",",
+                           "("
+                        ],
+                        "retriggerCharacters": [
+                           "\b"
+                        ]
+                     },
+                     "declarationProvider": true,
+                     "definitionProvider": true,
+                     "typeDefinitionProvider": true,
+                     "implementationProvider": true,
+                     "referencesProvider": true,
+                     "documentHighlightProvider": true,
+                     "documentSymbolProvider": true,
+                     "codeActionProvider": {},
+                     "documentFormattingProvider": true,
+                     "documentRangeFormattingProvider": true,
+                     "renameProvider": {},
+                     "foldingRangeProvider": true,
+                     "executeCommandProvider": {
+                        "commands": [
+                           "<HAS>",
+                           "als-named-parameters"]
+                     },
+                     "workspaceSymbolProvider": true,
+                     "callHierarchyProvider": {},
+                     "alsShowDepsProvider": true,
+                     "alsReferenceKinds": [
+                        "<HAS>",
+                        "reference"],
+                     "alsCheckSyntaxProvider": true
+                  }
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "initialized"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "workspace/didChangeConfiguration",
+            "params": {
+               "settings": {
+                  "ada": {
+                     "scenarioVariables": {},
+                     "defaultCharset": "ISO-8859-1",
+                     "enableDiagnostics": false,
+                     "followSymlinks": false,
+                     "documentationStyle": "gnat",
+                     "foldComments": false
+                  }
+               }
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "result": null
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{main.adb}",
+                  "languageId": "Ada",
+                  "version": 0,
+                  "text": "with Ada.Unchecked_Deallocation;\n\nprocedure Main is\n\n    type My_Type is new Integer;\n    type My_Type_Access is access all My_Type;\n\n    procedure Free is new Ada.Unchecked_Deallocation (My_Type, My_Type_Access);\n\n    A : My_Type_Access := new My_Type'(3);\nbegin\n    Free (A);\nend Main;\n"
+               }
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": 4,
+            "method": "textDocument/formatting",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{main.adb}"
+               },
+               "options": {
+                  "tabSize": 3,
+                  "insertSpaces": true,
+                  "trimTrailingWhitespace": true,
+                  "insertFinalNewline": false,
+                  "trimFinalNewlines": true
+               }
+            }
+         },
+         "wait": [
+            {
+               "id": 4,
+               "result": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 4,
+                           "character": 0
+                        },
+                        "end": {
+                           "line": 6,
+                           "character": 0
+                        }
+                     },
+                     "newText": "          type My_Type is new Integer;\n          type My_Type_Access is access all My_Type;\n"
+                  },
+                  {
+                     "range": {
+                        "start": {
+                           "line": 7,
+                           "character": 0
+                        },
+                        "end": {
+                           "line": 8,
+                           "character": 0
+                        }
+                     },
+                     "newText": "          procedure Free is new Ada.Unchecked_Deallocation\n                   (My_Type, My_Type_Access);\n"
+                  },
+                  {
+                     "range": {
+                        "start": {
+                           "line": 9,
+                           "character": 0
+                        },
+                        "end": {
+                           "line": 10,
+                           "character": 0
+                        }
+                     },
+                     "newText": "          A : My_Type_Access := new My_Type'(3);\n"
+                  },
+                  {
+                     "range": {
+                        "start": {
+                           "line": 11,
+                           "character": 0
+                        },
+                        "end": {
+                           "line": 12,
+                           "character": 0
+                        }
+                     },
+                     "newText": "          Free (A);\n"
+                  }
+               ]
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{main.adb}",
+                  "version": 1
+               },
+               "contentChanges": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 11,
+                           "character": 0
+                        },
+                        "end": {
+                           "line": 12,
+                           "character": 0
+                        }
+                     },
+                     "text": ""
+                  }
+               ]
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{main.adb}",
+                  "version": 2
+               },
+               "contentChanges": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 11,
+                           "character": 0
+                        },
+                        "end": {
+                           "line": 11,
+                           "character": 0
+                        }
+                     },
+                     "text": "          Free (A);\n"
+                  }
+               ]
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{main.adb}",
+                  "version": 3
+               },
+               "contentChanges": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 9,
+                           "character": 0
+                        },
+                        "end": {
+                           "line": 10,
+                           "character": 0
+                        }
+                     },
+                     "text": ""
+                  }
+               ]
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{main.adb}",
+                  "version": 4
+               },
+               "contentChanges": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 9,
+                           "character": 0
+                        },
+                        "end": {
+                           "line": 9,
+                           "character": 0
+                        }
+                     },
+                     "text": "          A : My_Type_Access := new My_Type'(3);\n"
+                  }
+               ]
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{main.adb}",
+                  "version": 5
+               },
+               "contentChanges": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 7,
+                           "character": 0
+                        },
+                        "end": {
+                           "line": 8,
+                           "character": 0
+                        }
+                     },
+                     "text": ""
+                  }
+               ]
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{main.adb}",
+                  "version": 6
+               },
+               "contentChanges": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 7,
+                           "character": 0
+                        },
+                        "end": {
+                           "line": 7,
+                           "character": 0
+                        }
+                     },
+                     "text": "          procedure Free is new Ada.Unchecked_Deallocation\n                   (My_Type, My_Type_Access);\n"
+                  }
+               ]
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{main.adb}",
+                  "version": 7
+               },
+               "contentChanges": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 4,
+                           "character": 0
+                        },
+                        "end": {
+                           "line": 6,
+                           "character": 0
+                        }
+                     },
+                     "text": ""
+                  }
+               ]
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{main.adb}",
+                  "version": 8
+               },
+               "contentChanges": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 4,
+                           "character": 0
+                        },
+                        "end": {
+                           "line": 4,
+                           "character": 0
+                        }
+                     },
+                     "text": "          type My_Type is new Integer;\n          type My_Type_Access is access all My_Type;\n"
+                  }
+               ]
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": 7,
+            "method": "shutdown"
+         },
+         "wait": [
+            {
+               "id": 7,
+               "result": null
+            }
+         ]
+      }
+   },
+   {
+      "stop": {
+         "exit_code": 0
+      }
+   }
+]

--- a/testsuite/ada_lsp/V701-011.formatting.options_precedence/test.yaml
+++ b/testsuite/ada_lsp/V701-011.formatting.options_precedence/test.yaml
@@ -1,0 +1,1 @@
+title: 'V701-011.formatting.options_precedence'


### PR DESCRIPTION
Options explicitly set in the project file should have precedence
over LSP options set by the client.