### PR TITLE
fix invalid command in build instructions

### DIFF
--- a/doc/devel/build.md
+++ b/doc/devel/build.md
@@ -7,7 +7,7 @@
 
 1. Disable dependency sharing in Alire
 
-       alr settings --global --set dependencies.shared false
+       alr config --global --set dependencies.shared false
 
 1. Clone repository
 


### PR DESCRIPTION
I tried the supplied command, it failed, I checked the help docs and found config, tried that and I could see that my config file now was changed. so it seems the old instructions are wrong.