### PR TITLE
V801-024 Add exception handlers and logs to the refactoring tools

### DIFF
--- a/source/ada/lsp-ada_handlers-refactor_change_parameter_mode.adb
+++ b/source/ada/lsp-ada_handlers-refactor_change_parameter_mode.adb
@@ -1,7 +1,7 @@
 ------------------------------------------------------------------------------
 --                         Language Server Protocol                         --
 --                                                                          --
---                        Copyright (C) 2021, AdaCore                       --
+--                     Copyright (C) 2021-2022, AdaCore                     --
 --                                                                          --
 -- This is free software;  you can redistribute it  and/or modify it  under --
 -- terms of the  GNU General Public License as published  by the Free Soft- --
@@ -15,8 +15,6 @@
 -- of the license.                                                          --
 ------------------------------------------------------------------------------
 
-with Ada.Exceptions;
-
 with Ada.Strings.UTF_Encoding;
 
 with Libadalang.Analysis; use Libadalang.Analysis;
@@ -24,6 +22,7 @@ with Libadalang.Common; use Libadalang.Common;
 
 with Laltools.Common; use Laltools.Common;
 
+with LSP.Common;
 with LSP.Messages;
 with LSP.Messages.Client_Requests;
 with LSP.Lal_Utils;
@@ -248,22 +247,28 @@ package body LSP.Ada_Handlers.Refactor_Change_Parameter_Mode is
         Client_Message_Receiver'Class;
       Error : in out LSP.Errors.Optional_ResponseError)
    is
+      use Laltools.Refactor;
+      use LSP.Messages;
+      use LSP.Types;
+      use VSS.Strings.Conversions;
+
       Message_Handler : LSP.Ada_Handlers.Message_Handler renames
         LSP.Ada_Handlers.Message_Handler (Handler.all);
-
       Context         : LSP.Ada_Contexts.Context renames
         Message_Handler.Contexts.Get (Self.Context).all;
 
       Document : constant LSP.Ada_Documents.Document_Access :=
         Message_Handler.Get_Open_Document (Self.Where.textDocument.uri);
-      Apply    : LSP.Messages.Client_Requests.Workspace_Apply_Edit_Request;
 
-      Workspace_Edits : LSP.Messages.WorkspaceEdit renames Apply.params.edit;
+      Apply           : Client_Requests.Workspace_Apply_Edit_Request;
+      Workspace_Edits : WorkspaceEdit renames Apply.params.edit;
+      Label           : Optional_Virtual_String renames Apply.params.label;
 
       Node : constant Ada_Node :=
         Document.Get_Node_At (Context, Self.Where.position);
 
-      Target_Subp               : Defining_Name := No_Defining_Name;
+      Target_Subp               : constant Defining_Name :=
+        Resolve_Name_Precisely (Get_Node_As_Name (Node));
       Target_Parameters_Indices : constant Parameter_Indices_Range_Type :=
         (First => Positive (Self.First_Param_Index),
          Last  => Positive (Self.Last_Param_Index));
@@ -298,12 +303,6 @@ package body LSP.Ada_Handlers.Refactor_Change_Parameter_Mode is
       end Value;
 
    begin
