### PR TITLE
V809-025: Make our commands Ada-specific

### DIFF
--- a/integration/vscode/ada/package.json
+++ b/integration/vscode/ada/package.json
@@ -417,20 +417,37 @@
         "commands": [
             {
                 "command": "ada.otherFile",
-                "title": "Go to other Ada file"
+                "title": "Ada: Go to other file"
             },
             {
                 "command": "ada.subprogramBox",
-                "title": "Add subprogram box"
+                "title": "Ada: Add subprogram box"
             }
         ],
         "keybindings": [
             {
                 "command": "ada.otherFile",
-                "key": "Alt+O",
-                "when": "editorLangId == 'ada' && editorTextFocus"
+                "key": "alt+O",
+                "when": "editorLangId == ada && editorTextFocus"
+            },
+            {
+                "command": "ada.subprogramBox",
+                "key": "alt+shift+B",
+                "when": "editorLangId == ada && editorTextFocus"
             }
-        ]
+        ],
+        "menus": {
+            "commandPalette": [
+                {
+                    "command": "ada.otherFile",
+                    "when": "editorLangId == ada"
+                },
+                {
+                    "command": "ada.subprogramBox",
+                    "when": "editorLangId == ada"
+                }
+            ]
+        }
     },
     "devDependencies": {
         "@types/glob": "7.2.0",


### PR DESCRIPTION
By prefixing them by 'Ada: ' (like other extensions do) and
by adding when clauses (i.e: filters) for their associated key
shortcuts and the command palette.