### PR TITLE
V511-027: Run PP on completion snippet

### DIFF
--- a/source/ada/lsp-ada_completions-names.adb
+++ b/source/ada/lsp-ada_completions-names.adb
@@ -51,6 +51,7 @@ package body LSP.Ada_Completions.Names is
       Use_Snippets : Boolean := Self.Snippets_Enabled;
 
    begin
+
       --  Get the outermost dotted name of which node is a prefix, so that when
       --  completing in a situation such as the following:
       --

--- a/source/ada/lsp-ada_completions-parameters.ads
+++ b/source/ada/lsp-ada_completions-parameters.ads
@@ -17,11 +17,13 @@
 --  A completion provider for parameters inside a call
 
 with LSP.Ada_Handlers;
+with LSP.Ada_Documents;
 
 package LSP.Ada_Completions.Parameters is
 
    type Parameter_Completion_Provider
      (Context                  : not null LSP.Ada_Handlers.Context_Access;
+      Document                 : LSP.Ada_Documents.Document_Access;
       Named_Notation_Threshold : Natural;
       Compute_Doc_And_Details  : Boolean)
    is new Completion_Provider with null record;

--- a/source/ada/lsp-ada_completions.adb
+++ b/source/ada/lsp-ada_completions.adb
@@ -15,16 +15,41 @@
 -- of the license.                                                          --
 ------------------------------------------------------------------------------
 
+with Ada.Characters.Latin_1;
+with Ada.Containers.Indefinite_Hashed_Maps;
 with Ada.Containers.Hashed_Sets;
-with Langkit_Support;
+with Ada.Strings;
+with Ada.Strings.Hash;
+with Ada.Strings.Unbounded; use Ada.Strings.Unbounded;
 
-with VSS.Strings;
+with GNATCOLL.Traces;
+
+with GNAT.Regpat;           use GNAT.Regpat;
+with GNAT.Strings;
+
+with Langkit_Support;
+with Libadalang.Analysis;   use Libadalang.Analysis;
 
 with LSP.Ada_Contexts;
 with LSP.Ada_Documents;
+with LSP.Common;
 with LSP.Lal_Utils;
+with LSP.Messages;          use LSP.Messages;
+
+with Pp.Actions;
+with Pp.Command_Lines;
+with Pp.Scanner;
+with Utils.Char_Vectors;
+with Utils.Command_Lines;
+with Utils.Command_Lines.Common;
+with VSS.Strings;
+with VSS.Strings.Conversions;
 
 package body LSP.Ada_Completions is
+
+   Me_Formatting : constant GNATCOLL.Traces.Trace_Handle :=
+     GNATCOLL.Traces.Create
+       ("ALS.COMPLETION.FORMATTING", Default => GNATCOLL.Traces.Off);
 
    ------------------------
    -- Is_Full_Sloc_Equal --
