### PR TITLE
Makefile: allow use of external variable for BUILD_MODE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ endif
 LIBRARY_TYPE?=relocatable
 
 # Build mode (dev or prod)
-BUILD_MODE=dev
+BUILD_MODE?=dev
 
 # Whether to enable coverage (empty for no, any other value for yes)
 COVERAGE=


### PR DESCRIPTION
This prevented the github actions build of the als to be done with -XBUILD_MODE=prod passed to gprbuild, even for non debug workflows.

TN: VC13-022