### PR TITLE
UB30-006 Fix exception raised when range formatting the whole document

### DIFF
--- a/scripts/traces_to_test.py
+++ b/scripts/traces_to_test.py
@@ -25,6 +25,9 @@ else:
 
 test = traces_to_test(inout_file, root)
 
+print("create test directory {}".format(root))
+os.makedirs(root, exist_ok=True)
+
 test_yaml_file = os.path.join(root, 'test.yaml')
 print("generating {}".format(test_yaml_file))
 with open(test_yaml_file, "w") as f:

--- a/source/ada/lsp-ada_documents.adb
+++ b/source/ada/lsp-ada_documents.adb
@@ -2456,18 +2456,26 @@ package body LSP.Ada_Documents is
       Start_Line      : constant LSP.Types.Line_Number :=
         LSP.Types.Line_Number (Segment.Start_Line) - 1;
       Start_Line_Text : constant VSS.Strings.Virtual_String :=
-        Self.Text.Slice
-          (Self.Line_To_Marker (Start_Line),
-           Self.Line_To_Marker (Start_Line + 1));
+        (if Self.Line_To_Marker.Last_Index = Start_Line then
+           Self.Text.Slice
+             (Self.Line_To_Marker (Start_Line), Self.Text.After_Last_Character)
+         else
+           Self.Text.Slice
+             (Self.Line_To_Marker (Start_Line),
+              Self.Line_To_Marker (Start_Line + 1)));
       Start_Iterator  : VSS.Strings.Character_Iterators.Character_Iterator :=
         Start_Line_Text.At_First_Character;
 
       End_Line        : constant LSP.Types.Line_Number :=
         LSP.Types.Line_Number (Segment.End_Line) - 1;
       End_Line_Text   : constant VSS.Strings.Virtual_String :=
-        Self.Text.Slice
-          (Self.Line_To_Marker (End_Line),
-           Self.Line_To_Marker (End_Line + 1));
+        (if Self.Line_To_Marker.Last_Index = End_Line then
+           Self.Text.Slice
+             (Self.Line_To_Marker (End_Line), Self.Text.After_Last_Character)
+         else
+           Self.Text.Slice
+             (Self.Line_To_Marker (End_Line),
+              Self.Line_To_Marker (End_Line + 1)));
       End_Iterator   : VSS.Strings.Character_Iterators.Character_Iterator :=
         End_Line_Text.At_First_Character;
       Success        : Boolean with Unreferenced;

--- a/testsuite/ada_lsp/range_formatting/UB30-006_range_format_whole_document/default.gpr
+++ b/testsuite/ada_lsp/range_formatting/UB30-006_range_format_whole_document/default.gpr
@@ -1,0 +1,3 @@
+project Default is
+   for Main use ("main.adb");
+end Default;

--- a/testsuite/ada_lsp/range_formatting/UB30-006_range_format_whole_document/main.adb
+++ b/testsuite/ada_lsp/range_formatting/UB30-006_range_format_whole_document/main.adb
@@ -1,0 +1,10 @@
+procedure Main is
+
+begin
+   declare
+   A : Integer;
+      begin
+      null;
+      end;
+
+end Main;

