### PR TITLE
VB28-039 Update Ubuntu and Mac OS X on GitHub CI

### DIFF
--- a/.github/workflows/build-binaries.sh
+++ b/.github/workflows/build-binaries.sh
@@ -57,17 +57,6 @@ else
     export BUILD_MODE=prod
 fi
 
-pip install --user subprojects/langkit/
-
-# Python used in GitHub CI on Windows can't understand
-# make's notation of absolute path in form of /d/PATH,
-# where /d is drive D: Let's use relative path instead
-sed -i -e '/langkit/s/.{CURDIR}/../' subprojects/gpr/Makefile
-
-make -C subprojects/gpr setup prefix=$prefix \
- GPR2KBDIR=./gprconfig_kb/db ENABLE_SHARED=no \
- ${DEBUG:+BUILD=debug} build-lib-static install-lib-static
-
 make -C subprojects/templates-parser setup prefix=$prefix \
  ENABLE_SHARED=no \
  ${DEBUG:+BUILD=debug} build-static install-static

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix: # Build debug and production
         debug: ['', 'debug']      # '' if production, 'debug' for debug
-        os: [macos-10.15, ubuntu-18.04, windows-latest]
+        os: [macos-11, ubuntu-20.04, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Setup Python 3.8
@@ -65,22 +65,6 @@ jobs:
         with:
           repository: AdaCore/templates-parser
           path: subprojects/templates-parser
-      - name: Get Langkit
-        uses: actions/checkout@v2
-        with:
-          repository: AdaCore/langkit
-          path: subprojects/langkit
-      - name: Get gpr
-        uses: actions/checkout@v2
-        with:
-          repository: AdaCore/gpr
-          path: subprojects/gpr
-          ref: edge
-      - name: Get gprconfig_kb
-        uses: actions/checkout@v2
-        with:
-          repository: AdaCore/gprconfig_kb
-          path: subprojects/gpr/gprconfig_kb
       - name: Get GNATdoc
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
because they are deprecated. Drop `libgpr2` building, because `libgpr2` is deployed with `libadalang` binaries as a dependency.