### PR TITLE
Fix invalid regex

### DIFF
--- a/integration/vscode/ada/advanced/ada.tmLanguage.json
+++ b/integration/vscode/ada/advanced/ada.tmLanguage.json
@@ -1702,7 +1702,7 @@
             "patterns": [
                 {
                     "begin": "(?i)\\bwith\\b",
-                    "end": "(?=(;|\\))",
+                    "end": "(?=(;|\\)))",
                     "beginCaptures": {
                         "0": { "name": "keyword.ada" }
                     },


### PR DESCRIPTION
Fixes #1229. This regex is invalid because it contains an unclosed group. As a result, it throws an error in Oniguruma (`vscode-textmate` silences regex errors). The corrected version of this regex is already used several times elsewhere in the grammar.