@@ -43,6 +68,9 @@ package body LSP.Ada_Completions is
 
    procedure Write_Completions
      (Context                  : LSP.Ada_Contexts.Context;
+      Document                 : LSP.Ada_Documents.Document;
+      Sloc                     : Langkit_Support.Slocs.Source_Location;
+      Node                     : Libadalang.Analysis.Ada_Node;
       Names                    : Completion_Maps.Map;
       Named_Notation_Threshold : Natural;
       Compute_Doc_And_Details  : Boolean;
@@ -90,7 +118,10 @@ package body LSP.Ada_Completions is
                if Append then
                   Result.Append
                     (LSP.Ada_Documents.Compute_Completion_Item
-                       (Context                  => Context,
+                       (Document                 => Document,
+                        Context                  => Context,
+                        Sloc                     => Sloc,
+                        Node                     => Node,
                         BD                       => Name.P_Basic_Decl,
                         Label                    => Label,
                         Use_Snippets             => Info.Use_Snippets,
@@ -106,6 +137,308 @@ package body LSP.Ada_Completions is
          end loop;
       end loop;
    end Write_Completions;
+
+   --------------------------
+   -- Pretty_Print_Snippet --
+   --------------------------
+
+   procedure Pretty_Print_Snippet
+     (Context : LSP.Ada_Contexts.Context;
+      Prefix  : String;
+      Span    : LSP.Messages.Span;
+      Rule    : Libadalang.Common.Grammar_Rule;
+      Result  : in out LSP.Messages.CompletionItem)
+   is
+
+      package Encoding_Maps is new Ada.Containers.Indefinite_Hashed_Maps
+        (Key_Type        => String,
+         Element_Type    => String,
+         Hash            => Ada.Strings.Hash,
+         Equivalent_Keys => "=");
+
+      Encoding : Encoding_Maps.Map;
+      --  Map of Snippet fake name to snippet:
+      --  {"Foo_1" : "$1", "Foo_2" : "${2: Integer}"}
+      --  $0 will not be replaced
+
+      procedure Set_PP_Switches
+        (Cmd : in out Utils.Command_Lines.Command_Line);
+      --  Force switches not enabled by default by GNATpp
+
+      function Encode_String (S : String) return String;
+      --  Create pseudo code for the snippet
+
+      function Decode_String (S : String) return String;
+      --  Recreate the snippet via the pseudo code
+
+      function Snippet_Placeholder (S : String) return String
+      is ("FooBar_" & S);
+      --  Generate a fake entity for a snippet (S is the index of the snippet)
+      --  The length of the placeholder will affect where the strings is cut
+      --  to avoid exceeding line length => 8/9 characters seems to be
+      --  reasonable (most of the time a placeholder is replacing the
+      --  parameter type's name)
+
+      function Find_Next_Placeholder
+        (S     : String;
+         Start : Integer)
+         return Match_Location;
+      --  Find the next placeholder starting from Start in S
+
+      function Post_Pretty_Print (S : String) return String;
+      --  Indent the block using the initial location and add back $0 (it has
+      --  been removed to not generate invalid pseudo code)
+
+      ---------------------
+      -- Set_PP_Switches --
+      ---------------------
+
+      procedure Set_PP_Switches
+        (Cmd : in out Utils.Command_Lines.Command_Line) is
+
+      begin
+         --  If not set by the user: align parameters and aggregates
+
+         if not Pp.Command_Lines.Pp_Nat_Switches.Explicit
+           (Cmd, Pp.Command_Lines.Call_Threshold)
+         then
+            Pp.Command_Lines.Pp_Nat_Switches.Set_Arg
+              (Cmd, Pp.Command_Lines.Call_Threshold, 1);
+         end if;
+
+         if not Pp.Command_Lines.Pp_Nat_Switches.Explicit
+           (Cmd, Pp.Command_Lines.Par_Threshold)
+         then
+            Pp.Command_Lines.Pp_Nat_Switches.Set_Arg
+              (Cmd, Pp.Command_Lines.Par_Threshold, 1);
+         end if;
+
+         if not Pp.Command_Lines.Pp_Boolean_Switches.Explicit
+           (Cmd, Pp.Command_Lines.Vertical_Named_Aggregates)
+         then
+            Pp.Command_Lines.Pp_Boolean_Switches.Set_Arg
+              (Cmd, Pp.Command_Lines.Vertical_Named_Aggregates);
+         end if;
+      end Set_PP_Switches;
+
+      -------------------
+      -- Encode_String --
+      -------------------
+
+      function Encode_String (S : String) return String
+      is
+         Res           : Unbounded_String;
+         Start_Encoded : Natural := 0;
+         Search_Index  : Boolean := False;
+         Encoded_Index : Unbounded_String;
+         In_Snippet    : Boolean := False;
+
+         procedure Add_Placeholder (Cursor : Natural);
+
+         ---------------------
+         -- Add_Placeholder --
+         ---------------------
+
+         procedure Add_Placeholder (Cursor : Natural) is
+            Placeholder : constant String :=
+              Snippet_Placeholder (To_String (Encoded_Index));
+         begin
+            if Encoded_Index /= Null_Unbounded_String then
+               Encoding.Insert
+                 (Placeholder, S (Start_Encoded .. Cursor));
+               Append (Res, Placeholder);
+               Encoded_Index := Null_Unbounded_String;
+            end if;
+         end Add_Placeholder;
+
+      begin
+         for I in S'Range loop
+            case S (I) is
+               when '$' =>
+                  Search_Index := True;
+                  Start_Encoded := I;
+                  Encoded_Index := Null_Unbounded_String;
+               when '{' =>
+                  In_Snippet := True;
+               when '}' =>
+                  Add_Placeholder (I);
+                  In_Snippet := False;
+                  Search_Index := False;
+               when '0' .. '9' =>
+                  if Search_Index then
+                     Append (Encoded_Index, S (I));
+                  elsif not In_Snippet then
+                     Append (Res, S (I));
+                  end if;
+               when others =>
+                  Search_Index := False;
+                  if not In_Snippet then
+                     Add_Placeholder (I);
+                     Append (Res, S (I));
+                  end if;
+            end case;
+         end loop;
+
+         --  Do nothing for $0 which will be removed at the end
+
+         return To_String (Res);
+      end Encode_String;
+
+      -------------------
+      -- Decode_String --
+      -------------------
+
+      function Decode_String (S : String) return String
+      is
+         Res : Unbounded_String;
+         U   : Unbounded_String := To_Unbounded_String (S);
+      begin
+         --  Remove the extra whitespace at the start
+         Trim (U, Ada.Strings.Left);
+
+         declare
+            Trimed_S  : constant String := To_String (U);
+            Cur_Index : Natural := Trimed_S'First;
+         begin
+            loop
+               declare
+                  Match : constant Match_Location :=
+                    Find_Next_Placeholder (Trimed_S, Cur_Index);
+               begin
+                  exit when Match = No_Match;
+                  Append
+                    (Res, Trimed_S (Cur_Index .. Match.First - 1));
+                  Append
+                    (Res, Encoding (Trimed_S (Match.First .. Match.Last)));
+                  Cur_Index := Match.Last + 1;
+               end;
+            end loop;
+
+            Append (Res, Trimed_S (Cur_Index .. Trimed_S'Last));
+         end;
+
+         return To_String (Res);
+      end Decode_String;
+
+      ---------------------------
+      -- Find_Next_Placeholder --
+      ---------------------------
+
+      function Find_Next_Placeholder
+        (S     : String;
+         Start : Integer)
+         return Match_Location
+      is
+         Placeholder_Regexp : constant Pattern_Matcher :=
+           Compile ("FooBar_[0-9]+");
+         Matched : Match_Array (0 .. 0);
+      begin
+         Match
+           (Self       => Placeholder_Regexp,
+            Data       => S,
+            Matches    => Matched,
+            Data_First => Start);
+         return Matched (0);
+      end Find_Next_Placeholder;
+
+      -----------------------
+      -- Post_Pretty_Print --
+      -----------------------
+
+      function Post_Pretty_Print (S : String) return String
+      is
+         Res : Unbounded_String;
+      begin
+         --  Remove this condition when V725-006 is fixed
+         if S (S'Last) = Ada.Characters.Latin_1.LF then
+            Append (Res, S (S'First .. S'Last - 1));
+         else
+            Append (Res, S);
+         end if;
+
+         --  Add back snippet terminator
+         Append (Res, "$0");
+         return To_String (Res);
+      end Post_Pretty_Print;
+
+   begin
+      if Me_Formatting.Active
+        and then Result.insertText.Is_Set
+        and then Result.insertTextFormat.Is_Set
+        and then Result.insertTextFormat.Value = Snippet
+      then
+         declare
+            Input : Utils.Char_Vectors.Char_Vector;
+            Output : Utils.Char_Vectors.Char_Vector;
+            PP_Messages : Pp.Scanner.Source_Message_Vector;
+            S : GNAT.Strings.String_Access;
+            Tmp_Unit : Analysis_Unit;
+            Cmd : Utils.Command_Lines.Command_Line := Context.Get_PP_Options;
+            Tmp_Context : constant Analysis_Context :=
+              Create_Context
+                (Charset =>
+                   Utils.Command_Lines.Common.Wide_Character_Encoding (Cmd));
+         begin
+            Set_PP_Switches (Cmd);
+
+            S :=
+              new String'
+                (VSS.Strings.Conversions.To_UTF_8_String
+                   (Result.insertText.Value));
+
+            declare
+               Full : constant String := Prefix & Encode_String (S.all);
+            begin
+               Input.Append (Full);
+               Tmp_Unit :=
+                 Get_From_Buffer
+                   (Context  => Tmp_Context,
+                    Filename => "",
+                    Buffer   => Full,
+                    Rule     => Rule);
+               --  -2 because:
+               --  - align using the column before the cursor
+               --  - and "column = offset - 1"
+               Pp.Actions.Set_Partial_Gnatpp_Offset
+                 (Integer (Span.first.character) - 2);
+               Pp.Actions.Format_Vector
+                 (Cmd            => Cmd,
+                  Input          => Input,
+                  Node           => Root (Tmp_Unit),
+                  Output         => Output,
+                  Messages       => PP_Messages,
+                  Partial_Gnatpp => True);
+               Pp.Actions.Set_Partial_Gnatpp_Offset (0);
+            exception
+               when E : others =>
+                  --  Failed to pretty print the snippet, keep the previous
+                  --  value.
+                  LSP.Common.Log (Context.Trace, E);
+                  return;
+            end;
+
+            GNAT.Strings.Free (S);
+            S := new String'(Output.To_Array);
+
+            if S.all /= "" then
+               --  The text is already formatted, don't try to indent it
+               Result.insertTextMode :=
+                 (Is_Set => True,
+                  Value  => asIs);
+               Result.textEdit :=
+                 (Is_Set => True,
+                  Value  =>
+                    (Is_TextEdit => True,
+                     TextEdit    =>
+                       (span    => Span,
+                        newText =>
+                          VSS.Strings.Conversions.To_Virtual_String
+                            (Post_Pretty_Print (Decode_String (S.all))))));
+            end if;
+            GNAT.Strings.Free (S);
+         end;
+      end if;
+   end Pretty_Print_Snippet;
 
    ---------------------------
    -- Generic_Write_Symbols --

--- a/source/ada/lsp-ada_completions.ads
+++ b/source/ada/lsp-ada_completions.ads
@@ -26,6 +26,7 @@ with Libadalang.Analysis;
 with Libadalang.Common;
 
 limited with LSP.Ada_Contexts;
+limited with LSP.Ada_Documents;
 limited with LSP.Ada_Completions.Filters;
 
 with LSP.Messages;
@@ -96,6 +97,9 @@ package LSP.Ada_Completions is
 
    procedure Write_Completions
      (Context                  : LSP.Ada_Contexts.Context;
+      Document                 : LSP.Ada_Documents.Document;
+      Sloc                     : Langkit_Support.Slocs.Source_Location;
+      Node                     : Libadalang.Analysis.Ada_Node;
       Names                    : Completion_Maps.Map;
       Named_Notation_Threshold : Natural;
       Compute_Doc_And_Details  : Boolean;
@@ -107,6 +111,15 @@ package LSP.Ada_Completions is
    --  If Compute_Doc_And_Details is True, the 'detail' and 'documentation'
    --  fields for all the resulting completion items will be computed
    --  immediately, which might take time.
+
+   procedure Pretty_Print_Snippet
+     (Context : LSP.Ada_Contexts.Context;
+      Prefix  : String;
+      Span    : LSP.Messages.Span;
+      Rule    : Libadalang.Common.Grammar_Rule;
+      Result  : in out LSP.Messages.CompletionItem);
+   --  If Result is a snippet then generate a textEdit over span using GNATpp.
+   --  Rule must match the content of "Prefix & Result.insertText.Value"
 
    generic
       with function Has_Been_Canceled return Boolean;

--- a/source/ada/lsp-ada_contexts.ads
+++ b/source/ada/lsp-ada_contexts.ads
@@ -200,6 +200,10 @@ package LSP.Ada_Contexts is
    function File_Count (Self : Context) return Natural;
    --  Return number of files known to this context.
 
+   function Get_PP_Options (Self : Context) return
+     Utils.Command_Lines.Command_Line;
+   --  Return the command line for the Pretty Printer
+
    function Analysis_Units
      (Self : Context) return Libadalang.Analysis.Analysis_Unit_Array;
    --  Return the analysis units for all Ada sources known to this context
@@ -333,6 +337,10 @@ private
        is (Self.Source_Files.Iterate);
 
    function File_Count (Self : Context) return Natural
-       is (Self.Source_Files.Length);
+   is (Self.Source_Files.Length);
+
+   function Get_PP_Options (Self : Context) return
+     Utils.Command_Lines.Command_Line is
+       (Utils.Command_Lines.Copy_Command_Line (Self.PP_Options));
 
 end LSP.Ada_Contexts;

--- a/source/ada/lsp-ada_documents.adb
+++ b/source/ada/lsp-ada_documents.adb
@@ -2327,7 +2327,10 @@ package body LSP.Ada_Documents is
    -----------------------------
 
    function Compute_Completion_Item
-     (Context                  : LSP.Ada_Contexts.Context;
+     (Document                 : LSP.Ada_Documents.Document;
+      Context                  : LSP.Ada_Contexts.Context;
+      Sloc                     : Langkit_Support.Slocs.Source_Location;
+      Node                     : Libadalang.Analysis.Ada_Node;
       BD                       : Libadalang.Analysis.Basic_Decl;
       Label                    : VSS.Strings.Virtual_String;
       Use_Snippets             : Boolean;
@@ -2774,17 +2777,17 @@ package body LSP.Ada_Documents is
       end loop;
    end Get_Any_Symbol;
 
-   ------------------------
-   -- Get_Completions_At --
-   ------------------------
+   -------------------------
+   -- Get_Completion_Node --
+   -------------------------
 
-   procedure Get_Completions_At
-     (Self      : Document;
-      Providers : LSP.Ada_Completions.Completion_Provider_List;
-      Context   : LSP.Ada_Contexts.Context;
-      Position  : LSP.Messages.Position;
-      Names     : out Ada_Completions.Completion_Maps.Map;
-      Result    : out LSP.Messages.CompletionList)
+   procedure Get_Completion_Node
+     (Self     : Document;
+      Context  : LSP.Ada_Contexts.Context;
+      Position : LSP.Messages.Position;
+      Sloc     : out Langkit_Support.Slocs.Source_Location;
+      Token    : out Libadalang.Common.Token_Reference;
+      Node     : out Libadalang.Analysis.Ada_Node)
    is
       use Libadalang.Common;
 
@@ -2832,24 +2835,36 @@ package body LSP.Ada_Documents is
 
          return Token;
       end Completion_Token;
+   begin
+      Sloc := Self.Get_Source_Location (Position);
+      Token := Completion_Token (Sloc);
+      declare
+         From : constant Langkit_Support.Slocs.Source_Location :=
+           Langkit_Support.Slocs.Start_Sloc
+             (Libadalang.Common.Sloc_Range
+                (Libadalang.Common.Data (Token)));
 
-      Sloc  : constant Langkit_Support.Slocs.Source_Location :=
-        Self.Get_Source_Location (Position);
+         Root : constant Libadalang.Analysis.Ada_Node :=
+           Self.Unit (Context).Root;
+      begin
+         Node := (if Root = No_Ada_Node then Root else Root.Lookup (From));
+      end;
+   end Get_Completion_Node;
 
-      Token : constant Libadalang.Common.Token_Reference :=
-        Completion_Token (Sloc);
+   ------------------------
+   -- Get_Completions_At --
+   ------------------------
 
-      From  : constant Langkit_Support.Slocs.Source_Location :=
-        Langkit_Support.Slocs.Start_Sloc
-          (Libadalang.Common.Sloc_Range
-             (Libadalang.Common.Data (Token)));
-
-      Root  : constant Libadalang.Analysis.Ada_Node :=
-        Self.Unit (Context).Root;
-
-      Node  : constant Libadalang.Analysis.Ada_Node :=
-        (if Root = No_Ada_Node then Root else Root.Lookup (From));
-
+   procedure Get_Completions_At
+     (Self      : Document;
+      Providers : LSP.Ada_Completions.Completion_Provider_List;
+      Context   : LSP.Ada_Contexts.Context;
+      Sloc      : Langkit_Support.Slocs.Source_Location;
+      Token     : Libadalang.Common.Token_Reference;
+      Node      : Libadalang.Analysis.Ada_Node;
+      Names     : out Ada_Completions.Completion_Maps.Map;
+      Result    : out LSP.Messages.CompletionList)
+   is
       Parent : constant Libadalang.Analysis.Ada_Node :=
         (if Node = No_Ada_Node then Node else Node.Parent);
 

--- a/source/ada/lsp-ada_documents.ads
+++ b/source/ada/lsp-ada_documents.ads
@@ -143,14 +143,25 @@ package LSP.Ada_Documents is
       return VSS.Strings.Virtual_String;
    --  Get an identifier at given position in the document or an empty string.
 
+   procedure Get_Completion_Node
+     (Self     : Document;
+      Context  : LSP.Ada_Contexts.Context;
+      Position : LSP.Messages.Position;
+      Sloc     : out Langkit_Support.Slocs.Source_Location;
+      Token    : out Libadalang.Common.Token_Reference;
+      Node     : out Libadalang.Analysis.Ada_Node);
+   --  Look at the tokens to find the best completion context.
+
    procedure Get_Completions_At
      (Self      : Document;
       Providers : LSP.Ada_Completions.Completion_Provider_List;
       Context   : LSP.Ada_Contexts.Context;
-      Position  : LSP.Messages.Position;
+      Sloc      : Langkit_Support.Slocs.Source_Location;
+      Token     : Libadalang.Common.Token_Reference;
+      Node      : Libadalang.Analysis.Ada_Node;
       Names     : out Ada_Completions.Completion_Maps.Map;
       Result    : out LSP.Messages.CompletionList);
-   --  Populate Result/Names with completions for given position in the
+   --  Populate Result/Names with completions Node in the
    --  document. Names works for defining name completions to create snippets
    --  and to avoid duplicates.
 
@@ -256,7 +267,10 @@ package LSP.Ada_Documents is
    --  VersionedTextDocumentIdentifier with a null version.
 
    function Compute_Completion_Item
-     (Context                  : LSP.Ada_Contexts.Context;
+     (Document                 : LSP.Ada_Documents.Document;
+      Context                  : LSP.Ada_Contexts.Context;
+      Sloc                     : Langkit_Support.Slocs.Source_Location;
+      Node                     : Libadalang.Analysis.Ada_Node;
       BD                       : Libadalang.Analysis.Basic_Decl;
       Label                    : VSS.Strings.Virtual_String;
       Use_Snippets             : Boolean;

--- a/testsuite/ada_lsp/U913-028.completion.params/test.json
+++ b/testsuite/ada_lsp/U913-028.completion.params/test.json
@@ -416,7 +416,7 @@
                         "label": "Params of Bar",
                         "kind": 15,
                         "sortText": "+0",
-                        "insertText": "${1:I : Integer})$0",
+                        "insertText": "I => ${1:Integer})$0",
                         "insertTextFormat": 2,
                         "additionalTextEdits": [],
                         "data": {

--- a/testsuite/ada_lsp/completion.snippet.formatting/default.gpr
+++ b/testsuite/ada_lsp/completion.snippet.formatting/default.gpr
@@ -1,0 +1,2 @@
+project Default is
+end Default;

--- a/testsuite/ada_lsp/completion.snippet.formatting/foo.adb
+++ b/testsuite/ada_lsp/completion.snippet.formatting/foo.adb
@@ -1,0 +1,25 @@
+procedure Foo is
+
+   procedure Bar (A, B, C, D, E, F, G, H, I, J : Integer);
+
+   procedure Bar (AAAAAAAA, BB, CCCCCCCC, DDDDDDDDDDDD, E : Integer);
+
+   procedure Bar (A, B : Integer);
+
+   procedure Bar (A, B, C, D, E, F, G, H, I, J : Integer) is
+   begin
+      null;
+   end Bar;
+
+   procedure Bar (AAAAAAAA, BB, CCCCCCCC, DDDDDDDDDDDD, E : Integer) is
+   begin
+      null;
+   end Bar;
+
+   procedure Bar (A, B : Integer) is
+   begin
+      null;
+   end Bar;
+begin
+   Bar (
+end Foo;

--- a/testsuite/ada_lsp/completion.snippet.formatting/test.json
+++ b/testsuite/ada_lsp/completion.snippet.formatting/test.json
@@ -1,0 +1,429 @@
+[
+   {
+      "comment": [
+         "Test the formatting of snippet via GNATPP"
+      ]
+   },
+   {
+      "start": {
+         "cmd": [
+             "${ALS}",
+             "--tracefile=./traces.cfg"
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+               "processId": 199714,
+               "rootUri": "$URI{.}",
+               "capabilities": {
+                  "workspace": {
+                     "applyEdit": true
+                  },
+                  "textDocument": {
+                     "completion": {
+                        "completionItem": {
+                           "snippetSupport": true,
+                           "documentationFormat": [
+                              "markdown",
+                              "plaintext"
+                           ],
+                           "resolveSupport": {
+                              "properties": [
+                                 "documentation",
+                                 "detail"
+                              ]
+                           }
+                        }
+                     }
+                  },
+                  "window": {
+                     "workDoneProgress": true
+                  }
+               }
+            }
+         },
+         "wait": [
+            {
+               "jsonrpc": "2.0",
+               "id": 1,
+               "result": {
+                  "capabilities": {
+                     "textDocumentSync": 2,
+                     "completionProvider": {
+                        "triggerCharacters": [
+                           ".",
+                           ",",
+                           "'",
+                           "("
+                        ],
+                        "resolveProvider": true
+                     }
+                  }
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "initialized"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "workspace/didChangeConfiguration",
+            "params": {
+               "settings": {
+                  "ada": {
+                     "projectFile": "$URI{default.gpr}",
+                     "scenarioVariables": {},
+                     "defaultCharset": "ISO-8859-1",
+                     "enableDiagnostics": true,
+                     "followSymlinks": false
+                  }
+               }
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}",
+                  "languageId": "Ada",
+                  "version": 0,
+                  "text": "procedure Foo is\n\n   procedure Bar (A, B, C, D, E, F, G, H, I, J : Integer);\n\n   procedure Bar (AAAAAAAA, BB, CCCCCCCC, DDDDDDDDDDDD, E : Integer);\n\n   procedure Bar (A, B : Integer);\n\n   procedure Bar (A, B, C, D, E, F, G, H, I, J : Integer) is\n   begin\n      null;\n   end Bar;\n\n   procedure Bar (AAAAAAAA, BB, CCCCCCCC, DDDDDDDDDDDD, E : Integer) is\n   begin\n      null;\n   end Bar;\n\n   procedure Bar (A, B : Integer) is\n   begin\n      null;\n   end Bar;\nbegin\n   Bar (\nend Foo;\n"
+               }
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": 6,
+            "method": "textDocument/completion",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}"
+               },
+               "position": {
+                  "line": 23,
+                  "character": 8
+               },
+               "context": {
+                  "triggerKind": 1
+               }
+            }
+         },
+         "wait": [
+            {
+               "id": 6,
+               "result": {
+                  "isIncomplete": false,
+                  "items": [
+                     {
+                        "label": "Params of Bar",
+                        "kind": 15,
+                        "sortText": "+00",
+                        "insertText": "${1:A : Integer}, ${2:B : Integer})$0",
+                        "insertTextFormat": 2,
+                        "textEdit": {
+                           "range": {
+                             "start": {
+                                "line": 23,
+                                "character": 3
+                              },
+                               "end": {
+                                 "line": 23,
+                                 "character": 8
+                              }
+                            },
+                            "newText": "Bar (${1:A : Integer}, ${2:B : Integer})$0"
+                        },
+                        "additionalTextEdits": [],
+                        "data": {
+                           "uri": "$URI{foo.adb}",
+                           "range": {
+                              "start": {
+                                 "line": 6,
+                                 "character": 3
+                              },
+                              "end": {
+                                 "line": 6,
+                                 "character": 34
+                              }
+                           }
+                        }
+                     },
+                     {
+                        "label": "A",
+                        "kind": 5,
+                        "sortText": "+01",
+                        "insertText": "A => ",
+                        "insertTextFormat": 1,
+                        "additionalTextEdits": []
+                     },
+                     {
+                        "label": "B",
+                        "kind": 5,
+                        "sortText": "+02",
+                        "insertText": "B => ",
+                        "insertTextFormat": 1,
+                        "additionalTextEdits": []
+                     },
+                     {
+                        "label": "Params of Bar",
+                        "kind": 15,
+                        "sortText": "+03",
+                        "insertText": "AAAAAAAA => ${1:Integer}, BB => ${2:Integer}, CCCCCCCC => ${3:Integer}, DDDDDDDDDDDD => ${4:Integer}, E => ${5:Integer})$0",
+                        "insertTextFormat": 2,
+                        "textEdit": {
+                           "range": {
+                             "start": {
+                                "line": 23,
+                                "character": 3
+                              },
+                               "end": {
+                                 "line": 23,
+                                 "character": 8
+                              }
+                            },
+                            "newText": "Bar\n   (AAAAAAAA     => ${1:Integer},\n    BB           => ${2:Integer},\n    CCCCCCCC     => ${3:Integer},\n    DDDDDDDDDDDD => ${4:Integer},\n    E            => ${5:Integer})$0"
+                        },
+                        "additionalTextEdits": [],
+                        "data": {
+                           "uri": "$URI{foo.adb}",
+                           "range": {
+                              "start": {
+                                 "line": 4,
+                                 "character": 3
+                              },
+                              "end": {
+                                 "line": 4,
+                                 "character": 69
+                              }
+                           }
+                        }
+                     },
+                     {
+                        "label": "AAAAAAAA",
+                        "kind": 5,
+                        "sortText": "+04",
+                        "insertText": "AAAAAAAA => ",
+                        "insertTextFormat": 1,
+                        "additionalTextEdits": []
+                     },
+                     {
+                        "label": "BB",
+                        "kind": 5,
+                        "sortText": "+05",
+                        "insertText": "BB => ",
+                        "insertTextFormat": 1,
+                        "additionalTextEdits": []
+                     },
+                     {
+                        "label": "CCCCCCCC",
+                        "kind": 5,
+                        "sortText": "+06",
+                        "insertText": "CCCCCCCC => ",
+                        "insertTextFormat": 1,
+                        "additionalTextEdits": []
+                     },
+                     {
+                        "label": "DDDDDDDDDDDD",
+                        "kind": 5,
+                        "sortText": "+07",
+                        "insertText": "DDDDDDDDDDDD => ",
+                        "insertTextFormat": 1,
+                        "additionalTextEdits": []
+                     },
+                     {
+                        "label": "E",
+                        "kind": 5,
+                        "sortText": "+08",
+                        "insertText": "E => ",
+                        "insertTextFormat": 1,
+                        "additionalTextEdits": []
+                     },
+                     {
+                        "label": "Params of Bar",
+                        "kind": 15,
+                        "sortText": "+09",
+                        "insertText": "A => ${1:Integer}, B => ${2:Integer}, C => ${3:Integer}, D => ${4:Integer}, E => ${5:Integer}, F => ${6:Integer}, G => ${7:Integer}, H => ${8:Integer}, I => ${9:Integer}, J => ${10:Integer})$0",
+                        "insertTextFormat": 2,
+                        "textEdit": {
+                           "range": {
+                             "start": {
+                                "line": 23,
+                                "character": 3
+                              },
+                               "end": {
+                                 "line": 23,
+                                 "character": 8
+                              }
+                            },
+                            "newText": "Bar\n   (A => ${1:Integer},\n    B => ${2:Integer},\n    C => ${3:Integer},\n    D => ${4:Integer},\n    E => ${5:Integer},\n    F => ${6:Integer},\n    G => ${7:Integer},\n    H => ${8:Integer},\n    I => ${9:Integer},\n    J => ${10:Integer})$0"
+                        },
+                        "additionalTextEdits": [],
+                        "data": {
+                           "uri": "$URI{foo.adb}",
+                           "range": {
+                              "start": {
+                                 "line": 2,
+                                 "character": 3
+                              },
+                              "end": {
+                                 "line": 2,
+                                 "character": 58
+                              }
+                           }
+                        }
+                     },
+                     {
+                        "label": "A",
+                        "kind": 5,
+                        "sortText": "+10",
+                        "insertText": "A => ",
+                        "insertTextFormat": 1,
+                        "additionalTextEdits": []
+                     },
+                     {
+                        "label": "B",
+                        "kind": 5,
+                        "sortText": "+11",
+                        "insertText": "B => ",
+                        "insertTextFormat": 1,
+                        "additionalTextEdits": []
+                     },
+                     {
+                        "label": "C",
+                        "kind": 5,
+                        "sortText": "+12",
+                        "insertText": "C => ",
+                        "insertTextFormat": 1,
+                        "additionalTextEdits": []
+                     },
+                     {
+                        "label": "D",
+                        "kind": 5,
+                        "sortText": "+13",
+                        "insertText": "D => ",
+                        "insertTextFormat": 1,
+                        "additionalTextEdits": []
+                     },
+                     {
+                        "label": "E",
+                        "kind": 5,
+                        "sortText": "+14",
+                        "insertText": "E => ",
+                        "insertTextFormat": 1,
+                        "additionalTextEdits": []
+                     },
+                     {
+                        "label": "F",
+                        "kind": 5,
+                        "sortText": "+15",
+                        "insertText": "F => ",
+                        "insertTextFormat": 1,
+                        "additionalTextEdits": []
+                     },
+                     {
+                        "label": "G",
+                        "kind": 5,
+                        "sortText": "+16",
+                        "insertText": "G => ",
+                        "insertTextFormat": 1,
+                        "additionalTextEdits": []
+                     },
+                     {
+                        "label": "H",
+                        "kind": 5,
+                        "sortText": "+17",
+                        "insertText": "H => ",
+                        "insertTextFormat": 1,
+                        "additionalTextEdits": []
+                     },
+                     {
+                        "label": "I",
+                        "kind": 5,
+                        "sortText": "+18",
+                        "insertText": "I => ",
+                        "insertTextFormat": 1,
+                        "additionalTextEdits": []
+                     },
+                     {
+                        "label": "J",
+                        "kind": 5,
+                        "sortText": "+19",
+                        "insertText": "J => ",
+                        "insertTextFormat": 1,
+                        "additionalTextEdits": []
+                     }
+                  ]
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didClose",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}"
+               }
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": 53,
+            "method": "shutdown"
+         },
+         "wait": [
+            {
+               "method": "textDocument/publishDiagnostics",
+               "params": {
+                  "uri": "$URI{foo.adb}",
+                  "diagnostics": []
+               }
+            },
+            {
+               "id": 53,
+               "result": null
+            }
+         ]
+      }
+   },
+   {
+      "stop": {
+         "exit_code": 0
+      }
+   }
+]

--- a/testsuite/ada_lsp/completion.snippet.formatting/test.yaml
+++ b/testsuite/ada_lsp/completion.snippet.formatting/test.yaml
@@ -1,0 +1,1 @@
+title: 'completion.snippet.formatting'

--- a/testsuite/ada_lsp/completion.snippet.formatting/traces.cfg
+++ b/testsuite/ada_lsp/completion.snippet.formatting/traces.cfg
@@ -16,5 +16,5 @@ ALS.NOTIFICATIONS_FOR_IMPRECISE_NAVIGATION=yes
 # Disable runtime indexing for most tests
 ALS.RUNTIME_INDEXING=no
 
-# Disable advanced PP formatting of snippet for most tests
-ALS.COMPLETION.FORMATTING=no
+# The test is about GNATpp enabled it
+ALS.COMPLETION.FORMATTING=yes

--- a/testsuite/ada_lsp/completion.snippet.formatting2/default.gpr
+++ b/testsuite/ada_lsp/completion.snippet.formatting2/default.gpr
@@ -1,0 +1,2 @@
+project Default is
+end Default;

--- a/testsuite/ada_lsp/completion.snippet.formatting2/foo.adb
+++ b/testsuite/ada_lsp/completion.snippet.formatting2/foo.adb
@@ -1,0 +1,12 @@
+procedure Foo is
+
+   procedure Bar (A, BBBBB, CCCCCCC : Integer; DDD : Float);
+
+   procedure Bar (A, BBBBB, CCCCCCC : Integer; DDD : Float) is
+   begin
+      null;
+   end Bar;
+
+begin
+   Bar 
+end Foo;

--- a/testsuite/ada_lsp/completion.snippet.formatting2/test.json
+++ b/testsuite/ada_lsp/completion.snippet.formatting2/test.json
@@ -1,0 +1,447 @@
+[
+   {
+      "comment": [
+         "Test the formatting of snippet via GNATPP => when adding",
+         "parameters in a call it should reformat the existing parameters"
+      ]
+   },
+   {
+      "start": {
+         "cmd": [
+             "${ALS}",
+             "--tracefile=./traces.cfg"
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+               "processId": 199714,
+               "rootUri": "$URI{.}",
+               "capabilities": {
+                  "workspace": {
+                     "applyEdit": true
+                  },
+                  "textDocument": {
+                     "completion": {
+                        "completionItem": {
+                           "snippetSupport": true,
+                           "documentationFormat": [
+                              "markdown",
+                              "plaintext"
+                           ],
+                           "resolveSupport": {
+                              "properties": [
+                                 "documentation",
+                                 "detail"
+                              ]
+                           }
+                        }
+                     }
+                  },
+                  "window": {
+                     "workDoneProgress": true
+                  }
+               }
+            }
+         },
+         "wait": [
+            {
+               "jsonrpc": "2.0",
+               "id": 1,
+               "result": {
+                  "capabilities": {
+                     "textDocumentSync": 2,
+                     "completionProvider": {
+                        "triggerCharacters": [
+                           ".",
+                           ",",
+                           "'",
+                           "("
+                        ],
+                        "resolveProvider": true
+                     }
+                  }
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "initialized"
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}",
+                  "languageId": "Ada",
+                  "version": 0,
+                  "text": "procedure Foo is\n\n   procedure Bar (A, BBBBB, CCCCCCC : Integer; DDD : Float);\n\n   procedure Bar (A, BBBBB, CCCCCCC : Integer; DDD : Float) is\n   begin\n      null;\n   end Bar;\n\nbegin\n   Bar \nend Foo;\n"
+               }
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}",
+                  "version": 1
+               },
+               "contentChanges": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 10,
+                           "character": 7
+                        },
+                        "end": {
+                           "line": 10,
+                           "character": 7
+                        }
+                     },
+                     "text": "("
+                  }
+               ]
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": 5,
+            "method": "textDocument/completion",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}"
+               },
+               "position": {
+                  "line": 10,
+                  "character": 8
+               },
+               "context": {
+                  "triggerKind": 2
+               }
+            }
+         },
+         "wait": [
+            {
+               "id": 5,
+               "result": {
+                  "isIncomplete": false,
+                  "items": [
+                     {
+                        "label": "Params of Bar",
+                        "kind": 15,
+                        "sortText": "+0",
+                        "insertText": "A => ${1:Integer}, BBBBB => ${2:Integer}, CCCCCCC => ${3:Integer}, DDD => ${4:Float})$0",
+                        "insertTextFormat": 2,
+                        "textEdit": {
+                           "range": {
+                              "start": {
+                                 "line": 10,
+                                 "character": 3
+                              },
+                              "end": {
+                                 "line": 10,
+                                 "character": 8
+                              }
+                           },
+                           "newText": "Bar\n   (A       => ${1:Integer},\n    BBBBB   => ${2:Integer},\n    CCCCCCC => ${3:Integer},\n    DDD     => ${4:Float})$0"
+                        },
+                        "additionalTextEdits": [],
+                        "data": {
+                           "uri": "$URI{foo.adb}",
+                           "range": {
+                              "start": {
+                                 "line": 2,
+                                 "character": 3
+                              },
+                              "end": {
+                                 "line": 2,
+                                 "character": 60
+                              }
+                           }
+                        }
+                     },
+                     {
+                        "label": "A",
+                        "kind": 5,
+                        "sortText": "+1",
+                        "insertText": "A => ",
+                        "insertTextFormat": 1,
+                        "additionalTextEdits": []
+                     },
+                     {
+                        "label": "BBBBB",
+                        "kind": 5,
+                        "sortText": "+2",
+                        "insertText": "BBBBB => ",
+                        "insertTextFormat": 1,
+                        "additionalTextEdits": []
+                     },
+                     {
+                        "label": "CCCCCCC",
+                        "kind": 5,
+                        "sortText": "+3",
+                        "insertText": "CCCCCCC => ",
+                        "insertTextFormat": 1,
+                        "additionalTextEdits": []
+                     },
+                     {
+                        "label": "DDD",
+                        "kind": 5,
+                        "sortText": "+4",
+                        "insertText": "DDD => ",
+                        "insertTextFormat": 1,
+                        "additionalTextEdits": []
+                     }
+                  ]
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": 12,
+            "method": "completionItem/resolve",
+            "params": {
+               "label": "A",
+               "kind": 5,
+               "sortText": "+1",
+               "insertText": "A => ",
+               "insertTextFormat": 1,
+               "additionalTextEdits": []
+            }
+         },
+         "wait": [
+            {
+               "id": 12,
+               "result": {
+                  "label": "A",
+                  "kind": 5,
+                  "sortText": "+1",
+                  "insertText": "A => ",
+                  "insertTextFormat": 1,
+                  "additionalTextEdits": []
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}",
+                  "version": 2
+               },
+               "contentChanges": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 10,
+                           "character": 8
+                        },
+                        "end": {
+                           "line": 10,
+                           "character": 8
+                        }
+                     },
+                     "text": "A => "
+                  }
+               ]
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}",
+                  "version": 3
+               },
+               "contentChanges": [
+                  {
+                     "range": {
+                        "start": {
+                           "line": 10,
+                           "character": 13
+                        },
+                        "end": {
+                           "line": 10,
+                           "character": 13
+                        }
+                     },
+                     "text": "1,"
+                  }
+               ]
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": 21,
+            "method": "textDocument/completion",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}"
+               },
+               "position": {
+                  "line": 10,
+                  "character": 15
+               },
+               "context": {
+                  "triggerKind": 2
+               }
+            }
+         },
+         "wait": [
+            {
+               "id": 21,
+               "result": {
+                  "isIncomplete": false,
+                  "items": [
+                     {
+                        "label": "Params of Bar",
+                        "kind": 15,
+                        "sortText": "+0",
+                        "insertText": " BBBBB => ${2:Integer}, CCCCCCC => ${3:Integer}, DDD => ${4:Float})$0",
+                        "insertTextFormat": 2,
+                        "textEdit": {
+                           "range": {
+                              "start": {
+                                 "line": 10,
+                                 "character": 3
+                              },
+                              "end": {
+                                 "line": 10,
+                                 "character": 15
+                              }
+                           },
+                           "newText": "Bar\n   (A       => 1,\n    BBBBB   => ${2:Integer},\n    CCCCCCC => ${3:Integer},\n    DDD     => ${4:Float})$0"
+                        },
+                        "additionalTextEdits": [],
+                        "data": {
+                           "uri": "$URI{foo.adb}",
+                           "range": {
+                              "start": {
+                                 "line": 2,
+                                 "character": 3
+                              },
+                              "end": {
+                                 "line": 2,
+                                 "character": 60
+                              }
+                           }
+                        }
+                     },
+                     {
+                        "label": "BBBBB",
+                        "kind": 5,
+                        "sortText": "+1",
+                        "insertText": " BBBBB => ",
+                        "insertTextFormat": 1,
+                        "additionalTextEdits": []
+                     },
+                     {
+                        "label": "CCCCCCC",
+                        "kind": 5,
+                        "sortText": "+2",
+                        "insertText": " CCCCCCC => ",
+                        "insertTextFormat": 1,
+                        "additionalTextEdits": []
+                     },
+                     {
+                        "label": "DDD",
+                        "kind": 5,
+                        "sortText": "+3",
+                        "insertText": " DDD => ",
+                        "insertTextFormat": 1,
+                        "additionalTextEdits": []
+                     }
+                  ]
+               }
+            }
+         ]
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "method": "textDocument/didClose",
+            "params": {
+               "textDocument": {
+                  "uri": "$URI{foo.adb}"
+               }
+            }
+         },
+         "wait": []
+      }
+   },
+   {
+      "send": {
+         "request": {
+            "jsonrpc": "2.0",
+            "id": 31,
+            "method": "shutdown"
+         },
+         "wait": [
+            {
+               "method": "textDocument/publishDiagnostics",
+               "params": {
+                  "uri": "$URI{foo.adb}",
+                  "diagnostics": []
+               }
+            },
+            {
+               "id": 31,
+               "result": null
+            }
+         ]
+      }
+   },
+   {
+      "stop": {
+         "exit_code": 0
+      }
+   }
+]

--- a/testsuite/ada_lsp/completion.snippet.formatting2/test.yaml
+++ b/testsuite/ada_lsp/completion.snippet.formatting2/test.yaml
@@ -1,0 +1,1 @@
+title: 'completion.snippet.formatting2'

--- a/testsuite/ada_lsp/completion.snippet.formatting2/traces.cfg
+++ b/testsuite/ada_lsp/completion.snippet.formatting2/traces.cfg
@@ -16,5 +16,5 @@ ALS.NOTIFICATIONS_FOR_IMPRECISE_NAVIGATION=yes
 # Disable runtime indexing for most tests
 ALS.RUNTIME_INDEXING=no
 
-# Disable advanced PP formatting of snippet for most tests
-ALS.COMPLETION.FORMATTING=no
+# The test is about GNATpp enabled it
+ALS.COMPLETION.FORMATTING=yes


### PR DESCRIPTION
Encode snippet in pseudo Ada code, run PP and decode it.
When successfull, it will generate a textEdit for the
completionItem.

Enforce PP switches to have the parameter aligned: it can
be disabled via a trace which is used to avoid updating
all the snippet tests.

Add tests with the trace disabled to check the PP behavior
on snippets.