### PR TITLE
Ensure that a test has unique request ids.

### DIFF
--- a/source/tester/tester-tests.ads
+++ b/source/tester/tester-tests.ads
@@ -16,9 +16,11 @@
 ------------------------------------------------------------------------------
 
 with Ada.Calendar;
+with Ada.Containers.Hashed_Sets;
 with Ada.Strings.Unbounded;
 
 private with VSS.Strings;
+private with VSS.Strings.Hash;
 
 with GNATCOLL.JSON;
 
@@ -47,6 +49,12 @@ private
       entry Cancel;
    end Watch_Dog_Task;
 
+   package String_Sets is new Ada.Containers.Hashed_Sets
+     (VSS.Strings.Virtual_String,
+      VSS.Strings.Hash,
+      VSS.Strings."=",
+      VSS.Strings."=");
+
    type Test is new LSP.Raw_Clients.Raw_Client with record
       Index        : Positive := 1;
       Sort_Reply   : GNATCOLL.JSON.JSON_Value;
@@ -58,9 +66,12 @@ private
       --  Task to restrict a command execution time
       Started      : Ada.Calendar.Time;
       --  Command execution start/reset time
+      Known_Ids    : String_Sets.Set;
+      --  Set of processed request ids
 
       Full_Server_Output : GNATCOLL.JSON.JSON_Array;
       --  Complete output received from the server
+
    end record;
 
    overriding procedure On_Error

--- a/testsuite/ada_lsp/SC28-001.named.parameters.0/SC28-001.named.parameters.0.json
+++ b/testsuite/ada_lsp/SC28-001.named.parameters.0/SC28-001.named.parameters.0.json
@@ -192,7 +192,7 @@
         "send": {
             "request": {
                 "jsonrpc": "2.0",
-                "id": "ada-1",
+                "id": "ada-2",
                 "method": "textDocument/codeAction",
                 "params": {
                     "textDocument": {
@@ -216,7 +216,7 @@
             "wait": [
                 {
                     "jsonrpc": "2.0",
-                    "id": "ada-1",
+                    "id": "ada-2",
                     "result": [
                         {
                             "title": "Name parameters in the call",

--- a/testsuite/ada_lsp/completion.aggregates.derived_private/test.json
+++ b/testsuite/ada_lsp/completion.aggregates.derived_private/test.json
@@ -225,7 +225,7 @@
       "send": {
          "request": {
             "jsonrpc": "2.0",
-            "id": 6,
+            "id": 7,
             "method": "shutdown"
          },
          "wait": []


### PR DESCRIPTION
This prevents test failures like this:
```
task server.input_task_0000000006F6B0B0 terminated by unhandled exception
raised CONSTRAINT_ERROR : LSP.Servers.Request_Maps.Delete: attempt to delete key not in map
[/home/runner/work/ada_language_server/ada_language_server/.obj/server/ada_language_server]
0x14420fd lsp__servers__request_maps__delete at ???
0x145d8c4 lsp__servers__input_task_typeTB at ???

```