### PR TITLE
V628-012: Improve highlighter robustness

### DIFF
--- a/source/ada/lsp-ada_documents.adb
+++ b/source/ada/lsp-ada_documents.adb
@@ -1730,7 +1730,7 @@ package body LSP.Ada_Documents is
       Unit : constant Libadalang.Analysis.Analysis_Unit :=
         Self.Unit (Context);
    begin
-      return Highlighter.Get_Tokens (Unit, Span);
+      return Highlighter.Get_Tokens (Unit, Context.Trace, Span);
    end Get_Tokens;
 
    -----------------

--- a/source/ada/lsp-ada_highlighters.ads
+++ b/source/ada/lsp-ada_highlighters.ads
@@ -18,6 +18,8 @@
 with Ada.Containers.Hashed_Maps;
 with Ada.Strings.Wide_Wide_Unbounded;
 
+with GNATCOLL.Traces;
+
 with Libadalang.Analysis;
 
 with LSP.Messages;
@@ -33,9 +35,10 @@ package LSP.Ada_Highlighters is
       Legend : out LSP.Messages.SemanticTokensLegend);
 
    function Get_Tokens
-     (Self : Ada_Highlighter'Class;
-      Unit : Libadalang.Analysis.Analysis_Unit;
-      Span : LSP.Messages.Span)
+     (Self  : Ada_Highlighter'Class;
+      Unit  : Libadalang.Analysis.Analysis_Unit;
+      Trace : GNATCOLL.Traces.Trace_Handle;
+      Span  : LSP.Messages.Span)
       return LSP.Messages.uinteger_Vector;
    --  If Span isn't empty then return unit tokens in given Span, otherwise
    --  return all tokens in the Unit.

--- a/testsuite/ada_lsp/V628-012.highlighting.defining_names/default.gpr
+++ b/testsuite/ada_lsp/V628-012.highlighting.defining_names/default.gpr
@@ -1,0 +1,5 @@
+project Default is
+
+   for Main use ("foo.adb");
+
+end Default;

--- a/testsuite/ada_lsp/V628-012.highlighting.defining_names/foo.adb
+++ b/testsuite/ada_lsp/V628-012.highlighting.defining_names/foo.adb
@@ -1,0 +1,8 @@
+procedure Foo is
+
+   type My_Type is new Integer range 1 .. 10;
+
+   X, Y : My_Type := 1;  --  Decl with multiple defining names
+begin
+   X := Y + My_Type (9);
+end Foo;

