### PR TITLE
Add `-fstack-protector` switch on Windows

### DIFF
--- a/gnat/lsp_server.gpr
+++ b/gnat/lsp_server.gpr
@@ -59,7 +59,10 @@ project LSP_Server is
          when "static" | "static-pic" =>
             case OS is
                when "Windows_NT" =>
-                  for Switches ("Ada") use ("-static", "-static-libstdc++", "-static-libgcc");
+                  for Switches ("Ada") use
+                    ("-static", "-static-libstdc++", "-static-libgcc",
+                     "-fstack-protector");
+                  --  Stack protector forces libssp.a linking for libgmp.a
                when "osx" | "unix" =>
                   --  On UNIX, we want to link libc dynamically: needed to find
                   --  a recent version of iconv_open (and a recommended practice)


### PR DESCRIPTION
to avoid linking error:

    libgmp.a(tdiv_r.o):(.text+0x2ec): more undefined references
      to `__stack_chk_fail' follow