--- a/testsuite/ada_lsp/range_formatting/UB30-006_range_format_whole_document/test.json
+++ b/testsuite/ada_lsp/range_formatting/UB30-006_range_format_whole_document/test.json
@@ -1,0 +1,181 @@
+[
+    {
+        "comment": [
+            "test automatically generated"
+        ]
+    },
+    {
+        "start": {
+            "cmd": [
+                "${ALS}"
+            ]
+        }
+    },
+    {
+        "send": {
+            "request": {
+                "jsonrpc": "2.0",
+                "id": 0,
+                "method": "initialize",
+                "params": {
+                    "processId": 84339,
+                    "locale": "en-gb",
+                    "rootPath": "$URI{.}",
+                    "rootUri": "$URI{.}",
+                    "capabilities": {
+                        "workspace": {
+                            "applyEdit": true,
+                            "workspaceEdit": {
+                                "documentChanges": true,
+                                "resourceOperations": [
+                                    "create",
+                                    "rename",
+                                    "delete"
+                                ]
+                            },
+                            "executeCommand": {
+                                "dynamicRegistration": true
+                            }
+                        },
+                        "textDocument": {
+                            "codeAction": {
+                                "dynamicRegistration": true,
+                                "codeActionLiteralSupport": {
+                                    "codeActionKind": {
+                                        "valueSet": [
+                                            "<HAS>",
+                                            "refactor",
+                                            "refactor.extract",
+                                            "refactor.inline",
+                                            "refactor.rewrite"
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "wait": [
+                {
+                    "jsonrpc": "2.0",
+                    "id": 0
+                }
+            ]
+        }
+    },
+    {
+        "send": {
+            "request": {
+                "jsonrpc": "2.0",
+                "method": "initialized",
+                "params": {}
+            },
+            "wait": []
+        }
+    },
+    {
+        "send": {
+            "request": {
+                "jsonrpc": "2.0",
+                "method": "workspace/didChangeConfiguration",
+                "params": {
+                    "settings": {
+                        "ada": {
+                            "trace": {
+                                "server": "verbose"
+                            },
+                            "projectFile": "default.gpr",
+                            "scenarioVariables": {},
+                            "defaultCharset": "iso-8859-1",
+                            "displayMethodAncestryOnNavigation": "usage_and_abstract_only",
+                            "enableDiagnostics": true,
+                            "useCompletionSnippets": true,
+                            "renameInComments": true
+                        }
+                    }
+                }
+            },
+            "wait": [
+                {
+                    "jsonrpc": "2.0",
+                    "id": 2,
+                    "method": "window/workDoneProgress/create",
+                    "params": {
+                        "token": "<ANY>"
+                    }
+                }
+            ]
+        }
+    },
+    {
+        "send": {
+            "request": {
+                "jsonrpc": "2.0",
+                "method": "textDocument/didOpen",
+                "params": {
+                    "textDocument": {
+                        "uri": "$URI{main.adb}",
+                        "languageId": "ada",
+                        "version": 1,
+                        "text": "procedure Main is\n\nbegin\n   declare\n   A : Integer;\n      begin\n      null;\n      end;\n\nend Main;"
+                    }
+                }
+            },
+            "wait": []
+        }
+    },
+    {
+        "send": {
+            "request": {
+                "jsonrpc": "2.0",
+                "id": 12,
+                "method": "textDocument/rangeFormatting",
+                "params": {
+                    "textDocument": {
+                        "uri": "$URI{main.adb}"
+                    },
+                    "range": {
+                        "start": {
+                            "line": 0,
+                            "character": 12
+                        },
+                        "end": {
+                            "line": 9,
+                            "character": 6
+                        }
+                    },
+                    "options": {
+                        "tabSize": 3,
+                        "insertSpaces": true
+                    }
+                }
+            },
+            "wait": [
+                {
+                    "id": 12,
+                    "result": [
+                        {
+                            "range": {
+                                "start": {
+                                    "line": 0,
+                                    "character": 0
+                                },
+                                "end": {
+                                    "line": 9,
+                                    "character": 9
+                                }
+                            },
+                            "newText": "procedure Main is\n\nbegin\n   declare\n      A : Integer;\n   begin\n      null;\n   end;\n\nend Main;"
+                        }
+                    ]
+                }
+            ]
+        }
+    },
+    {
+        "stop": {
+            "exit_code": 0
+        }
+    }
+]

--- a/testsuite/ada_lsp/range_formatting/UB30-006_range_format_whole_document/test.yaml
+++ b/testsuite/ada_lsp/range_formatting/UB30-006_range_format_whole_document/test.yaml
@@ -1,0 +1,1 @@
+title: 'UB30-006_range_format_whole_document'


### PR DESCRIPTION
If the user selects from the procedure name `Main` to the procedure end label `Main`, the whole file needs to be formatted. This PR fixes an exception that was being raised when converting from `Source_Location_Range` to `Span`.
```ada
procedure Main is

begin
   declare
   A : Integer;
      begin
      null;
      end;

end Main;
```