-      Apply.params.label :=
-        (Is_Set => True,
-         Value  =>
-           VSS.Strings.Conversions.To_Virtual_String (Command'External_Tag));
-      Target_Subp := Resolve_Name_Precisely (Get_Node_As_Name (Node));
-
       if Target_Subp.Is_Null then
          Error :=
            (Is_Set => True,
@@ -323,22 +322,38 @@ package body LSP.Ada_Handlers.Refactor_Change_Parameter_Mode is
 
       Edits := Changer.Refactor (Analysis_Units'Access);
 
-      Workspace_Edits := LSP.Lal_Utils.To_Workspace_Edit
-        (Edits,
-         Message_Handler.Resource_Operations,
-         Message_Handler.Versioned_Documents,
-         Message_Handler'Access);
+      if Edits = No_Refactoring_Edits then
+         Error :=
+           (Is_Set => True,
+            Value  =>
+              (code    => LSP.Errors.UnknownErrorCode,
+               message => VSS.Strings.Conversions.To_Virtual_String
+                 ("Failed to execute the Change Parameter Mode refactoring."),
+               data    => <>));
 
-      Client.On_Workspace_Apply_Edit_Request (Apply);
+      else
+         Workspace_Edits :=
+           LSP.Lal_Utils.To_Workspace_Edit
+             (Edits               => Edits,
+              Resource_Operations => Message_Handler.Resource_Operations,
+              Versioned_Documents => Message_Handler.Versioned_Documents,
+              Document_Provider   => Message_Handler'Access);
+         Label :=
+           (Is_Set => True,
+            Value  => To_Virtual_String (Command'External_Tag));
+
+         Client.On_Workspace_Apply_Edit_Request (Apply);
+      end if;
 
    exception
       when E : others =>
+         LSP.Common.Log (Message_Handler.Trace, E);
          Error :=
            (Is_Set => True,
             Value  =>
               (code => LSP.Errors.UnknownErrorCode,
                message => VSS.Strings.Conversions.To_Virtual_String
-                 (Ada.Exceptions.Exception_Information (E)),
+                 ("Failed to execute the Change Parameter Mode refactoring."),
                data => <>));
    end Execute;
 

--- a/source/ada/lsp-ada_handlers-refactor_change_parameters_default_value.adb
+++ b/source/ada/lsp-ada_handlers-refactor_change_parameters_default_value.adb
@@ -21,15 +21,15 @@
 -- <http://www.gnu.org/licenses/>.                                          --
 ------------------------------------------------------------------------------
 
-with Ada.Exceptions;
 with Ada.Strings.UTF_Encoding;
 
 with Langkit_Support.Slocs; use Langkit_Support.Slocs;
 
-with  Libadalang.Analysis; use  Libadalang.Analysis;
+with Libadalang.Analysis; use  Libadalang.Analysis;
 
 with Laltools.Refactor.Subprogram_Signature.Change_Parameters_Default_Value;
 
+with LSP.Common;
 with LSP.Messages.Client_Requests;
 with LSP.Lal_Utils;
 
@@ -138,8 +138,11 @@ package body LSP.Ada_Handlers.Refactor_Change_Parameters_Default_Value is
         Client_Message_Receiver'Class;
       Error   : in out LSP.Errors.Optional_ResponseError)
    is
+      use Laltools.Refactor;
       use Laltools.Refactor.Subprogram_Signature.
             Change_Parameters_Default_Value;
+      use LSP.Messages;
+      use LSP.Types;
       use VSS.Strings.Conversions;
 
       Message_Handler : LSP.Ada_Handlers.Message_Handler renames
@@ -147,17 +150,17 @@ package body LSP.Ada_Handlers.Refactor_Change_Parameters_Default_Value is
       Context         : LSP.Ada_Contexts.Context renames
         Message_Handler.Contexts.Get (Self.Context).all;
 
-      Apply : LSP.Messages.Client_Requests.Workspace_Apply_Edit_Request;
-
-      Workspace_Edits : LSP.Messages.WorkspaceEdit renames Apply.params.edit;
+      Apply           : Client_Requests.Workspace_Apply_Edit_Request;
+      Workspace_Edits : WorkspaceEdit renames Apply.params.edit;
+      Label           : Optional_Virtual_String renames Apply.params.label;
 
       Unit : constant Analysis_Unit :=
         Context.LAL_Context.Get_From_File
           (Context.URI_To_File (Self.Where.uri));
 
       Parameters_SLOC_Range : constant Source_Location_Range :=
-        (Line_Number (Self.Where.span.first.line) + 1,
-         Line_Number (Self.Where.span.last.line) + 1,
+        (Langkit_Support.Slocs.Line_Number (Self.Where.span.first.line) + 1,
+         Langkit_Support.Slocs.Line_Number (Self.Where.span.last.line) + 1,
          Column_Number (Self.Where.span.first.character) + 1,
          Column_Number (Self.Where.span.last.character) + 1);
 
@@ -169,31 +172,48 @@ package body LSP.Ada_Handlers.Refactor_Change_Parameters_Default_Value is
            New_Parameters_Default_Value     =>
              To_Unbounded_UTF_8_String (Self.New_Parameters_Default_Value));
 
-      Edits : Laltools.Refactor.Refactoring_Edits;
-
       function Analysis_Units return Analysis_Unit_Array is
         (Context.Analysis_Units);
       --  Provides the Context Analysis_Unit_Array to the Pull_Upper
 
+      Edits : constant Laltools.Refactor.Refactoring_Edits :=
+        Changer.Refactor (Analysis_Units'Access);
+
    begin
-      Edits := Changer.Refactor (Analysis_Units'Access);
+      if Edits = No_Refactoring_Edits then
+         Error :=
+           (Is_Set => True,
+            Value  =>
+              (code    => LSP.Errors.UnknownErrorCode,
+               message => VSS.Strings.Conversions.To_Virtual_String
+                 ("Failed to execute the Change Parameter Default Value "
+                  & "refactoring."),
+               data    => <>));
 
-      Workspace_Edits := LSP.Lal_Utils.To_Workspace_Edit
-        (Edits               => Edits,
-         Resource_Operations => Message_Handler.Resource_Operations,
-         Versioned_Documents => Message_Handler.Versioned_Documents,
-         Document_Provider   => Message_Handler'Access);
+      else
+         Workspace_Edits :=
+           LSP.Lal_Utils.To_Workspace_Edit
+             (Edits               => Edits,
+              Resource_Operations => Message_Handler.Resource_Operations,
+              Versioned_Documents => Message_Handler.Versioned_Documents,
+              Document_Provider   => Message_Handler'Access);
+         Label :=
+           (Is_Set => True,
+            Value  => To_Virtual_String (Command'External_Tag));
 
-      Client.On_Workspace_Apply_Edit_Request (Apply);
+         Client.On_Workspace_Apply_Edit_Request (Apply);
+      end if;
 
    exception
       when E : others =>
+         LSP.Common.Log (Message_Handler.Trace, E);
          Error :=
            (Is_Set => True,
             Value  =>
               (code => LSP.Errors.UnknownErrorCode,
                message => VSS.Strings.Conversions.To_Virtual_String
-                 (Ada.Exceptions.Exception_Information (E)),
+                 ("Failed to execute the Change Parameter Default Value "
+                  & "refactoring."),
                data => <>));
    end Execute;
 

--- a/source/ada/lsp-ada_handlers-refactor_extract_subprogram.adb
+++ b/source/ada/lsp-ada_handlers-refactor_extract_subprogram.adb
@@ -15,7 +15,6 @@
 -- of the license.                                                          --
 ------------------------------------------------------------------------------
 
-with Ada.Exceptions;
 with Ada.Strings.UTF_Encoding;
 
 with Langkit_Support.Slocs; use Langkit_Support.Slocs;
@@ -27,6 +26,7 @@ with Laltools.Refactor; use Laltools.Refactor;
 with Laltools.Refactor.Extract_Subprogram;
 use Laltools.Refactor.Extract_Subprogram;
 
+with LSP.Common;
 with LSP.Messages.Client_Requests;
 with LSP.Lal_Utils;
 
@@ -147,14 +147,18 @@ package body LSP.Ada_Handlers.Refactor_Extract_Subprogram is
         Client_Message_Receiver'Class;
       Error : in out LSP.Errors.Optional_ResponseError)
    is
+      use LSP.Messages;
+      use LSP.Types;
+      use VSS.Strings.Conversions;
+
       Message_Handler : LSP.Ada_Handlers.Message_Handler renames
         LSP.Ada_Handlers.Message_Handler (Handler.all);
       Context         : LSP.Ada_Contexts.Context renames
         Message_Handler.Contexts.Get (Self.Context_Id).all;
 
-      Apply : LSP.Messages.Client_Requests.Workspace_Apply_Edit_Request;
-
-      Workspace_Edits : LSP.Messages.WorkspaceEdit renames Apply.params.edit;
+      Apply           : Client_Requests.Workspace_Apply_Edit_Request;
+      Workspace_Edits : WorkspaceEdit renames Apply.params.edit;
+      Label           : Optional_Virtual_String renames Apply.params.label;
 
       function Analysis_Units return Analysis_Unit_Array is
         (Context.Analysis_Units);
@@ -164,8 +168,10 @@ package body LSP.Ada_Handlers.Refactor_Extract_Subprogram is
         Context.LAL_Context.Get_From_File
           (Context.URI_To_File (Self.Section_To_Extract_SLOC.uri));
       Section_To_Extract : constant Source_Location_Range :=
-        (Line_Number (Self.Section_To_Extract_SLOC.span.first.line) + 1,
-         Line_Number (Self.Section_To_Extract_SLOC.span.last.line) + 1,
+        (Langkit_Support.Slocs.Line_Number
+           (Self.Section_To_Extract_SLOC.span.first.line) + 1,
+         Langkit_Support.Slocs.Line_Number
+           (Self.Section_To_Extract_SLOC.span.last.line) + 1,
          Column_Number (Self.Section_To_Extract_SLOC.span.first.character) + 1,
          Column_Number (Self.Section_To_Extract_SLOC.span.last.character) + 1);
 
@@ -180,26 +186,42 @@ package body LSP.Ada_Handlers.Refactor_Extract_Subprogram is
                 Location        =>
                   (Section_To_Extract.Start_Line,
                    Section_To_Extract.Start_Column)));
-
-      Edits : constant Refactoring_Edits :=
+      Edits     : constant Refactoring_Edits :=
         Extractor.Refactor (Analysis_Units'Access);
 
    begin
-      Workspace_Edits := LSP.Lal_Utils.To_Workspace_Edit
-        (Edits.Text_Edits,
-         Message_Handler.Versioned_Documents,
-         Message_Handler'Access);
+      if Edits = No_Refactoring_Edits then
+         Error :=
+           (Is_Set => True,
+            Value  =>
+              (code    => LSP.Errors.UnknownErrorCode,
+               message => VSS.Strings.Conversions.To_Virtual_String
+                 ("Failed to execute the Extract Subprogram refactoring."),
+               data    => <>));
 
-      Client.On_Workspace_Apply_Edit_Request (Apply);
+      else
+         Workspace_Edits :=
+           LSP.Lal_Utils.To_Workspace_Edit
+             (Edits               => Edits,
+              Resource_Operations => Message_Handler.Resource_Operations,
+              Versioned_Documents => Message_Handler.Versioned_Documents,
+              Document_Provider   => Message_Handler'Access);
+         Label :=
+           (Is_Set => True,
+            Value  => To_Virtual_String (Command'External_Tag));
+
+         Client.On_Workspace_Apply_Edit_Request (Apply);
+      end if;
 
    exception
       when E : others =>
+         LSP.Common.Log (Message_Handler.Trace, E);
          Error :=
            (Is_Set => True,
             Value  =>
               (code => LSP.Errors.UnknownErrorCode,
                message => VSS.Strings.Conversions.To_Virtual_String
-                 (Ada.Exceptions.Exception_Information (E)),
+                 ("Failed to execute the Extract Subprogram refactoring."),
                data => <>));
    end Execute;
 

--- a/source/ada/lsp-ada_handlers-refactor_imports_commands.adb
+++ b/source/ada/lsp-ada_handlers-refactor_imports_commands.adb
@@ -1,7 +1,7 @@
 ------------------------------------------------------------------------------
 --                         Language Server Protocol                         --
 --                                                                          --
---                     Copyright (C) 2020-2021, AdaCore                     --
+--                     Copyright (C) 2020-2022, AdaCore                     --
 --                                                                          --
 -- This is free software;  you can redistribute it  and/or modify it  under --
 -- terms of the  GNU General Public License as published  by the Free Soft- --
@@ -14,17 +14,18 @@
 -- COPYING3.  If not, go to http://www.gnu.org/licenses for a complete copy --
 -- of the license.                                                          --
 ------------------------------------------------------------------------------
-with Ada.Exceptions;
+
 with Ada.Strings.UTF_Encoding;
 with Ada.Strings.Wide_Wide_Unbounded;
 
-with Laltools.Common;
+with Langkit_Support.Text;
 
 with Libadalang.Analysis;
 with Libadalang.Common;
 
-with Langkit_Support.Text;
+with Laltools.Common;
 
+with LSP.Common;
 with LSP.Messages;
 with LSP.Messages.Client_Requests;
 with LSP.Lal_Utils;
@@ -303,14 +304,16 @@ package body LSP.Ada_Handlers.Refactor_Imports_Commands is
       end if;
 
       Client.On_Workspace_Apply_Edit_Request (Apply);
+
    exception
       when E : others =>
+         LSP.Common.Log (Message_Handler.Trace, E);
          Error :=
            (Is_Set => True,
             Value  =>
               (code    => LSP.Errors.UnknownErrorCode,
                message => VSS.Strings.Conversions.To_Virtual_String
-                 (Ada.Exceptions.Exception_Information (E)),
+                 ("Failed to execute the Auto Imports refactoring"),
                data    => <>));
    end Execute;
 

--- a/source/ada/lsp-ada_handlers-refactor_move_parameter.adb
+++ b/source/ada/lsp-ada_handlers-refactor_move_parameter.adb
@@ -1,7 +1,7 @@
 ------------------------------------------------------------------------------
 --                         Language Server Protocol                         --
 --                                                                          --
---                        Copyright (C) 2021, AdaCore                       --
+--                     Copyright (C) 2021-2022, AdaCore                     --
 --                                                                          --
 -- This is free software;  you can redistribute it  and/or modify it  under --
 -- terms of the  GNU General Public License as published  by the Free Soft- --
@@ -15,13 +15,13 @@
 -- of the license.                                                          --
 ------------------------------------------------------------------------------
 
-with Ada.Exceptions;
 with Ada.Strings.UTF_Encoding;
 
 with Libadalang.Analysis; use Libadalang.Analysis;
 
 with Laltools.Common; use Laltools.Common;
 
+with LSP.Common;
 with LSP.Messages;
 with LSP.Messages.Client_Requests;
 with LSP.Lal_Utils;
@@ -193,45 +193,45 @@ package body LSP.Ada_Handlers.Refactor_Move_Parameter is
         Client_Message_Receiver'Class;
       Error : in out LSP.Errors.Optional_ResponseError)
    is
+      use Laltools.Refactor;
+      use LSP.Messages;
+      use LSP.Types;
+      use VSS.Strings.Conversions;
+
       Message_Handler : LSP.Ada_Handlers.Message_Handler renames
         LSP.Ada_Handlers.Message_Handler (Handler.all);
-
       Context         : LSP.Ada_Contexts.Context renames
         Message_Handler.Contexts.Get (Self.Context).all;
 
       Document : constant LSP.Ada_Documents.Document_Access :=
         Message_Handler.Get_Open_Document (Self.Where.textDocument.uri);
-      Apply    : LSP.Messages.Client_Requests.Workspace_Apply_Edit_Request;
 
-      Workspace_Edits : LSP.Messages.WorkspaceEdit renames Apply.params.edit;
+      Apply           : Client_Requests.Workspace_Apply_Edit_Request;
+      Workspace_Edits : WorkspaceEdit renames Apply.params.edit;
+      Label           : Optional_Virtual_String renames Apply.params.label;
 
       Node : constant Ada_Node :=
         Document.Get_Node_At (Context, Self.Where.position);
 
-      Target_Subp            : Defining_Name := No_Defining_Name;
+      Target_Subp            : constant Defining_Name :=
+        Resolve_Name_Precisely (Get_Node_As_Name (Node));
       Target_Parameter_Index : constant Positive :=
         Positive (Self.Parameter_Index);
 
-      Edits : Laltools.Refactor.Refactoring_Edits;
+      Edits : Refactoring_Edits;
 
       function Analysis_Units return Analysis_Unit_Array is
         (Context.Analysis_Units);
       --  Provides the Context Analysis_Unit_Array to the Mode_Changer
 
    begin
-      Apply.params.label :=
-        (Is_Set => True,
-         Value  =>
-           VSS.Strings.Conversions.To_Virtual_String (Command'External_Tag));
-      Target_Subp := Resolve_Name_Precisely (Get_Node_As_Name (Node));
-
       if Target_Subp.Is_Null then
          Error :=
            (Is_Set => True,
             Value  =>
               (code    => LSP.Errors.InvalidRequest,
                message =>
-                 "Could not execute Move Parameter command. "
+                 "Failed to execute the Move Parameter refactoring. "
                  & "The target subprogram could not be resolved precisely.",
                data    => <>));
          return;
@@ -253,22 +253,38 @@ package body LSP.Ada_Handlers.Refactor_Move_Parameter is
          end;
       end if;
 
-      Workspace_Edits := LSP.Lal_Utils.To_Workspace_Edit
-        (Edits,
-         Message_Handler.Resource_Operations,
-         Message_Handler.Versioned_Documents,
-         Message_Handler'Access);
-
-      Client.On_Workspace_Apply_Edit_Request (Apply);
-
-   exception
-      when E : others =>
+      if Edits = No_Refactoring_Edits then
          Error :=
            (Is_Set => True,
             Value  =>
               (code    => LSP.Errors.UnknownErrorCode,
                message => VSS.Strings.Conversions.To_Virtual_String
-                 (Ada.Exceptions.Exception_Information (E)),
+                 ("Failed to execute the Move Parameter refactoring."),
+               data    => <>));
+
+      else
+         Workspace_Edits :=
+           LSP.Lal_Utils.To_Workspace_Edit
+             (Edits               => Edits,
+              Resource_Operations => Message_Handler.Resource_Operations,
+              Versioned_Documents => Message_Handler.Versioned_Documents,
+              Document_Provider   => Message_Handler'Access);
+         Label :=
+           (Is_Set => True,
+            Value  => To_Virtual_String (Command'External_Tag));
+
+         Client.On_Workspace_Apply_Edit_Request (Apply);
+      end if;
+
+   exception
+      when E : others =>
+         LSP.Common.Log (Message_Handler.Trace, E);
+         Error :=
+           (Is_Set => True,
+            Value  =>
+              (code    => LSP.Errors.UnknownErrorCode,
+               message => VSS.Strings.Conversions.To_Virtual_String
+                 ("Failed to execute the Move Parameter refactoring."),
                data    => <>));
    end Execute;
 

--- a/source/ada/lsp-ada_handlers-refactor_suppress_seperate.adb
+++ b/source/ada/lsp-ada_handlers-refactor_suppress_seperate.adb
@@ -1,7 +1,7 @@
 ------------------------------------------------------------------------------
 --                         Language Server Protocol                         --
 --                                                                          --
---                        Copyright (C) 2021, AdaCore                       --
+--                     Copyright (C) 2021-2022, AdaCore                     --
 --                                                                          --
 -- This is free software;  you can redistribute it  and/or modify it  under --
 -- terms of the  GNU General Public License as published  by the Free Soft- --
@@ -15,16 +15,15 @@
 -- of the license.                                                          --
 ------------------------------------------------------------------------------
 
-with Ada.Exceptions;
-
 with Ada.Strings.UTF_Encoding;
 
 with Libadalang.Analysis; use Libadalang.Analysis;
-with Laltools.Common; use Laltools.Common;
 
+with Laltools.Common; use Laltools.Common;
 with Laltools.Refactor.Suppress_Separate;
 use Laltools.Refactor.Suppress_Separate;
 
+with LSP.Common;
 with LSP.Messages;
 with LSP.Messages.Client_Requests;
 with LSP.Lal_Utils;
@@ -131,45 +130,44 @@ package body LSP.Ada_Handlers.Refactor_Suppress_Seperate is
         Client_Message_Receiver'Class;
       Error : in out LSP.Errors.Optional_ResponseError)
    is
+      use Laltools.Refactor;
+      use LSP.Messages;
+      use LSP.Types;
+      use VSS.Strings.Conversions;
+
       Message_Handler : LSP.Ada_Handlers.Message_Handler renames
         LSP.Ada_Handlers.Message_Handler (Handler.all);
-
       Context         : LSP.Ada_Contexts.Context renames
         Message_Handler.Contexts.Get (Self.Context).all;
 
       Document : constant LSP.Ada_Documents.Document_Access :=
         Message_Handler.Get_Open_Document (Self.Where.textDocument.uri);
-      Apply    : LSP.Messages.Client_Requests.Workspace_Apply_Edit_Request;
 
-      Workspace_Edits : LSP.Messages.WorkspaceEdit renames Apply.params.edit;
+      Apply           : Client_Requests.Workspace_Apply_Edit_Request;
+      Workspace_Edits : WorkspaceEdit renames Apply.params.edit;
+      Label           : Optional_Virtual_String renames Apply.params.label;
 
       Node : constant Ada_Node :=
         Document.Get_Node_At (Context, Self.Where.position);
 
-      Target_Separate : Basic_Decl := No_Basic_Decl;
+      Target_Separate : constant Basic_Decl :=
+        Get_Node_As_Name (Node).Parent.Parent.Parent.As_Basic_Decl;
 
       Suppressor : Separate_Suppressor;
-      Edits      : Laltools.Refactor.Refactoring_Edits;
+      Edits      : Refactoring_Edits;
 
       function Analysis_Units return Analysis_Unit_Array is
         (Context.Analysis_Units);
       --  Provides the Context Analysis_Unit_Array to the Mode_Changer
 
    begin
-      Apply.params.label :=
-        (Is_Set => True,
-         Value  =>
-           VSS.Strings.Conversions.To_Virtual_String (Command'External_Tag));
-      Target_Separate :=
-        Get_Node_As_Name (Node).Parent.Parent.Parent.As_Basic_Decl;
-
       if Target_Separate.Is_Null then
          Error :=
            (Is_Set => True,
             Value  =>
               (code    => LSP.Errors.InvalidRequest,
                message => VSS.Strings.To_Virtual_String
-                 ("Could not execute Suppress Separate command. "
+                 ("Failed to execute the Suppress Separate refactoring. "
                   & "The target subprogram could not be resolved precisely."),
                data    => <>));
          return;
@@ -179,23 +177,39 @@ package body LSP.Ada_Handlers.Refactor_Suppress_Seperate is
 
       Edits := Suppressor.Refactor (Analysis_Units'Access);
 
-      Workspace_Edits := LSP.Lal_Utils.To_Workspace_Edit
-        (Edits,
-         Message_Handler.Resource_Operations,
-         Message_Handler.Versioned_Documents,
-         Message_Handler'Access,
-         True);
-
-      Client.On_Workspace_Apply_Edit_Request (Apply);
-
-   exception
-      when E : others =>
+      if Edits = No_Refactoring_Edits then
          Error :=
            (Is_Set => True,
             Value  =>
               (code    => LSP.Errors.UnknownErrorCode,
                message => VSS.Strings.Conversions.To_Virtual_String
-                 (Ada.Exceptions.Exception_Information (E)),
+                 ("Failed to execute the Suppress Separate refactoring."),
+               data    => <>));
+
+      else
+         Workspace_Edits :=
+           LSP.Lal_Utils.To_Workspace_Edit
+             (Edits               => Edits,
+              Resource_Operations => Message_Handler.Resource_Operations,
+              Versioned_Documents => Message_Handler.Versioned_Documents,
+              Document_Provider   => Message_Handler'Access,
+              Rename              => True);
+         Label :=
+           (Is_Set => True,
+            Value  => To_Virtual_String (Command'External_Tag));
+
+         Client.On_Workspace_Apply_Edit_Request (Apply);
+      end if;
+
+   exception
+      when E : others =>
+         LSP.Common.Log (Message_Handler.Trace, E);
+         Error :=
+           (Is_Set => True,
+            Value  =>
+              (code    => LSP.Errors.UnknownErrorCode,
+               message => VSS.Strings.Conversions.To_Virtual_String
+                 ("Failed to execute the Suppress Separate refactoring."),
                data    => <>));
    end Execute;
 


### PR DESCRIPTION
See this commit in laltools:
https://github.com/AdaCore/libadalang-tools/commit/68ffb694053abefd74d123dee250450d576a6aa7
If any exception is raised by Is_<Refactoring_Tool>_Available, it is now logged and False is returned.
If any exception is raised by <Refactoring_Tool>.Refactor, it is now logged and No_Refactoring_Edits is returned.
To enable the logs, add `LALTOOLS.REFACTOR=yes` to the ALS traces.

This patches:
- refactors the ALS part according to the changes in laltools
- adds an extra exception handler when executing the refactoring code actions
- Improves the failed request message shown to the user