--- a/testsuite/ada_lsp/V628-012.highlighting.defining_names/test.json
+++ b/testsuite/ada_lsp/V628-012.highlighting.defining_names/test.json
@@ -1,0 +1,255 @@
+[
+   {
+      "comment": [
+         "Basic test for semanticTokens"
+      ]
+   },
+   {
+      "start": {
+         "cmd": [
+            "${ALS}"
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "params": {
+               "processId": 31570,
+               "capabilities": {
+                  "textDocument": {
+                     "completion": {
+                        "completionItem": {
+                           "documentationFormat": [
+                              "plaintext",
+                              "markdown"
+                           ],
+                           "snippetSupport": true
+                        },
+                        "dynamicRegistration": true
+                     },
+                     "semanticTokens": {
+                        "refreshSupport":true,
+                        "dynamicRegistration":true,
+                        "tokenTypes": ["namespace","type","class","enum","interface","struct","typeParameter","parameter","variable","property","enumMember","event","function","method","macro","keyword","modifier","comment","string","number","regexp","operator"],
+                        "tokenModifiers": ["declaration","definition","readonly","static","deprecated","abstract","async","modification","documentation","defaultLibrary"],
+                        "formats":["relative"],
+                        "requests": {
+                           "range": true,
+                            "full": true
+                        },
+                        "overlappingTokenSupport" : true,
+                        "multilineTokenSupport" : true
+                     },
+                     "definition": {},
+                     "hover": {},
+                     "formatting": {
+                        "dynamicRegistration": true
+                     },
+                     "implementation": {},
+                     "codeLens": {},
+                     "typeDefinition": {},
+                     "selectionRange": {},
+                     "documentHighlight": {},
+                     "documentSymbol": {
+                        "hierarchicalDocumentSymbolSupport": true
+                     },
+                     "synchronization": {},
+                     "references": {},
+                     "rangeFormatting": {},
+                     "onTypeFormatting": {},
+                     "declaration": {},
+                     "foldingRange": {
+                        "lineFoldingOnly": true
+                     },
+                     "colorProvider": {}
+                  },
+                  "workspace": {
+                     "applyEdit": true,
+                     "executeCommand": {},
+                     "didChangeWatchedFiles": {},
+                     "workspaceEdit": {},
+                     "didChangeConfiguration": {},
+                     "semanticTokens": {
+                        "refreshSupport": true
+                     }
+                  }
+               },
+               "rootUri": "$URI{.}"
+            },
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize"
+         },
+          "wait": [
+              {
+                  "jsonrpc": "2.0",
+                  "id": 1,
+                  "result": {
+                      "capabilities": {
+                          "textDocumentSync": 2,
+                          "completionProvider": {
+                              "triggerCharacters": [
+                                  ".",
+                                  ",",
+                                  "'",
+                                  "("
+                              ],
+                              "resolveProvider": true
+                          },
+                          "semanticTokensProvider": {
+                            "legend": {
+                              "tokenTypes": ["namespace","type","class","enum","interface","struct","typeParameter","parameter","variable","property","enumMember","function","keyword","modifier","comment","string","number","operator"],
+                              "tokenModifiers": ["declaration","definition","readonly","static","deprecated","abstract","modification","documentation","defaultLibrary"]
+                            },
+                            "range": true,
+                            "full": {}
+                          },
+                          "hoverProvider": true,
+                          "declarationProvider": true,
+                          "definitionProvider": true,
+                          "typeDefinitionProvider": true,
+                          "implementationProvider": true,
+                          "referencesProvider": true,
+                          "codeActionProvider": {
+                          },
+                          "renameProvider": {
+                          },
+                          "foldingRangeProvider": true,
+                          "executeCommandProvider": {},
+                          "alsReferenceKinds": [
+                              "reference",
+                              "access",
+                              "write",
+                              "call",
+                              "dispatching call",
+                              "parent",
+                              "child",
+                              "overriding"
+                          ]
+                      }
+                  }
+              }
+          ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0", 
+            "method": "initialized"
+         }, 
+         "wait": []
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "params": {
+               "settings": {
+                  "ada": {
+                     "projectFile": "$URI{default.gpr}", 
+                     "scenarioVariables": {},
+                     "defaultCharset": "ISO-8859-1"
+                  }
+               }
+            }, 
+            "jsonrpc": "2.0", 
+            "method": "workspace/didChangeConfiguration"
+         }, 
+         "wait": []
+      }
+   }, 
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}",
+                  "languageId": "Ada",
+                  "version": 0,
+                  "text": "procedure Foo is\n\n   type My_Type is new Integer range 1 .. 10;\n\n   X, Y : My_Type := 1;  --  Decl with multiple defining names\nbegin\n   X := Y + My_Type (9);\nend Foo;\n"
+               }
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "textDocument/semanticTokens/range",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}"
+               },
+               "range": {
+                   "start": {
+                       "line": 0,
+                       "character": 0
+                   }, 
+                   "end": {
+                       "line": 4,
+                       "character": 0
+                   }
+                }
+            }
+         },
+         "wait": [
+                   {
+                    "jsonrpc": "2.0",
+                    "id": 2,
+                    "result": {
+                       "data": [0,10,3,11,1,2,8,7,1,9,0,15,7,1,264,2,3,1,8,1,0,3,1,8,1,0,4,7,1,8]}
+                 }
+         ]
+
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "textDocument/semanticTokens/full",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}"
+               }
+            }
+         },
+         "wait": [
+                    {  
+                       "jsonrpc": "2.0",
+                       "id": 3,
+                       "result": {
+                         "data": [0,10,3,11,1,2,8,7,1,9,0,15,7,1,264,2,3,1,8,1,0,3,1,8,1,0,4,7,1,8,2,3,1,8,64,0,5,1,8,0,0,4,7,1,8,1,4,3,11,0]
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didClose",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}"
+               }
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "stop": {
+         "exit_code": 0
+      }
+   }
+]

--- a/testsuite/ada_lsp/V628-012.highlighting.defining_names/test.yaml
+++ b/testsuite/ada_lsp/V628-012.highlighting.defining_names/test.yaml
@@ -1,0 +1,1 @@
+title: 'V628-012.highlighting.defining_names'


### PR DESCRIPTION
Fix "Basic decl having multiple defining names" property errors.
Add generic exception handler and log the error.

Add simple test.