### PR TITLE
V725-006 Update formatted text last character offset

### DIFF
--- a/source/ada/lsp-ada_documents.adb
+++ b/source/ada/lsp-ada_documents.adb
@@ -1171,8 +1171,7 @@ package body LSP.Ada_Documents is
          Edit_Span  : constant LSP.Messages.Span :=
            Self.To_LSP_Range (Output_Selection_Range);
          Output_Str : constant String :=
-           Char_Vectors.Elems (Output)
-             (1 .. Char_Vectors.Last_Index (Output) - 1);
+           Char_Vectors.Elems (Output) (1 .. Char_Vectors.Last_Index (Output));
          Edit_Text  : constant VSS.Strings.Virtual_String :=
            VSS.Strings.Conversions.To_Virtual_String (Output_Str);
 


### PR DESCRIPTION
Companion patch for a change in partial gnatpp that no longer adds a line break to the end of the formatted text.