### PR TITLE
V809-013: Add 'subprogram box' command

### DIFF
--- a/integration/vscode/ada/package.json
+++ b/integration/vscode/ada/package.json
@@ -418,6 +418,10 @@
             {
                 "command": "ada.otherFile",
                 "title": "Go to other Ada file"
+            },
+            {
+                "command": "ada.subprogramBox",
+                "title": "Add subprogram box"
             }
         ],
         "keybindings": [


### PR DESCRIPTION
The command is based on the LSP DocumentSymbols request to
retrieve the enclosing subprogram, if any.